### PR TITLE
Fix padString for ByteBuffer longer than 255

### DIFF
--- a/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/Utility.java
+++ b/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/Utility.java
@@ -1,5 +1,6 @@
 /*
  *  Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2021, Logical Clocks AB and/or its affiliates. All rights reserved.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,
@@ -101,13 +102,6 @@ public class Utility {
     static {
         for (int i = 0; i < 255; ++i) {
             ZERO_PAD[i] = (byte)0;
-        }
-    }
- 
-    static final byte[] BLANK_PAD = new byte[255];
-    static {
-        for (int i = 0; i < 255; ++i) {
-            BLANK_PAD[i] = (byte)' ';
         }
     }
 
@@ -1763,7 +1757,9 @@ public class Utility {
             buffer.limit(requiredLength);
             //pad to fixed length
             buffer.position(suppliedLength);
-            buffer.put(BLANK_PAD, 0, requiredLength - suppliedLength);
+            for (int i = 0; i < (requiredLength - suppliedLength); i++) {
+                buffer.put((byte)' ');
+            }
             buffer.position(0);
         }
         return buffer;


### PR DESCRIPTION
BLANK_PAD was a byte array of 255. If the number of bytes to pad
was longer than 255 bytes, the buffer.put() operation throws an
IndexOutOfBoundsException.

Replace the buffer.put() operation with the equivalent for loop
operation which initializes the correct number of bytes.