### PR TITLE
HOPSWORKS-2407

### DIFF
--- a/storage/ndb/tools/NdbImport.cpp
+++ b/storage/ndb/tools/NdbImport.cpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -73,7 +74,7 @@ NdbImport::Opt::Opt()
   m_table = 0;
   m_input_type = "csv";
   m_input_file = 0;
-  m_input_workers = 4;
+  m_input_workers = 2;
   m_output_type = "ndb";
   m_output_workers = 2;
   m_db_workers = 4;
@@ -85,6 +86,7 @@ NdbImport::Opt::Opt()
   m_stopt_file = 0;
   m_stats_file = 0;
   m_continue = false;
+  m_use_write = false;
   m_resume = false;
   m_monitor = 2;
   m_ai_prefetch_sz = 1024;
@@ -97,15 +99,15 @@ NdbImport::Opt::Opt()
   m_pagebuffer = 500000;
   m_rowbatch = 0;
   m_rowbytes = 500000;
-  m_opbatch = 500;
-  m_opbytes = 0;
+  m_opbatch = 250;
+  m_opbytes = 100000;
   m_polltimeout = 1000;
   m_temperrors = 0;
   m_tempdelay = 10;
-  m_rowswait = 10;
+  m_rowswait = 1;
   m_idlespin = 0;
   m_idlesleep = 1;
-  m_checkloop = 100;
+  m_checkloop = 1;
   m_alloc_chunk = 20;
   m_rejects = 0;
   // character set

--- a/storage/ndb/tools/NdbImport.hpp
+++ b/storage/ndb/tools/NdbImport.hpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -76,6 +77,7 @@ public:
     const char* m_stopt_file;
     const char* m_stats_file;
     bool m_continue;
+    bool m_use_write;
     bool m_resume;
     uint m_monitor;
     uint m_ai_prefetch_sz;

--- a/storage/ndb/tools/NdbImportUtil.cpp
+++ b/storage/ndb/tools/NdbImportUtil.cpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021, 2021, Logical Clocks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -3046,6 +3047,7 @@ NdbImportUtil::set_error_gen(Error& error, int line,
                              const char* fmt, ...)
 {
   c_error_lock.lock();
+  NdbImport::set_stop_all();
   new (&error) Error;
   error.line = line;
   error.type = Error::Type_gen;
@@ -3067,6 +3069,7 @@ NdbImportUtil::set_error_usage(Error& error, int line,
                                const char* fmt, ...)
 {
   c_error_lock.lock();
+  NdbImport::set_stop_all();
   new (&error) Error;
   error.line = line;
   error.type = Error::Type_usage;
@@ -3087,6 +3090,7 @@ void
 NdbImportUtil::set_error_alloc(Error& error, int line)
 {
   c_error_lock.lock();
+  NdbImport::set_stop_all();
   new (&error) Error;
   error.line = line;
   error.type = Error::Type_alloc;
@@ -3101,6 +3105,7 @@ NdbImportUtil::set_error_mgm(Error& error, int line,
                              NdbMgmHandle handle)
 {
   c_error_lock.lock();
+  NdbImport::set_stop_all();
   new (&error) Error;
   error.line = line;
   error.type = Error::Type_mgm;
@@ -3118,6 +3123,7 @@ NdbImportUtil::set_error_con(Error& error, int line,
                              const Ndb_cluster_connection* con)
 {
   c_error_lock.lock();
+  NdbImport::set_stop_all();
   new (&error) Error;
   error.line = line;
   error.type = Error::Type_con;
@@ -3134,6 +3140,7 @@ NdbImportUtil::set_error_ndb(Error& error, int line,
                              const NdbError& ndberror, const char* fmt, ...)
 {
   c_error_lock.lock();
+  NdbImport::set_stop_all();
   new (&error) Error;
   error.line = line;
   error.type = Error::Type_ndb;
@@ -3150,6 +3157,7 @@ NdbImportUtil::set_error_os(Error& error, int line,
                             const char* fmt, ...)
 {
   c_error_lock.lock();
+  NdbImport::set_stop_all();
   new (&error) Error;
   error.line = line;
   error.type = Error::Type_os;
@@ -3181,6 +3189,7 @@ NdbImportUtil::set_error_data(Error& error, int line,
                               int code, const char* fmt, ...)
 {
   c_error_lock.lock();
+  NdbImport::set_stop_all();
   new (&error) Error;
   error.line = line;
   error.type = Error::Type_data;

--- a/storage/ndb/tools/ndb_import.cpp
+++ b/storage/ndb/tools/ndb_import.cpp
@@ -125,8 +125,12 @@ my_long_options[] =
     &g_opt.m_max_rows, &g_opt.m_max_rows, 0,
     GET_UINT, REQUIRED_ARG, g_opt.m_max_rows, 0, 0, 0, 0, 0 },
   { "continue", NDB_OPT_NOSHORT,
-    "If one job (e.g. CSV import) fails, continue to next job",
+    "continue is no longer supported, we will always stop at failure",
     &g_opt.m_continue, &g_opt.m_continue, 0,
+    GET_BOOL, NO_ARG, false, 0, 0, 0, 0, 0 },
+  { "use-write", NDB_OPT_NOSHORT,
+    "Use Write instead of Insert",
+    &g_opt.m_use_write, &g_opt.m_use_write, 0,
     GET_BOOL, NO_ARG, false, 0, 0, 0, 0, 0 },
   { "resume", NDB_OPT_NOSHORT,
     "If the job(s) are aborted due to e.g. too many rejects or"
@@ -922,8 +926,7 @@ doimp()
       {
         jobs_fail++;
         ret = -1;
-        if (imp_error || !g_opt.m_continue)
-          break;
+        break;
       }
     }
     CHK1(ret == 0);


### PR DESCRIPTION
ndb_import can hang when there are NDB errors in loading a large
CSV file. In this case the execution threads stops progressing
due to the failures. However the CSV input threads and the output
workers are all stuck in trying to send rows to the next thread
in the pipeline (output threads for CSV input threads and execution
threads for output threads). They are stuck in this state since
there are no checks for stop processing in this code path.

Added checks for stop processing in those paths, but also changed
such that all errors will lead to stopping the entire ndb_import
program and not just the current job being executed. It is better
to have a program with a consistent error behaviour rather than
trying to continue processing after a failure.

Changed some parameters for ndb_import to make it more responsive
and quicker to change jobs. Some of those led to dramatic decrease
of time to perform import jobs.