### PR TITLE
HOPSWORKS-2407

### DIFF
--- a/mysql-test/suite/ndb/r/ndb_import0.result
+++ b/mysql-test/suite/ndb/r/ndb_import0.result
@@ -62,34 +62,12 @@ b int not null
 ) engine=ndb;
 select count(*) from t4;
 count(*)
-997
+998
 # test with rejects and --stats
 delete from t4;
 select count(*) from t4;
 count(*)
-997
-# test --continue option with missing table
-create table t5a (a int primary key) engine=ndb;
-create table t5c like t5a;
-select count(*) from t5a;
-count(*)
-2
-select count(*) from t5c;
-count(*)
-2
-# test --continue option with rejects
-delete from t5a;
-delete from t5c;
-create table t5b like t5a;
-select count(*) from t5a;
-count(*)
-2
-select count(*) from t5b;
-count(*)
-1
-select count(*) from t5c;
-count(*)
-2
+998
 # test quoting and escapes
 create table t6 (
 a int primary key,
@@ -176,5 +154,5 @@ date_died DATE NOT NULL
 ) engine=ndb CHARACTER SET latin1;
 include/assert_grep.inc [Require CSV parser to fail with syntax error]
 drop table tpersons;
-drop table t1, t1ver, t2, t2ver, t3, t3ver, t4, t5a, t5b, t5c,
+drop table t1, t1ver, t2, t2ver, t3, t3ver, t4,
 t6, t6ver, t7, t7ver, t8, t8ver, t9, t9ver;

--- a/mysql-test/suite/ndb/t/ndb_import.pl
+++ b/mysql-test/suite/ndb/t/ndb_import.pl
@@ -922,7 +922,9 @@ sub gen_csvline {
   # if no errors from fields, create error on the row
   if ($opts->{rejectsflag}) {
     while ($opts->{rejectserrs} eq "") {
-      if (myrand(2) == 0 && $rowid > 0) {
+      if (myrand(2) == 0 && $rowid > 0 && $rowid == 0) {
+	# Will never generate duplicate pk, this type of error
+	# is unrecoverable in ndb_import in RonDB.
         # duplicate pk (one will be accepted, could be this one)
         my $oldrowid = myrand($rowid);
         my $oldpkvals = $opts->{pkvals}{$oldrowid};

--- a/mysql-test/suite/ndb/t/ndb_import0.test
+++ b/mysql-test/suite/ndb/t/ndb_import0.test
@@ -213,8 +213,6 @@ open($fh, ">:raw", $file)
 for my $i (0..999) {
   if ($i == 333) {
     print $fh $i, "\t", $i*10, "\t", 333, $lt;
-  } elsif ($i == 666) {
-    print $fh 111, "\t", $i*10, $lt;
   } elsif ($i == 999) {
     print $fh $i, "\t", "abcde", $lt;
   } else {
@@ -232,7 +230,7 @@ create table t4 (
 ) engine=ndb;
 
 exec $NDB_IMPORT --state-dir=$MYSQLTEST_VARDIR/tmp --log-level=1
-     --rejects=3
+     --rejects=2
      test $MYSQLTEST_VARDIR/tmp/t4.csv >> $NDB_TOOLS_OUTPUT 2>&1;
 select count(*) from t4;
 
@@ -250,7 +248,7 @@ select count(*) from t4;
 delete from t4;
 
 exec $NDB_IMPORT --state-dir=$MYSQLTEST_VARDIR/tmp --log-level=1
-     --rejects=3 --stats
+     --rejects=2 --stats
      test $MYSQLTEST_VARDIR/tmp/t4.csv >> $NDB_TOOLS_OUTPUT 2>&1;
 select count(*) from t4;
 
@@ -262,55 +260,6 @@ select count(*) from t4;
 --file_exists $MYSQLTEST_VARDIR/tmp/t4.map
 --error 0
 --file_exists $MYSQLTEST_VARDIR/tmp/t4.stt
-
---echo # test --continue option with missing table
-
-create table t5a (a int primary key) engine=ndb;
-create table t5c like t5a;
-
-write_file $MYSQLTEST_VARDIR/tmp/t5a.csv;
-111
-222
-EOF
-
-write_file $MYSQLTEST_VARDIR/tmp/t5b.csv;
-111
-111
-EOF
-
-write_file $MYSQLTEST_VARDIR/tmp/t5c.csv;
-111
-222
-EOF
-
-# files have '\n' terminator so add --csvopt=n
-
---error 1
-exec $NDB_IMPORT --state-dir=$MYSQLTEST_VARDIR/tmp --log-level=1
-     --continue --csvopt=n
-     test
-     $MYSQLTEST_VARDIR/tmp/t5a.csv
-     $MYSQLTEST_VARDIR/tmp/t5b.csv
-     $MYSQLTEST_VARDIR/tmp/t5c.csv >> $NDB_TOOLS_OUTPUT 2>&1;
-select count(*) from t5a;
-select count(*) from t5c;
-
---echo # test --continue option with rejects
-
-delete from t5a;
-delete from t5c;
-create table t5b like t5a;
-
---error 1
-exec $NDB_IMPORT --state-dir=$MYSQLTEST_VARDIR/tmp --log-level=1
-     --continue --csvopt=n
-     test
-     $MYSQLTEST_VARDIR/tmp/t5a.csv
-     $MYSQLTEST_VARDIR/tmp/t5b.csv
-     $MYSQLTEST_VARDIR/tmp/t5c.csv >> $NDB_TOOLS_OUTPUT 2>&1;
-select count(*) from t5a;
-select count(*) from t5b;
-select count(*) from t5c;
 
 --echo # test quoting and escapes
 
@@ -709,7 +658,7 @@ exec $NDB_IMPORT --state-dir=$MYSQLTEST_VARDIR/tmp
 
 drop table tpersons;
 
-drop table t1, t1ver, t2, t2ver, t3, t3ver, t4, t5a, t5b, t5c,
+drop table t1, t1ver, t2, t2ver, t3, t3ver, t4,
            t6, t6ver, t7, t7ver, t8, t8ver, t9, t9ver;
 --source suite/ndb/include/backup_restore_cleanup.inc
 --remove_files_wildcard $MYSQLTEST_VARDIR/tmp t*.csv

--- a/storage/ndb/tools/NdbImportUtil.cpp
+++ b/storage/ndb/tools/NdbImportUtil.cpp
@@ -3188,8 +3188,14 @@ void
 NdbImportUtil::set_error_data(Error& error, int line,
                               int code, const char* fmt, ...)
 {
+  /**
+   * Error in CSV data is the only error which will not cause
+   * ndb_import to immediately fail. This type of error is
+   * recoverable, but as the code is written, errors in
+   * NDB API processing isn't recoverable and thus it is
+   * better to fail fast for those errors.
+   */
   c_error_lock.lock();
-  NdbImport::set_stop_all();
   new (&error) Error;
   error.line = line;
   error.type = Error::Type_data;


### PR DESCRIPTION
We don't support --continue for ndb_import any more.
We added support for handling rejected lines in CSV files.
We still don't support any errors in NDB API processing.
Fixed ndb_import test programs to reflect this.