### PR TITLE
Fix bug in JamEvent::isEmpty

### DIFF
--- a/storage/ndb/src/kernel/vm/Emulator.hpp
+++ b/storage/ndb/src/kernel/vm/Emulator.hpp
@@ -97,7 +97,7 @@ public:
 
   bool isEmpty() const
   {
-    return m_jamVal == 0x7fffffff;
+    return (m_jamVal & 0x7fffffff) == 0x7fffffff;
   }
 
   /*


### PR DESCRIPTION
It is common for an empty JamEvent to be marked as the last event
before the execution of the next incoming signal. In these cases,
JamEvent::isEmpty used to erroneously return false, causing the Jam
event log to contain lines for file "unknown_file_32767", line 65535.