### PR TITLE
HOPSWORKS-2932: Fix possible corruption of crash log

### DIFF
--- a/storage/ndb/src/kernel/vm/mt.cpp
+++ b/storage/ndb/src/kernel/vm/mt.cpp
@@ -1006,7 +1006,7 @@ private:
  */
 struct thr_job_buffer // 32k
 {
-  static const unsigned SIZE = 8190;
+  static const unsigned SIZE = 8188;
 
   /*
    * Amount of signal data currently in m_data buffer.
@@ -1018,12 +1018,13 @@ struct thr_job_buffer // 32k
    * signals from released buffers.
    */
   Uint32 m_prioa;
-  union {
-    Uint32 m_data[SIZE];
 
-    thr_job_buffer * m_next; // For free-list
-  };
-};  
+  Uint32 m_data[SIZE];
+
+  thr_job_buffer * m_next; // For free-list
+};
+// Make sure that the size assumption holds.
+NDB_STATIC_ASSERT((sizeof(thr_job_buffer) == sizeof(Alloc_page)));
 
 static
 inline


### PR DESCRIPTION
In mt.cpp, struct thr_job_buffer, was a union of m_data and
m_next. Presumably, this union was created under the assumption that
m_data isn't used when the buffer is in the free-list. This assumption
does not hold for the crashlog.

- Add static assert to encode the assumption that the size of
  thr_job_buffer is the same as the global memory manager page size.
- Remove union of m_data and m_next, and adjust thr_job_buffer::SIZE
  accordingly.