### PR TITLE
HOPSWORKS-2426

### DIFF
--- a/storage/ndb/src/kernel/ndbd.cpp
+++ b/storage/ndb/src/kernel/ndbd.cpp
@@ -576,7 +576,7 @@ init_global_memory_manager(EmulatorData &ed, Uint32 *watchCounter)
       g_eventLogger->info("No Undo log buffer used, will be allocated from"
                           " TransactionMemory if later defined by command");
     }
-    g_eventLogger->info("Total TransactionMemory size is %llu MBytes",
+    g_eventLogger->info("Total TransactionMemory size is %u MBytes",
                          transmem/32);
   }
   g_eventLogger->info("TransactionMemory can expand and use"

--- a/storage/ndb/src/kernel/vm/Configuration.hpp
+++ b/storage/ndb/src/kernel/vm/Configuration.hpp
@@ -205,7 +205,8 @@ private:
   void assign_default_memory_sizes(const ndb_mgm_configuration_iterator *p);
   static Uint32 get_num_threads();
   static Uint64 get_total_memory(
-                  const ndb_mgm_configuration_iterator *p);
+                  const ndb_mgm_configuration_iterator *p,
+                  bool & total_memory_set);
   Uint64 get_schema_memory(ndb_mgm_configuration_iterator *p);
   static Uint64 get_and_set_transaction_memory(
            const ndb_mgm_configuration_iterator *p);

--- a/storage/ndb/src/mgmsrv/ConfigInfo.cpp
+++ b/storage/ndb/src/mgmsrv/ConfigInfo.cpp
@@ -995,7 +995,7 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     false,
     ConfigInfo::CI_INT64,
     "0",
-    "8G",
+    "2G",
     "65536G" },
 
   {
@@ -3455,7 +3455,7 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     ConfigInfo::CI_USED,
     false,
     ConfigInfo::CI_INT,
-    "8M",
+    "4M",
     "64K",
     STR_VALUE(MAX_INT_RNIL) },
 
@@ -3817,7 +3817,7 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     ConfigInfo::CI_USED,
     false,
     ConfigInfo::CI_INT,
-    "8M",
+    "4M",
     "64K",
     STR_VALUE(MAX_INT_RNIL)
   },


### PR DESCRIPTION
To support minimal configurations down to 2GB memory space we made the
following changes:
1) Make it possible to set TotalMemoryConfig down to 2GB
2) Remove OS overhead when setting TotalMemoryConfig
3) Decrease the SendBufferMemory from 8M to 4M

Using the following settings:
NumCPUs=4
TotalMemoryConfig=3G
MaxNoOfTables=2000
MaxNoOfOrderedIndexes=1000
MaxNoOfUniqueHashIndexes=1000
MaxNoOfAttributes=20000
MaxNoOfTriggers=30000
TransactionMemory=200M
SharedGlobalMemory=400M

we will be able to fit nicely into 3GB memory space and out of this
a bit more than half is used by DataMemory and DiskPageBufferMemory.

AutomaticMemoryConfig computation will be affected by the settings
of MaxNoOfTables, MaxNoOfOrderedIndexes, MaxNoOfUniqueHashIndexes,
MaxNoOfAttributes, MaxNoOfTriggers and also the setting of
TransactionMemory and SharedGlobalMemory.

NumCPUs is used to ensure that we use a small configuration when
it comes to the number of threads if the test is started on a large
machine with lots of data nodes (can be useful for testing).