### PR TITLE
HOPSWORKS-2874 Bugfix in Dbtc::initialiseTcConnect

### DIFF
--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcInit.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcInit.cpp
@@ -459,6 +459,7 @@ void Dbtc::initRecords(const ndb_mgm_configuration_iterator * mgm_cfg)
   tcConnectRecord.init(
       TcConnectRecord::TYPE_ID,
       pc,
+      // See comment in Dbtc::initialiseTcConnect
       reserveConnectRecord + reserveFailConnectRecord,
       UINT28_MAX);
   while(tcConnectRecord.startup())

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
@@ -16004,9 +16004,33 @@ void Dbtc::initTable(Signal* signal)
 
 void Dbtc::initialiseTcConnect(Signal* signal) 
 {
+  /**
+   * 1) Allocate reserved records, to make sure they are not allocated as fail
+   *    records.
+   * 2) Allocate fail records. These are allocated in order to always be
+   *    available in case of node failure.
+   * 3) Free reserved records.
+   *
+   * tcConnectRecord is a ComposedSlotPool, which means that records with lower
+   * .i value can be accessed faster than those with high .i value. We want to
+   * make sure we have a good number of fast-access records for regular use,
+   * hence the "reserved records". We protect reserved records (in step 1 and 3)
+   * from becoming allocated to the fail record list.
+   *
+   * Note that DbtcInit.cpp initializes tcConnectRecord with
+   * (reserveConnectRecord + reserveFailConnectRecord) fast-access records.
+   * Either one of these two measures would be enough to protect reserved
+   * records.
+   */
   jam();
+  const ndb_mgm_configuration_iterator * mgm_cfg =
+    m_ctx.m_config.getOwnConfigIterator();
+  Uint32 reserveConnectRecord;
+  ndbrequire(!ndb_mgm_get_int_parameter(mgm_cfg,
+                                        CFG_TC_RESERVED_CONNECT_RECORD,
+                                        &reserveConnectRecord));
   SLList<TcConnectRecord_pool> fast_record_list(tcConnectRecord);
-  for (Uint32 i = 0; i < 10000; i++)
+  for (Uint32 i = 0; i < reserveConnectRecord; i++)
   {
     refresh_watch_dog();
     jam();

--- a/storage/ndb/src/kernel/vm/Configuration.cpp
+++ b/storage/ndb/src/kernel/vm/Configuration.cpp
@@ -83,6 +83,8 @@ NodeBitmask g_not_active_nodes;
 #define DEB_AUTOMATIC_MEMORY(arglist) do { } while (0)
 #endif
 
+#define DEFAULT_TC_RESERVED_CONNECT_RECORD 8192
+
 bool
 Configuration::init(int _no_start, int _initial,
                     int _initialstart)
@@ -1771,6 +1773,12 @@ Configuration::calcSizeAlt(ConfigValues * ownConfig)
   const char * msg = "Invalid configuration fetched";
   char buf[255];
 
+  /**
+   * These initializations are only used for variables that are not present in
+   * the configuration we receive from the management server. That will only
+   * happen for older management servers that lacks definitions for some
+   * variables.
+   */
   unsigned int noOfTables = 0;
   unsigned int noOfUniqueHashIndexes = 0;
   unsigned int noOfOrderedIndexes = 0;
@@ -1791,7 +1799,7 @@ Configuration::calcSizeAlt(ConfigValues * ownConfig)
   unsigned int noOfTriggerOperations = 4000;
   unsigned int reservedScanRecords = 256 / 4;
   unsigned int reservedLocalScanRecords = 32 / 4;
-  unsigned int reservedOperations = 32768 / 4;
+  unsigned int reservedOperations = DEFAULT_TC_RESERVED_CONNECT_RECORD;
   unsigned int reservedTransactions = 4096 / 4;
   unsigned int reservedIndexOperations = 8192 / 4;
   unsigned int reservedTriggerOperations = 4000 / 4;
@@ -2038,7 +2046,7 @@ Configuration::calcSizeAlt(ConfigValues * ownConfig)
   }
   if (reservedOperations == 0)
   {
-    reservedOperations = noOfOperations / 4;
+    reservedOperations = DEFAULT_TC_RESERVED_CONNECT_RECORD;
   }
   if (reservedTransactions == 0)
   {
@@ -2222,7 +2230,7 @@ Configuration::calcSizeAlt(ConfigValues * ownConfig)
 
     cfg.put(CFG_TC_TARGET_CONNECT_RECORD, noOfOperations + 16 + noOfTransactions);
     cfg.put(CFG_TC_MAX_CONNECT_RECORD, UINT32_MAX);
-    cfg.put(CFG_TC_RESERVED_CONNECT_RECORD, reservedOperations / tcInstances);
+    cfg.put(CFG_TC_RESERVED_CONNECT_RECORD, reservedOperations);
 
     cfg.put(CFG_TC_TARGET_TO_CONNECT_RECORD, takeOverOperations);
     cfg.put(CFG_TC_MAX_TO_CONNECT_RECORD, takeOverOperations);


### PR DESCRIPTION
- Use configured reserved record count in Dbtc::initialiseTcConnect
  rather than a constant.
- Change default number of reserved records to a constant.
- Add comments.