### PR TITLE
HOPSWORKS-2749

### DIFF
--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
@@ -19330,7 +19330,7 @@ void Dblqh::execCOPY_FRAGREQ(Signal* signal)
     ord->tableId = tabptr.i;
     ord->fragId = fragId;
     ord->fragDistributionKey = key;
-    i = 1;
+    i = 0;
     while ((i = nodemask.find(i+1)) != NdbNodeBitmask::NotFound)
     {
       Uint32 instanceNo = getInstanceNo(i,


### PR DESCRIPTION
We can get constant failures due to 1204, distribution key errors in node 1
with 3-4 replicas. We miss spreading the new distribution key to node 1 when
other nodes are primary replicas and starting nodes for the fragment.