### PR TITLE
HOPSWORKS-2885

### DIFF
--- a/storage/ndb/ndbapi-examples/ndbapi_array_simple/ndbapi_array_simple.cpp
+++ b/storage/ndb/ndbapi-examples/ndbapi_array_simple/ndbapi_array_simple.cpp
@@ -325,10 +325,11 @@ static void do_read(Ndb& ndb)
           const char* first;
           size_t count;
           get_byte_array(attr[i], first, count);
+         const signed char* signed_first = (const signed char*)first;
           int sum = 0;
-          for (const char* byte = first; byte < first + count; byte++)
+          for (const signed char* byte = signed_first; byte < signed_first + count; byte++)
           {
-            sum += (int)(*byte);
+            sum += (*byte);
           }
           cout << ", stored bytes length: " << count
                << ", sum of byte array: " << sum << endl;

--- a/storage/ndb/ndbapi-examples/ndbapi_array_using_adapter/ndbapi_array_using_adapter.cpp
+++ b/storage/ndb/ndbapi-examples/ndbapi_array_using_adapter/ndbapi_array_using_adapter.cpp
@@ -274,11 +274,12 @@ static void do_read(Ndb& ndb)
         size_t data_length;
         attr_adapter.get_byte_array(attr[i], data_ptr,
                                     data_length, error);
+       const signed char* signed_data_ptr = (const signed char*)data_ptr;
         if(error == ReadOnlyArrayAdapter::Success)
         {
           int sum = 0;
           for (size_t j = 0; j < data_length; j++)
-            sum += (int)(data_ptr[j]);
+            sum += (int)(signed_data_ptr[j]);
           cout << ", stored bytes length: " << data_length
                << ", sum of byte array: " << sum << endl;
         }


### PR DESCRIPTION
Sum of const char* isn't portable. ARM64 treats this as an unsigned char and
x86 treats it as signed char.