### PR TITLE
HOPSWORKS-2442, HOPSWORKS-2443

### DIFF
--- a/storage/ndb/src/kernel/blocks/dbdih/DbdihMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbdih/DbdihMain.cpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
+   Copyright (c) 2021, 2021, Logical Clocks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -2424,7 +2425,7 @@ void Dbdih::execREAD_NODESCONF(Signal* signal)
      * doesn't assist the send thread in this scenario.
      */
     log_setNoSend();
-    setNoSend();
+    setNoSend(1);
   }
   if (c_2pass_inr)
   {
@@ -4822,7 +4823,7 @@ void Dbdih::execINCL_NODEREQ(Signal* signal)
       con_lineNodes >= 16)
   {
     log_setNoSend();
-    setNoSend();
+    setNoSend(1);
   }
 
   /*-------------------------------------------------------------------------*/
@@ -10048,7 +10049,7 @@ void Dbdih::execNODE_FAILREP(Signal* signal)
       con_lineNodes >= 16)
   {
     log_setNoSend();
-    setNoSend();
+    setNoSend(1);
   }
   const bool masterTakeOver = (oldMasterId != newMasterId);
   bool check_more_start_lcp = false;

--- a/storage/ndb/src/kernel/blocks/thrman.hpp
+++ b/storage/ndb/src/kernel/blocks/thrman.hpp
@@ -1,5 +1,7 @@
 /*
    Copyright (c) 2011, 2020, Oracle and/or its affiliates.
+   Copyright (c) 2021, 2021, Logical Clocks AB and/or its affiliates.
+
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -73,6 +75,7 @@ private:
   Uint32 m_num_send_threads;
   Uint32 m_num_threads;
   Uint32 m_send_thread_percentage;
+  Uint32 m_send_thread_assistance_level;
   Uint32 m_node_overload_level;
 
   Uint32 m_spin_time_change_count;
@@ -331,6 +334,7 @@ private:
   void sendSTTORRY(Signal*, bool);
   void sendNextCONTINUEB(Signal*, Uint32 delay, Uint32 type);
   void measure_cpu_usage(Signal*);
+  void check_send_thread_helpers(Signal*);
   void mark_measurements_not_done();
   void check_overload_status(Signal*, bool, bool);
   void set_spin_stat(Uint32, bool);
@@ -343,7 +347,7 @@ private:
   void set_enable_adaptive_spinning(bool val);
   void set_spintime_per_call(Uint32 val);
 
-  Uint32 calculate_mean_send_thread_load();
+  Uint32 calculate_mean_send_thread_load(Uint32 num_milliseconds);
   void calculate_measurement(MeasurementRecordPtr measurePtr,
                              struct ndb_rusage *curr_rusage,
                              struct ndb_rusage *base_rusage,
@@ -383,8 +387,10 @@ private:
   void sendSET_WAKEUP_THREAD_ORD(Signal *signal,
                                  Uint32 instance_no,
                                  Uint32 wakeup_instance);
+  void handle_send_delay();
   void get_idle_block_threads(Uint32 *thread_list,
-                              Uint32 & num_threads_found);
+                              Uint32 & num_threads_found,
+                              Uint32 max_helpers);
   void assign_wakeup_threads(Signal*, Uint32*, Uint32);
   void update_current_wakeup_instance(Uint32 * threads_list,
                                       Uint32 num_threads_found,
@@ -400,8 +406,9 @@ private:
   bool calculate_cpu_load_last_20seconds(MeasurementRecord *measure);
   bool calculate_cpu_load_last_400seconds(MeasurementRecord *measure);
 
-  bool calculate_send_thread_load_last_second(Uint32 send_instance,
-                                              SendThreadMeasurement *measure);
+  bool calculate_send_thread_load_last_ms(Uint32 send_instance,
+                                          SendThreadMeasurement *measure,
+                                          Uint32 num_milliseconds);
   void fill_in_current_measure(CPURecordPtr cpuPtr,
                                struct ndb_hwinfo *hwinfo);
   bool calculate_next_CPU_measure(CPUMeasurementRecord *lastMeasurePtrP,

--- a/storage/ndb/src/kernel/vm/Configuration.cpp
+++ b/storage/ndb/src/kernel/vm/Configuration.cpp
@@ -1257,9 +1257,6 @@ Configuration::setupConfiguration(){
   _spinTimePerCall = 1000;
   iter.get(CFG_DB_SPIN_TIME_PER_CALL, &_spinTimePerCall);
 
-  _maxSendDelay = 0;
-  iter.get(CFG_DB_MAX_SEND_DELAY, &_maxSendDelay);
-
   _realtimeScheduler = 0;
   iter.get(CFG_DB_REALTIME_SCHEDULER, &_realtimeScheduler);
 
@@ -1595,12 +1592,6 @@ bool
 Configuration::realtimeScheduler() const
 {
   return (bool)_realtimeScheduler;
-}
-
-Uint32
-Configuration::maxSendDelay() const
-{
-  return _maxSendDelay;
 }
 
 void 

--- a/storage/ndb/src/kernel/vm/Configuration.hpp
+++ b/storage/ndb/src/kernel/vm/Configuration.hpp
@@ -89,8 +89,6 @@ public:
 
   Uint32 spinTimePerCall() const;
 
-  Uint32 maxSendDelay() const;
-
   Uint32 schedulerResponsiveness() const
   { return _schedulerResponsiveness; }
   void setSchedulerResponsiveness(Uint32 val)
@@ -170,7 +168,6 @@ private:
   Uint32 _schedulerSpinTimer;
   Uint32 _spinTimePerCall;
   Uint32 _realtimeScheduler;
-  Uint32 _maxSendDelay;
   Uint32 _schedulerResponsiveness;
   Uint32 _timeBetweenWatchDogCheckInitial;
 #ifdef ERROR_INSERT

--- a/storage/ndb/src/kernel/vm/SimulatedBlock.cpp
+++ b/storage/ndb/src/kernel/vm/SimulatedBlock.cpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2021, 2021, Logical Clocks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -656,10 +657,28 @@ SimulatedBlock::setNeighbourNode(NodeId node)
 }
 
 void
-SimulatedBlock::setNoSend()
+SimulatedBlock::setNoSend(Uint32 val)
 {
 #ifdef NDBD_MULTITHREADED
-  mt_setNoSend(m_threadId);
+  mt_setNoSend(m_threadId, val);
+#endif
+}
+
+void
+SimulatedBlock::setNoSendTmp(Uint32 val)
+{
+#ifdef NDBD_MULTITHREADED
+  mt_setNoSendTmp(m_threadId, val);
+#endif
+}
+
+Uint32
+SimulatedBlock::getNoSend()
+{
+#ifdef NDBD_MULTITHREADED
+  return mt_getNoSend(m_threadId);
+#else
+  return 0;
 #endif
 }
 
@@ -677,6 +696,32 @@ SimulatedBlock::setWakeupThread(Uint32 wakeup_instance)
 {
 #ifdef NDBD_MULTITHREADED
   mt_setWakeupThread(m_threadId, wakeup_instance);
+#endif
+}
+
+bool
+SimulatedBlock::is_recover_thread(Uint32 thr_no)
+{
+#ifdef NDBD_MULTITHREADED
+  return mt_is_recover_thread(thr_no);
+#else
+  return false;
+#endif
+}
+
+void
+SimulatedBlock::setMaxSendDelay(Uint32 max_send_delay)
+{
+#ifdef NDBD_MULTITHREADED
+  mt_setMaxSendDelay(max_send_delay);
+#endif
+}
+
+void
+SimulatedBlock::setMinSendDelay(Uint32 min_send_delay)
+{
+#ifdef NDBD_MULTITHREADED
+  mt_setMinSendDelay(min_send_delay);
 #endif
 }
 

--- a/storage/ndb/src/kernel/vm/SimulatedBlock.hpp
+++ b/storage/ndb/src/kernel/vm/SimulatedBlock.hpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
+   Copyright (c) 2021, 2021, Logical Clocks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -140,12 +141,14 @@ struct PackedWordsContainer
 
 #define LIGHT_LOAD_CONST 0
 #define MEDIUM_LOAD_CONST 1
-#define OVERLOAD_CONST 2
+#define HIGH_LOAD_CONST 2
+#define OVERLOAD_CONST 3
 enum OverloadStatus
 {
   LIGHT_LOAD = LIGHT_LOAD_CONST,
   MEDIUM_LOAD = MEDIUM_LOAD_CONST,
-  OVERLOAD = OVERLOAD_CONST
+  HIGH_LOAD = HIGH_LOAD_CONST,
+  OVERLOAD_LOAD = OVERLOAD_CONST
 };
 
 /**
@@ -696,12 +699,17 @@ protected:
   Uint32 getEstimatedJobBufferLevel();
   Uint32 getCPUSocket(Uint32 thr_no);
   void setOverloadStatus(OverloadStatus new_status);
+  void setMaxSendDelay(Uint32 max_send_delay);
+  void setMinSendDelay(Uint32 min_send_delay);
+  bool is_recover_thread(Uint32 thr_no);
   void setWakeupThread(Uint32 wakeup_instance);
   void setNodeOverloadStatus(OverloadStatus new_status);
   void setSendNodeOverloadStatus(OverloadStatus new_status);
   void startChangeNeighbourNode();
   void setNeighbourNode(NodeId node);
-  void setNoSend();
+  void setNoSend(Uint32 val);
+  void setNoSendTmp(Uint32 val);
+  Uint32 getNoSend();
   void endChangeNeighbourNode();
   void getPerformanceTimers(Uint64 &micros_sleep,
                             Uint64 &spin_time,

--- a/storage/ndb/src/kernel/vm/mt.hpp
+++ b/storage/ndb/src/kernel/vm/mt.hpp
@@ -1,4 +1,5 @@
 /* Copyright (c) 2008, 2020, Oracle and/or its affiliates.
+   Copyright (c) 2021, 2021, Logical Clocks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -93,11 +94,16 @@ void mt_getSendBufferLevel(Uint32 self, NodeId node, SB_LevelType &level);
 Uint32 mt_getEstimatedJobBufferLevel(Uint32 self);
 bool mt_isEstimatedJobBufferLevelChanged(Uint32 self);
 NDB_TICKS mt_getHighResTimer(Uint32 self);
-void mt_setNoSend(Uint32 self);
+void mt_setNoSend(Uint32 self, Uint32 val);
+void mt_setNoSendTmp(Uint32 self, Uint32 val);
+Uint32 mt_getNoSend(Uint32 self);
 void mt_startChangeNeighbourNode();
 void mt_setNeighbourNode(NodeId node);
 void mt_endChangeNeighbourNode();
 void mt_setWakeupThread(Uint32 self, Uint32 wakeup_instance);
+void mt_setMaxSendDelay(Uint32 max_send_delay);
+void mt_setMinSendDelay(Uint32 min_send_delay);
+bool mt_is_recover_thread(Uint32 thr_no);
 void mt_setOverloadStatus(Uint32 self,
                          OverloadStatus new_status);
 void mt_setNodeOverloadStatus(Uint32 self,

--- a/storage/ndb/src/mgmsrv/ConfigInfo.cpp
+++ b/storage/ndb/src/mgmsrv/ConfigInfo.cpp
@@ -715,7 +715,7 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     "MaxSendDelay",
     DB_TOKEN,
     "Max number of microseconds to delay sending in ndbmtd",
-    ConfigInfo::CI_USED,
+    ConfigInfo::CI_DEPRECATED,
     false,
     ConfigInfo::CI_INT,
     "0",


### PR DESCRIPTION
Block threads are very eager to assist with sending. In situation where we have
large data nodes with more than 32 CPUs this will lead to a very busy sending.
This leads to sending chunks of data that is too small. This leads both to contention
on send mutexes and it leads to sending small messages that hurts the receivers
and makes them less efficient.

To avoid this a more balanced approach on sending is required where block
threads assist sending, but as load goes up the assistance becomes less urgent.

In this patch we use the implementation of MaxSendDelay and turn it into an
adaptive algorithm. To create this adaptive algorithm we add another CPU
load level called HIGH_LOAD. This means that we have LIGHT_LOAD up to 30%
load, MEDIUM load is between 30% and 60%, HIGH LOAD is between 60% and
75% and above that we have OVERLOAD_LOAD.

We implement two new mechanisms, the first is max_send_delay. This is
activated when threads starts reaching HIGH_LOAD. This means that when
a block thread puts a transporter into the send queue, it will have to
wait a number of microseconds before the send is allowed to occur. This
gives the send a chance to gather other sends before the send is
actually performed. The max send delay is larger for higher loads and
for larger data nodes. It is never set higher than 200 microseconds.

The second mechanism is the minimum send delay. Each time we send and the
min send delay is nonzero, we set the transporter in a mode where it has
to wait to send even if a send is scheduled. This setting normally isn't
affecting things when max_send_delay is set. So it acts to secure against
overloading the receivers when our load is still not at HIGH_LOAD.
This is at most set to 40 microseconds.

In the past up to 4 block threads could be choosen to assist the send
threads. This mechanism had a bug in resetting the activation. This is
now fixed. In addition the new mechanisms is only providing for main
and rep threads to assist the send threads. In addition the main and
rep threads only do when the send threads are at a high load. Once
we have entered this mode, we will wait to remove the assistance using
a hysteresis. We have two levels of send thread support, the first adds
the main thread and the second level adds also the rep thread. Neither
of those will assist when they are reaching up to MEDIUM_LOAD level.
This should be fairly uncommon for those threads except in some special
scenarios.

By default main and rep threads are now not assisting send threads
at all.

Block threads will only send to at most one transporter when reaching
MEDIUM_LOAD, as before they will not assist send threads at all after
reaching the OVERLOAD_LOAD level.

The main and rep threads are activated using the WAKEUP_THREAD_ORD
signal, when this is sent the main/rep thread is setting nosend=0
and once every 50ms it is restored to nosend=1. Thus it is necessary
to constantly send WAKEUP_THREAD_ORD signals to those threads to
keep them waking up to assist send threads.

To handle this swapping between nosend 0 and 1, we introduce a
m_nosend_tmp that is the one used to decide whether to perform
assistance or not, the configured value is in the m_nosend
variable.

To decide whether send thread assistance is required we modify
the method to calculate send thread load such that it uses
a parameter with number of milliseconds back we want to
track. We use 200 milliseconds to decide on send thread
assistance.

The configuration parameter MaxSendDelay is deprecated and no longer
used. All of its functionality is now automated.

As a first step to remove the recover thread from disturbing the
block threads we make sure that it never performs any send thread
assistance. This assistance will disturb things, the recover threads
still wake up and use about 0.1-0.2% of a CPU, this should also be
removed eventually or handled in some other manner.

Also ensured that recover threads are not performing any spinning.

Handling send thread assistance until done is now only handled by
main and rep threads. Thus we changed the setting of the pending_send
variable.

Removed incrementing the m_overload_counter when calling
set_max_delay. This should only be incremented when calling
the set_overload_delay function.

Added some comments on this new functionality.

Fixed some problems with lagging timers. Important to perform
do_send also when this happens.