### PR TITLE
HOPSWORKS-2313

### DIFF
--- a/mysql-test/suite/ndb/t/clusterj.cnf
+++ b/mysql-test/suite/ndb/t/clusterj.cnf
@@ -9,6 +9,7 @@ mysqld=
 ndbapi=,,,
 DataMemory            = 50M
 MaxNoOfOrderedIndexes = 150
+ClassicFragmentation  = 1
 
 [cluster_config.mysqld.1.1]
 NodeId=64


### PR DESCRIPTION
The clusterj test case failed since we didn't set ClassicFragmentation=1 but used
AutomaticThreadConfig=0 and AutomaticMemoryConfig=0.