### PR TITLE
Fix 2 test cases in testMgmd

### DIFF
--- a/storage/ndb/src/mgmsrv/ConfigManager.cpp
+++ b/storage/ndb/src/mgmsrv/ConfigManager.cpp
@@ -1447,7 +1447,9 @@ ConfigManager::execCONFIG_CHECK_REQ(SignalSender& ss, SimpleSignal* sig)
                        m_config_state, CS_UNINITIALIZED);
     return;
   }
-
+  /**
+   * We support reload from any node, this is antique test that is no
+   * no longer valid. 
   if (m_config_change.m_loaded_config && ss.getOwnNodeId() < nodeId)
   {
     g_eventLogger->debug("Got CONFIG_CHECK_REQ from node: %d while "
@@ -1460,7 +1462,7 @@ ConfigManager::execCONFIG_CHECK_REQ(SignalSender& ss, SimpleSignal* sig)
                        m_config_state, CS_UNINITIALIZED);
     return;
   }
-
+  */
   g_eventLogger->debug("Got CONFIG_CHECK_REQ from node: %d. "
                        "Our generation: %d, other generation: %d, "
                        "our state: %d, other state: %d, "
@@ -1580,6 +1582,9 @@ ConfigManager::sendConfigCheckReq(SignalSender& ss, NodeBitmask to)
 
   g_eventLogger->debug("Sending CONFIG_CHECK_REQ to %s",
                        BaseString::getPrettyText(to).c_str());
+
+  /* Avoid busy waiting, 10 ms we can wait without any harm done. */
+  NdbSleep_MilliSleep(10);
 
   require(m_waiting_for.isclear());
 

--- a/storage/ndb/test/ndbapi/testMgmd.cpp
+++ b/storage/ndb/test/ndbapi/testMgmd.cpp
@@ -1480,15 +1480,14 @@ runTestUnresolvedHosts2(NDBT_Context* ctx, NDBT_Step* step)
   CHECK(mgmd.start_from_config_ini(wd.path()));    // Start management node
   CHECK(mgmd.connect(config));                     // Connect to management node
   CHECK(mgmd.wait_confirmed_config());             // Wait for configuration
+  ndb1.wait(ndbd_exit_code, 50);                   // Wait for first data node to connect
 
-  /* Start data node 2.
-     Expect it to run for at least 20 seconds, trying to allocate a node id.
-     But in the second 20-second interval, it will time out and shut down.
+  /**
+   * Start data node 2. Expect it to fail immediately since hostname is wrong
   */
   Ndbd ndb2(2);
   CHECK(ndb2.start(wd.path(), mgmd.connectstring(config)));
-  CHECK(ndb2.wait(ndbd_exit_code, 200) == 0);   // first 20-second wait
-  CHECK(ndb2.wait(ndbd_exit_code, 200) == 1);   // second 20-second wait
+  CHECK(ndb2.wait(ndbd_exit_code, 50) == 1);
 
   /* Shut down the cluster */
   ndb_mgm_stop2(mgmd.handle(), -1, 0, 0);

--- a/storage/ndb/test/src/NDBT_Find.cpp
+++ b/storage/ndb/test/src/NDBT_Find.cpp
@@ -177,5 +177,5 @@ NDBT_find_ndb_mgmd(BaseString& path)
 void
 NDBT_find_ndbd(BaseString& path)
 {
-  return NDBT_find_executable_in_test_env(path, "ndbd");
+  return NDBT_find_executable_in_test_env(path, "ndbmtd");
 }


### PR DESCRIPTION
UnresolvedHosts2 assumed that the node would wait for 30 seconds
before failing when connecting from the wrong hostname, this
failed instantly.

Bug45495 test case failed due to a check that should have been removed
more than 10 years ago when fixing Bug45495. It assumed that reload
in parallel could only be applied when nodes were starting in node id
order.