### PR TITLE
RONDB-123: Change company name "Logical Clocks AB" -> "Hopsworks AB"

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,5 @@
+# Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
+<antonios@hopsworks.ai> <antonios@logicalclocks.com>
+<axel@hopsworks.ai> <axel@logicalclocks.com>
+<mikael@hopsworks.ai> <mikael@logicalclocks.com>
+<salman@hopsworks.ai> <salman@logicalclocks.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2006, 2021, Oracle and/or its affiliates.
-# Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 # 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <p align="center">
     <a href="https://rondb.com" alt="rondb.com">
         <img src="https://img.shields.io/badge/rondb-com-green" /></a>
-    <a href="https://logicalclocks.com" alt="logicalclocks.com">
-        <img src="https://img.shields.io/static/v1?label=logicalclocks&message=com&color=blueviolet" /></a>
+    <a href="https://hopsworks.ai" alt="hopsworks.ai">
+        <img src="https://img.shields.io/static/v1?label=hopsworks&message=ai&color=blueviolet" /></a>
     <a href="https://dev.mysql.com/doc/" alt="dev.mysql.com/doc">
         <img src="https://img.shields.io/static/v1?label=mysql&message=doc&color=blue" /></a>
     <a href="https://dev.mysql.com/downloads/" alt="dev.mysql.com/downloads">
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  Give a star and make a developer happy <img src="https://content.logicalclocks.com/hubfs/1f49a.png">
+  Give a star and make a developer happy <img src="https://content.hopsworks.ai/hubfs/1f49a.png">
 </p>
 
 ---
@@ -31,7 +31,7 @@ License information can be found [here](https://github.com/logicalclocks/rondb/b
 
 ## Who is behind RondDB?
 
-RonDB is brought to you by the RonDB team at [Logical Clocks AB](https://www.logicalclocks.com/).
+RonDB is brought to you by the RonDB team at [Hopsworks AB](https://www.hopsworks.ai/).
 
 ## More information
 
@@ -53,4 +53,4 @@ There are no existing managed databases available today with these attributes. W
 ---
 
 Copyright (c) 2000, 2021, Oracle and/or its affiliates.   
-Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.

--- a/cmake/package_name.cmake
+++ b/cmake/package_name.cmake
@@ -1,5 +1,5 @@
 # Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-# Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,
@@ -159,8 +159,8 @@ IF(NOT CPACK_SOURCE_PACKAGE_FILE_NAME)
   ELSE()
   ENDIF()
 ENDIF()
-SET(CPACK_PACKAGE_CONTACT "Logical Clocks <mikael@logicalclocks.com>")
-SET(CPACK_PACKAGE_VENDOR "Logical Clocks")
+SET(CPACK_PACKAGE_CONTACT "Hopsworks AB <mikael@hopsworks.ai>")
+SET(CPACK_PACKAGE_VENDOR "Hopsworks AB")
 SET(CPACK_SOURCE_GENERATOR "TGZ")
 INCLUDE(cpack_source_ignore_files)
 

--- a/hopsworks_scripts/config_git
+++ b/hopsworks_scripts/config_git
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
 set -e
 
@@ -20,7 +20,7 @@ mkscript() {
     echo
 }
 
-mkscript .git/hooks/pre-commit "A hook to check copyright for Logical Clocks" <<"EOF"
+mkscript .git/hooks/pre-commit "A hook to check copyright for Hopsworks AB" <<"EOF"
 #!/bin/bash
 set -e
 year=`date +%Y`
@@ -42,13 +42,13 @@ git diff --cached --name-only --diff-filter=d |
                 tac;
         } |
             # Check that a correct copyright notice is present
-            grep -Eq '^[ #*-]*Copyright (\(c\)|\\\(co) ('"$(seq -s '|' 2020 $year)), $year, "'Logical Clocks and\/or its affiliates\.$' ||
+            grep -Eq '^[ #*-]*Copyright (\(c\)|\\\(co) ('"$(seq -s '|' 2020 $year)), $year, "'Hopsworks AB and\/or its affiliates\.$' ||
             # If not, fail with instructions
             {
                 echo "$filename:";
-                echo "  Can't find a correct copyright notice for Logical Clocks.";
+                echo "  Can't find a correct copyright notice for Hopsworks AB.";
                 echo "  If one exists, correct it, otherwise add the following to the header comment:";
-                echo "   Copyright (c) $year, $year, Logical Clocks and/or its affiliates.";
+                echo "   Copyright (c) $year, $year, Hopsworks AB and/or its affiliates.";
                 exitcode=1;
             }
         done
@@ -60,10 +60,10 @@ git config merge.conflictstyle diff3
 echo This repository is now configured to use the diff3 merge conflictstyle
 echo ""
 
-git config user.email | grep -Eq "@logicalclocks\.com$" || {
-    echo Warning: Git is not configured to identify you as an employee of Logical Clocks.
+git config user.email | grep -Eq "@hopsworks\.ai$" || {
+    echo Warning: Git is not configured to identify you as an employee of Hopsworks AB.
     echo You can do so by running:
     echo "    git config --global user.name 'Firstname Lastname'"
-    echo "    git config --global user.email yourname@logicalclocks.com"
+    echo "    git config --global user.email yourname@hopsworks.ai"
     echo
 }

--- a/man/ndb_import.1
+++ b/man/ndb_import.1
@@ -3360,7 +3360,7 @@ option\&.
 .PP
 Copyright \(co 1997, 2021, Oracle and/or its affiliates.
 .br
-Copyright \(co 2021, 2021, Logical Clocks and/or its affiliates.
+Copyright \(co 2021, 2022, Hopsworks AB and/or its affiliates.
 .PP
 This documentation is free software; you can redistribute it and/or modify it only under the terms of the GNU General Public License as published by the Free Software Foundation; version 2 of the License.
 .PP
@@ -3375,4 +3375,4 @@ online at http://dev.mysql.com/doc/ and at http://docs.rondb.com.
 .SH AUTHOR
 Oracle Corporation (http://dev.mysql.com/).
 .br
-Logical Clocks (http://logicalclocks.com/).
+Hopsworks AB (http://www.hopsworks.ai/).

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -2,7 +2,7 @@
 # -*- cperl -*-
 
 # Copyright (c) 2004, 2021, Oracle and/or its affiliates.
-# Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/sql/debug_lock_order.cc
+++ b/sql/debug_lock_order.cc
@@ -1,5 +1,5 @@
 /* Copyright (c) 2014, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/storage/ndb/clusterj/clusterj-api/src/main/java/com/mysql/clusterj/Constants.java
+++ b/storage/ndb/clusterj/clusterj-api/src/main/java/com/mysql/clusterj/Constants.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021, LogicalClocks, and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-api/src/main/java/com/mysql/clusterj/DynamicObject.java
+++ b/storage/ndb/clusterj/clusterj-api/src/main/java/com/mysql/clusterj/DynamicObject.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021, LogicalClocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-api/src/main/java/com/mysql/clusterj/Session.java
+++ b/storage/ndb/clusterj/clusterj-api/src/main/java/com/mysql/clusterj/Session.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021, LogicalClocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -194,7 +194,7 @@ public interface Session  extends AutoCloseable {
      *  The closeCache call can cache the session for later reuse in the SessionFactory.
      *  close will never do this.
      *
-     * closeCache is an add-on by Logical Clocks
+     * closeCache is an add-on by Hopsworks AB
      *
      * If dropCache is set to true, the cached instances will
      * be droppped as part of the close call, otherwise they
@@ -268,7 +268,7 @@ public interface Session  extends AutoCloseable {
      * session.newInstance(T.class), find(T.class), or query; or Iterable<T>, or array T[].
      * Resources released can include direct buffers used to hold instance data.
      * Released resources may be returned to a pool if releaseCache is used.
-     * releaseCache is an add-on by Logical Clocks
+     * releaseCache is an add-on by Hopsworks AB
      * @param obj a domain object of type T, an Iterable<T>, or array T[]
      * @return the input parameter
      * @throws ClusterJUserException if the instance is not a domain object T, Iterable<T>, or array T[],
@@ -278,7 +278,7 @@ public interface Session  extends AutoCloseable {
     <T> T releaseCache(T obj, Class<?> cls);
 
     /** Release all cached instances of a certain type or all types.
-     *  Added by Logical Clocks.
+     *  Added by Hopsworks AB.
      */
     <T> void dropInstanceCache(Class<?> type);
     void dropInstanceCache();

--- a/storage/ndb/clusterj/clusterj-api/src/main/java/com/mysql/clusterj/SessionFactory.java
+++ b/storage/ndb/clusterj/clusterj-api/src/main/java/com/mysql/clusterj/SessionFactory.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2010, 2021, Oracle and/or its affiliates.
- *  Copyright (c) 2020, 2021 LogicalClocks, and/or its affiliates.
+ *  Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,
@@ -155,7 +155,7 @@ public interface SessionFactory {
 
     /**
      * Drop the session cache.
-     * Added by Logical Clocks.
+     * Added by Hopsworks AB.
      */
     public void dropSessionCache();
 }

--- a/storage/ndb/clusterj/clusterj-core/CMakeLists.txt
+++ b/storage/ndb/clusterj/clusterj-core/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-# Copyright (c) 2020, 2021 LogicalClocks and/or its affiliates.
+# Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/SessionFactoryImpl.java
+++ b/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/SessionFactoryImpl.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021 LogicalClocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/SessionImpl.java
+++ b/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/SessionImpl.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021 LogicalClocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/dtocache/DTOCache.java
+++ b/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/dtocache/DTOCache.java
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2020,2021 LogicalClocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/metadata/AbstractDomainFieldHandlerImpl.java
+++ b/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/metadata/AbstractDomainFieldHandlerImpl.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/metadata/DomainFieldHandlerImpl.java
+++ b/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/metadata/DomainFieldHandlerImpl.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/metadata/DomainTypeHandlerImpl.java
+++ b/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/metadata/DomainTypeHandlerImpl.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021 LogicalClocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/util/JDK14LoggerImpl.java
+++ b/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/util/JDK14LoggerImpl.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021 LogicalClocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
    Use is subject to license terms.
 
    This program is free software; you can redistribute it and/or modify

--- a/storage/ndb/clusterj/clusterj-test/CMakeLists.txt
+++ b/storage/ndb/clusterj/clusterj-test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-# Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/AbstractClusterJModelTest.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/AbstractClusterJModelTest.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/AbstractClusterJTest.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/AbstractClusterJTest.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/Bug17200163Test.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/Bug17200163Test.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2013, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/DateAsPkSqlDateTypesTest.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/DateAsPkSqlDateTypesTest.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/DynamicStringPKTest.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/DynamicStringPKTest.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
- *  Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+ *  Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/LongvarcharPKTest.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/LongvarcharPKTest.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
- *  Copyright (c) 2021, 2021 Logical Clocks and/or its affiliates.
+ *  Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/ReconnectTest.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/ReconnectTest.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/VarcharPKTest.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/VarcharPKTest.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
- *  Copyright (c) 2021, 2021 Logical Clocks and/or its affiliates.
+ *  Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/ConversationSummary.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/ConversationSummary.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2013, 2021, Oracle and/or its affiliates.
- *  Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+ *  Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/DateAsPkSqlDateTypes.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/DateAsPkSqlDateTypes.java
@@ -1,6 +1,6 @@
 /*
    Copyright 2010 Sun Microsystems, Inc.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
    Use is subject to license terms.
 
    This program is free software; you can redistribute it and/or modify

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/DateIdBase.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/DateIdBase.java
@@ -1,6 +1,6 @@
 /*
    Copyright 2010 Sun Microsystems, Inc.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
    Use is subject to license terms.
 
    This program is free software; you can redistribute it and/or modify

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/DynamicStringPKs.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/DynamicStringPKs.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
- *  Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+ *  Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/LongvarcharPK.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/LongvarcharPK.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
- *  Copyright (c) 2021, 2021 Logical Clocks and/or its affiliates.
+ *  Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/VarcharPK.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/model/VarcharPK.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
- *  Copyright (c) 2021, 2021 Logical Clocks and/or its affiliates.
+ *  Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-test/src/main/resources/schema.sql
+++ b/storage/ndb/clusterj/clusterj-test/src/main/resources/schema.sql
@@ -1,5 +1,5 @@
 -- Copyright (c) 2009, 2021, Oracle and/or its affiliates.
--- Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+-- Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 --
 -- This program is free software; you can redistribute it and/or modify
 -- it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/ClusterTransactionImpl.java
+++ b/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/ClusterTransactionImpl.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2009, 2021, Oracle and/or its affiliates.
- *  Copyright (c) 2020, 2021 LogicalClocks, and/or its affiliates.
+ *  Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/NdbRecordSmartValueHandlerImpl.java
+++ b/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/NdbRecordSmartValueHandlerImpl.java
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2012, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021 LogicalClocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/Utility.java
+++ b/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/Utility.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2010, 2021, Oracle and/or its affiliates.
- *  Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+ *  Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-tie/src/test/java/testsuite/clusterj/tie/LongvarcharPKTest.java
+++ b/storage/ndb/clusterj/clusterj-tie/src/test/java/testsuite/clusterj/tie/LongvarcharPKTest.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
- *  Copyright (c) 2021, 2021 Logical Clocks and/or its affiliates.
+ *  Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/clusterj/clusterj-tie/src/test/java/testsuite/clusterj/tie/VarcharPKTest.java
+++ b/storage/ndb/clusterj/clusterj-tie/src/test/java/testsuite/clusterj/tie/VarcharPKTest.java
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
- *  Copyright (c) 2021, 2021 Logical Clocks and/or its affiliates.
+ *  Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/debugger/EventLogger.hpp
+++ b/storage/ndb/include/debugger/EventLogger.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/debugger/SignalLoggerManager.hpp
+++ b/storage/ndb/include/debugger/SignalLoggerManager.hpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/BlockNumbers.h
+++ b/storage/ndb/include/kernel/BlockNumbers.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/GlobalSignalNumbers.h
+++ b/storage/ndb/include/kernel/GlobalSignalNumbers.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/RefConvert.hpp
+++ b/storage/ndb/include/kernel/RefConvert.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/kernel_config_parameters.h
+++ b/storage/ndb/include/kernel/kernel_config_parameters.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2004, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/ndb_limits.h
+++ b/storage/ndb/include/kernel/ndb_limits.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/Abort.hpp
+++ b/storage/ndb/include/kernel/signaldata/Abort.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/AccLock.hpp
+++ b/storage/ndb/include/kernel/signaldata/AccLock.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/BackupContinueB.hpp
+++ b/storage/ndb/include/kernel/signaldata/BackupContinueB.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/ConfigChange.hpp
+++ b/storage/ndb/include/kernel/signaldata/ConfigChange.hpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/DictTabInfo.hpp
+++ b/storage/ndb/include/kernel/signaldata/DictTabInfo.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/DihScanTab.hpp
+++ b/storage/ndb/include/kernel/signaldata/DihScanTab.hpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/DumpStateOrd.hpp
+++ b/storage/ndb/include/kernel/signaldata/DumpStateOrd.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/LqhFrag.hpp
+++ b/storage/ndb/include/kernel/signaldata/LqhFrag.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/RestoreImpl.hpp
+++ b/storage/ndb/include/kernel/signaldata/RestoreImpl.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/SignalData.hpp
+++ b/storage/ndb/include/kernel/signaldata/SignalData.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/StopReq.hpp
+++ b/storage/ndb/include/kernel/signaldata/StopReq.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/SumaImpl.hpp
+++ b/storage/ndb/include/kernel/signaldata/SumaImpl.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/TakeOver.hpp
+++ b/storage/ndb/include/kernel/signaldata/TakeOver.hpp
@@ -1,6 +1,6 @@
 /* 
    Copyright (c) 2007, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/TcContinueB.hpp
+++ b/storage/ndb/include/kernel/signaldata/TcContinueB.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/TrpKeepAlive.hpp
+++ b/storage/ndb/include/kernel/signaldata/TrpKeepAlive.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/kernel/signaldata/TupFrag.hpp
+++ b/storage/ndb/include/kernel/signaldata/TupFrag.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/mgmapi/mgmapi.h
+++ b/storage/ndb/include/mgmapi/mgmapi.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/mgmapi/ndbd_exit_codes.h
+++ b/storage/ndb/include/mgmapi/ndbd_exit_codes.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/portlib/NdbConfig.h
+++ b/storage/ndb/include/portlib/NdbConfig.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
     Use is subject to license terms.
 
    This program is free software; you can redistribute it and/or modify

--- a/storage/ndb/include/transporter/TransporterCallback.hpp
+++ b/storage/ndb/include/transporter/TransporterCallback.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/transporter/TransporterDefinitions.hpp
+++ b/storage/ndb/include/transporter/TransporterDefinitions.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/util/SimpleProperties.hpp
+++ b/storage/ndb/include/util/SimpleProperties.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/include/util/version.h
+++ b/storage/ndb/include/util/version.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
     Use is subject to license terms.
 
    This program is free software; you can redistribute it and/or modify

--- a/storage/ndb/ndbapi-examples/ndbapi_retries/ndbapi_retries.cpp
+++ b/storage/ndb/ndbapi-examples/ndbapi_retries/ndbapi_retries.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/nodejs/jones-ndb/impl/ndb/ndb_service_provider.js
+++ b/storage/ndb/nodejs/jones-ndb/impl/ndb/ndb_service_provider.js
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2014, 2021, Oracle and/or its affiliates.
- Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+ Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
  
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/nodejs/perftest/jscrund.js
+++ b/storage/ndb/nodejs/perftest/jscrund.js
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2013, 2021, Oracle and/or its affiliates.
- Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+ Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
  
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/nodejs/samples/tweet/tweet.js
+++ b/storage/ndb/nodejs/samples/tweet/tweet.js
@@ -2,7 +2,7 @@
  *
  * This depends on the schema defined in create_tweet_tables.sql
  *
- * Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+ * Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
  */
 
 'use strict';

--- a/storage/ndb/plugin/ha_ndb_index_stat.cc
+++ b/storage/ndb/plugin/ha_ndb_index_stat.cc
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/plugin/ha_ndbinfo.cc
+++ b/storage/ndb/plugin/ha_ndbinfo.cc
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/plugin/ha_ndbinfo_sql.cc
+++ b/storage/ndb/plugin/ha_ndbinfo_sql.cc
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/plugin/ndb_global_schema_lock.cc
+++ b/storage/ndb/plugin/ndb_global_schema_lock.cc
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/plugin/ndb_repl_tab.cc
+++ b/storage/ndb/plugin/ndb_repl_tab.cc
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2012, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/BlockNames.cpp
+++ b/storage/ndb/src/common/debugger/BlockNames.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/EventLogger.cpp
+++ b/storage/ndb/src/common/debugger/EventLogger.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/SignalLoggerManager.cpp
+++ b/storage/ndb/src/common/debugger/SignalLoggerManager.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/AccLock.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/AccLock.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/DictTabInfo.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/DictTabInfo.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/FireTrigOrd.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/FireTrigOrd.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/FsReadWriteReq.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/FsReadWriteReq.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/FsRef.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/FsRef.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/IndxAttrInfo.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/IndxAttrInfo.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/IndxKeyInfo.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/IndxKeyInfo.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/LCP.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/LCP.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks AB and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/LqhFrag.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/LqhFrag.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/LqhKey.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/LqhKey.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/PackedSignal.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/PackedSignal.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/RestoreImpl.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/RestoreImpl.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2016, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/SignalDataPrint.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/SignalDataPrint.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/SignalNames.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/SignalNames.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/StartRec.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/StartRec.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/SumaImpl.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/SumaImpl.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks AB and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/TcIndx.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/TcIndx.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/TcKeyRef.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/TcKeyRef.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/TcKeyReq.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/TcKeyReq.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/TcRollbackRep.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/TcRollbackRep.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/TrigAttrInfo.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/TrigAttrInfo.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/TrpKeepAlive.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/TrpKeepAlive.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/TupCommit.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/TupCommit.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/TupKey.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/TupKey.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/debugger/signaldata/UtilDelete.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/UtilDelete.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/portlib/NdbConfig.cpp
+++ b/storage/ndb/src/common/portlib/NdbConfig.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/portlib/NdbHW.cpp
+++ b/storage/ndb/src/common/portlib/NdbHW.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2013, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/portlib/NdbMutex.cpp
+++ b/storage/ndb/src/common/portlib/NdbMutex.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/portlib/memtest.cpp
+++ b/storage/ndb/src/common/portlib/memtest.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/portlib/ndb_daemon.cpp
+++ b/storage/ndb/src/common/portlib/ndb_daemon.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/transporter/Loopback_Transporter.cpp
+++ b/storage/ndb/src/common/transporter/Loopback_Transporter.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/transporter/Loopback_Transporter.hpp
+++ b/storage/ndb/src/common/transporter/Loopback_Transporter.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/transporter/Packer.cpp
+++ b/storage/ndb/src/common/transporter/Packer.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/util/HashMap2.cpp
+++ b/storage/ndb/src/common/util/HashMap2.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/util/SimpleProperties.cpp
+++ b/storage/ndb/src/common/util/SimpleProperties.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/util/mysql_utils_test.cpp
+++ b/storage/ndb/src/common/util/mysql_utils_test.cpp
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2010, 2021, Oracle and/or its affiliates.
- Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+ Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/util/ndb_opts.cpp
+++ b/storage/ndb/src/common/util/ndb_opts.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/util/testSimpleProperties.cpp
+++ b/storage/ndb/src/common/util/testSimpleProperties.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/util/version.cpp
+++ b/storage/ndb/src/common/util/version.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/CMakeLists.txt
+++ b/storage/ndb/src/kernel/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-# Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/SimBlockList.cpp
+++ b/storage/ndb/src/kernel/SimBlockList.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/angel.cpp
+++ b/storage/ndb/src/kernel/angel.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/ERROR_codes.txt
+++ b/storage/ndb/src/kernel/blocks/ERROR_codes.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-# Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/backup/BackupInit.cpp
+++ b/storage/ndb/src/kernel/blocks/backup/BackupInit.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbacc/Dbacc.hpp
+++ b/storage/ndb/src/kernel/blocks/dbacc/Dbacc.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbacc/DbaccInit.cpp
+++ b/storage/ndb/src/kernel/blocks/dbacc/DbaccInit.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbacc/DbaccMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbacc/DbaccMain.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbacc/Dbqacc.cpp
+++ b/storage/ndb/src/kernel/blocks/dbacc/Dbqacc.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2019, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbdict/Dbdict.cpp
+++ b/storage/ndb/src/kernel/blocks/dbdict/Dbdict.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbdict/Dbdict.hpp
+++ b/storage/ndb/src/kernel/blocks/dbdict/Dbdict.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbdih/Dbdih.hpp
+++ b/storage/ndb/src/kernel/blocks/dbdih/Dbdih.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbdih/DbdihInit.cpp
+++ b/storage/ndb/src/kernel/blocks/dbdih/DbdihInit.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbdih/DbdihMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbdih/DbdihMain.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbinfo/Dbinfo.cpp
+++ b/storage/ndb/src/kernel/blocks/dbinfo/Dbinfo.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhProxy.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhProxy.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhProxy.hpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhProxy.hpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dblqh/Dbqlqh.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/Dbqlqh.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2019, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks AB and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbspj/Dbspj.hpp
+++ b/storage/ndb/src/kernel/blocks/dbspj/Dbspj.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbspj/DbspjMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbspj/DbspjMain.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks AB and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtc/Dbtc.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/Dbtc.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcInit.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcInit.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcProxy.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcProxy.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/Dbqtup.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/Dbqtup.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2019, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupAbort.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupAbort.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupClient.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupClient.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
    as published by the Free Software Foundation.

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupCommit.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupCommit.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupDebug.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupDebug.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupDiskAlloc.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupDiskAlloc.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupExecQuery.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupExecQuery.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupGen.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupGen.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupIndex.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupIndex.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupMeta.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupMeta.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupPagMan.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupPagMan.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupPageMap.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupPageMap.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupProxy.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupProxy.hpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
    as published by the Free Software Foundation.

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupRoutines.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupRoutines.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupScan.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupScan.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupStoredProcDef.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupStoredProcDef.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupTabDesMan.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupTabDesMan.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupTrigger.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupTrigger.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupVarAlloc.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupVarAlloc.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/Undo_buffer.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/Undo_buffer.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtup/Undo_buffer.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/Undo_buffer.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtux/Dbqtux.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/Dbqtux.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2019, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtux/Dbtux.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/Dbtux.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtux/DbtuxBuild.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/DbtuxBuild.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtux/DbtuxDebug.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/DbtuxDebug.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtux/DbtuxGen.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/DbtuxGen.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtux/DbtuxMaint.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/DbtuxMaint.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtux/DbtuxMeta.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/DbtuxMeta.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtux/DbtuxNode.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/DbtuxNode.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtux/DbtuxScan.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/DbtuxScan.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtux/DbtuxStat.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/DbtuxStat.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbutil/DbUtil.cpp
+++ b/storage/ndb/src/kernel/blocks/dbutil/DbUtil.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/lgman.cpp
+++ b/storage/ndb/src/kernel/blocks/lgman.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/lgman.hpp
+++ b/storage/ndb/src/kernel/blocks/lgman.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/ndbcntr/Ndbcntr.hpp
+++ b/storage/ndb/src/kernel/blocks/ndbcntr/Ndbcntr.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/ndbcntr/NdbcntrMain.cpp
+++ b/storage/ndb/src/kernel/blocks/ndbcntr/NdbcntrMain.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/pgman.cpp
+++ b/storage/ndb/src/kernel/blocks/pgman.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/pgman.hpp
+++ b/storage/ndb/src/kernel/blocks/pgman.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/record_types.hpp
+++ b/storage/ndb/src/kernel/blocks/record_types.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2006, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/suma/Suma.cpp
+++ b/storage/ndb/src/kernel/blocks/suma/Suma.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/suma/Suma.hpp
+++ b/storage/ndb/src/kernel/blocks/suma/Suma.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/suma/SumaInit.cpp
+++ b/storage/ndb/src/kernel/blocks/suma/SumaInit.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/thrman.cpp
+++ b/storage/ndb/src/kernel/blocks/thrman.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/thrman.hpp
+++ b/storage/ndb/src/kernel/blocks/thrman.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/trix/Trix.cpp
+++ b/storage/ndb/src/kernel/blocks/trix/Trix.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/trpman.hpp
+++ b/storage/ndb/src/kernel/blocks/trpman.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/error/ErrorReporter.cpp
+++ b/storage/ndb/src/kernel/error/ErrorReporter.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/error/ErrorReporter.hpp
+++ b/storage/ndb/src/kernel/error/ErrorReporter.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/main.cpp
+++ b/storage/ndb/src/kernel/main.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/ndbd.hpp
+++ b/storage/ndb/src/kernel/ndbd.hpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/CMakeLists.txt
+++ b/storage/ndb/src/kernel/vm/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-# Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/Configuration.hpp
+++ b/storage/ndb/src/kernel/vm/Configuration.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/CountingPool.cpp
+++ b/storage/ndb/src/kernel/vm/CountingPool.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2012, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/DL64HashTable.hpp
+++ b/storage/ndb/src/kernel/vm/DL64HashTable.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2017, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/DL64HashTable2.hpp
+++ b/storage/ndb/src/kernel/vm/DL64HashTable2.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2017, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/DLC64HashTable.hpp
+++ b/storage/ndb/src/kernel/vm/DLC64HashTable.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2017, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/DynArr256.cpp
+++ b/storage/ndb/src/kernel/vm/DynArr256.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2006, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/Emulator.hpp
+++ b/storage/ndb/src/kernel/vm/Emulator.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/FastScheduler.cpp
+++ b/storage/ndb/src/kernel/vm/FastScheduler.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/FastScheduler.hpp
+++ b/storage/ndb/src/kernel/vm/FastScheduler.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/Intrusive64List.cpp
+++ b/storage/ndb/src/kernel/vm/Intrusive64List.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2015, 2017, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021, Logical Clocks, and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/Intrusive64List.hpp
+++ b/storage/ndb/src/kernel/vm/Intrusive64List.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2013, 2019, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/IntrusiveTags.hpp
+++ b/storage/ndb/src/kernel/vm/IntrusiveTags.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2017, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/NdbinfoTables.cpp
+++ b/storage/ndb/src/kernel/vm/NdbinfoTables.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/Pool.cpp
+++ b/storage/ndb/src/kernel/vm/Pool.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2006, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/Pool.hpp
+++ b/storage/ndb/src/kernel/vm/Pool.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2006, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/RWPool.hpp
+++ b/storage/ndb/src/kernel/vm/RWPool.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2006, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/RWPool64.hpp
+++ b/storage/ndb/src/kernel/vm/RWPool64.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2006, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2020, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/Rope.cpp
+++ b/storage/ndb/src/kernel/vm/Rope.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/Rope.hpp
+++ b/storage/ndb/src/kernel/vm/Rope.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/SectionReader.cpp
+++ b/storage/ndb/src/kernel/vm/SectionReader.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/SegmentList.cpp
+++ b/storage/ndb/src/kernel/vm/SegmentList.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/SimBlockList.hpp
+++ b/storage/ndb/src/kernel/vm/SimBlockList.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/TransientPagePool.cpp
+++ b/storage/ndb/src/kernel/vm/TransientPagePool.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2017, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/TransientPagePool.hpp
+++ b/storage/ndb/src/kernel/vm/TransientPagePool.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2017, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/TransientPool.hpp
+++ b/storage/ndb/src/kernel/vm/TransientPool.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2017, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/TransientSlotPool.cpp
+++ b/storage/ndb/src/kernel/vm/TransientSlotPool.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2017, 2021, Oracle and/or its affiliates.
    Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/TransientSlotPool.hpp
+++ b/storage/ndb/src/kernel/vm/TransientSlotPool.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2017, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/TransporterCallback.cpp
+++ b/storage/ndb/src/kernel/vm/TransporterCallback.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/dummy_nonmt.cpp
+++ b/storage/ndb/src/kernel/vm/dummy_nonmt.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/mt.cpp
+++ b/storage/ndb/src/kernel/vm/mt.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/mt.hpp
+++ b/storage/ndb/src/kernel/vm/mt.hpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/mt_thr_config.cpp
+++ b/storage/ndb/src/kernel/vm/mt_thr_config.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/ndbd_malloc.cpp
+++ b/storage/ndb/src/kernel/vm/ndbd_malloc.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/ndbd_malloc.hpp
+++ b/storage/ndb/src/kernel/vm/ndbd_malloc.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/ndbd_malloc_impl.cpp
+++ b/storage/ndb/src/kernel/vm/ndbd_malloc_impl.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2006, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -2367,7 +2367,7 @@ void perf_test(int sz, int run_time)
 }
 #endif
 /**
- * Logical Clocks memory pool
+ * Hopsworks AB memory pool
  * --------------------------
  * This module implements a malloc/free API that can use the global memory
  * pools where most of the memory in the NDB data node resides. This makes it
@@ -3697,7 +3697,7 @@ void lc_init_long_lived_memory_pool(LC_MAP_POOL_ID map_pool_id_func,
 }
 
 /**
- * Logical Clocks short lived memory handler
+ * Hopsworks AB short lived memory handler
  *
  * This malloc/free implementation is based on the use case where the memory
  * is used to handle short-lived messages that pass through in a matter of
@@ -4659,7 +4659,7 @@ bench_short_test()
 static void
 test_get_array_pos()
 {
-  printf("Test Logical Clocks get_array_pos\n");
+  printf("Test Hopsworks AB get_array_pos\n");
   size_t size_array[31];
   lc_uint32 pos_array[31];
   lc_uint32 i = 0;
@@ -4744,8 +4744,8 @@ test_get_array_pos()
 static void
 lc_ndbd_malloc_test()
 {
-  /* Testing Logical Clocks memory pool for ndbmtd */
-  printf("Test Logical Clocks memory pool for ndbmtd\n");
+  /* Testing Hopsworks AB memory pool for ndbmtd */
+  printf("Test Hopsworks AB memory pool for ndbmtd\n");
   init_lc_ndbd_memory_pool(12,
                            NUM_THREADS,
                            NUM_THREADS/2,
@@ -4782,7 +4782,7 @@ lc_ndbd_malloc_test()
   printf("num_mallocs: %d\n", num_mallocs.load());
   bench_short_test();
   bench_long_test();
-  printf("Successful Test of Logical Clocks memory pool for ndbmtd\n");
+  printf("Successful Test of Hopsworks AB memory pool for ndbmtd\n");
   return;
 }
 

--- a/storage/ndb/src/kernel/vm/ndbd_malloc_impl.hpp
+++ b/storage/ndb/src/kernel/vm/ndbd_malloc_impl.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2006, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/pc.hpp
+++ b/storage/ndb/src/kernel/vm/pc.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/test_context.cpp
+++ b/storage/ndb/src/kernel/vm/test_context.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/vm/test_jamFileNames.sh
+++ b/storage/ndb/src/kernel/vm/test_jamFileNames.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+# Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/mgmclient/main.cpp
+++ b/storage/ndb/src/mgmclient/main.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/mgmsrv/Config.cpp
+++ b/storage/ndb/src/mgmsrv/Config.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/mgmsrv/Config.hpp
+++ b/storage/ndb/src/mgmsrv/Config.hpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/mgmsrv/ConfigManager.hpp
+++ b/storage/ndb/src/mgmsrv/ConfigManager.hpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/mgmsrv/InitConfigFileParser.cpp
+++ b/storage/ndb/src/mgmsrv/InitConfigFileParser.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.hpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/mgmsrv/Services.cpp
+++ b/storage/ndb/src/mgmsrv/Services.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/mgmsrv/Services.hpp
+++ b/storage/ndb/src/mgmsrv/Services.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/mgmsrv/main.cpp
+++ b/storage/ndb/src/mgmsrv/main.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/mgmsrv/ndb_mgmd_error.h
+++ b/storage/ndb/src/mgmsrv/ndb_mgmd_error.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2007, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/Ndb.cpp
+++ b/storage/ndb/src/ndbapi/Ndb.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/NdbDictionaryImpl.cpp
+++ b/storage/ndb/src/ndbapi/NdbDictionaryImpl.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/NdbDictionaryImpl.hpp
+++ b/storage/ndb/src/ndbapi/NdbDictionaryImpl.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/NdbEventOperationImpl.cpp
+++ b/storage/ndb/src/ndbapi/NdbEventOperationImpl.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/NdbImpl.hpp
+++ b/storage/ndb/src/ndbapi/NdbImpl.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/NdbQueryOperation.cpp
+++ b/storage/ndb/src/ndbapi/NdbQueryOperation.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/NdbScanOperation.cpp
+++ b/storage/ndb/src/ndbapi/NdbScanOperation.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/NdbTransaction.cpp
+++ b/storage/ndb/src/ndbapi/NdbTransaction.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/Ndbif.cpp
+++ b/storage/ndb/src/ndbapi/Ndbif.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/SignalSender.cpp
+++ b/storage/ndb/src/ndbapi/SignalSender.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/ndb_cluster_connection_impl.hpp
+++ b/storage/ndb/src/ndbapi/ndb_cluster_connection_impl.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2004, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/ndberror.cpp
+++ b/storage/ndb/src/ndbapi/ndberror.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2004, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/trp_client.cpp
+++ b/storage/ndb/src/ndbapi/trp_client.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/trp_client.hpp
+++ b/storage/ndb/src/ndbapi/trp_client.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/ndbapi/trp_node.hpp
+++ b/storage/ndb/src/ndbapi/trp_node.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/crund/helpers/src/utils/Properties_test.cpp
+++ b/storage/ndb/test/crund/helpers/src/utils/Properties_test.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testBackup.cpp
+++ b/storage/ndb/test/ndbapi/testBackup.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testBasic.cpp
+++ b/storage/ndb/test/ndbapi/testBasic.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testBitfield.cpp
+++ b/storage/ndb/test/ndbapi/testBitfield.cpp
@@ -1,6 +1,6 @@
  /*
    Copyright (c) 2004, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testBlobs.cpp
+++ b/storage/ndb/test/ndbapi/testBlobs.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testDict.cpp
+++ b/storage/ndb/test/ndbapi/testDict.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testFK.cpp
+++ b/storage/ndb/test/ndbapi/testFK.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2013, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testIndex.cpp
+++ b/storage/ndb/test/ndbapi/testIndex.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testMgmd.cpp
+++ b/storage/ndb/test/ndbapi/testMgmd.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
 
    This program is free software; you can redistribute it and/or modify

--- a/storage/ndb/test/ndbapi/testNdbApi.cpp
+++ b/storage/ndb/test/ndbapi/testNdbApi.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testNodeRestart.cpp
+++ b/storage/ndb/test/ndbapi/testNodeRestart.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testOIBasic.cpp
+++ b/storage/ndb/test/ndbapi/testOIBasic.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testSRBank.cpp
+++ b/storage/ndb/test/ndbapi/testSRBank.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testScan.cpp
+++ b/storage/ndb/test/ndbapi/testScan.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testScanFilter.cpp
+++ b/storage/ndb/test/ndbapi/testScanFilter.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2007, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/testSystemRestart.cpp
+++ b/storage/ndb/test/ndbapi/testSystemRestart.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/ndbapi/test_event.cpp
+++ b/storage/ndb/test/ndbapi/test_event.cpp
@@ -1,6 +1,6 @@
 /*
  Copyright (c) 2003, 2021, Oracle and/or its affiliates.
- Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+ Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/run-test/atrt-mysqltest
+++ b/storage/ndb/test/run-test/atrt-mysqltest
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Copyright (c) 2010, 2021, Oracle and/or its affiliates.
-# Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/run-test/conf-autotest.cnf
+++ b/storage/ndb/test/run-test/conf-autotest.cnf
@@ -1,5 +1,5 @@
 # Copyright (c) 2015, 2021, Oracle and/or its affiliates.
-# Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+# Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/run-test/conf-macbookpro.local.cnf
+++ b/storage/ndb/test/run-test/conf-macbookpro.local.cnf
@@ -1,5 +1,5 @@
 # Copyright (c) 2015, 2020, Oracle and/or its affiliates.
-# Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/run-test/create_mtr_suites.pl
+++ b/storage/ndb/test/run-test/create_mtr_suites.pl
@@ -2,7 +2,7 @@
 # -*- cperl -*-
 # Copyright (c) 2009, 2021, Oracle and/or its affiliates.
 #  Use is subject to license terms.
-# Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+# Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/run-test/daily-basic--00-tests.txt
+++ b/storage/ndb/test/run-test/daily-basic--00-tests.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2015, 2021, Oracle and/or its affiliates.
-# Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/run-test/daily-devel--08-tests.txt
+++ b/storage/ndb/test/run-test/daily-devel--08-tests.txt
@@ -1,5 +1,5 @@
 # Copyright (c) 2015, 2020, Oracle and/or its affiliates.
-# Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+# Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/run-test/main.cpp
+++ b/storage/ndb/test/run-test/main.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/run-test/setup.cpp
+++ b/storage/ndb/test/run-test/setup.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2007, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/run-test/test_execution_resources.hpp
+++ b/storage/ndb/test/run-test/test_execution_resources.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2019, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/src/NDBT_Find.cpp
+++ b/storage/ndb/test/src/NDBT_Find.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2009, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
 
    This program is free software; you can redistribute it and/or modify

--- a/storage/ndb/test/src/UtilTransactions.cpp
+++ b/storage/ndb/test/src/UtilTransactions.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/tools/cpcc.cpp
+++ b/storage/ndb/test/tools/cpcc.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/tools/hugoFill.cpp
+++ b/storage/ndb/test/tools/hugoFill.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/tools/hugoLoad.cpp
+++ b/storage/ndb/test/tools/hugoLoad.cpp
@@ -1,7 +1,7 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
    Use is subject to license terms.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/tools/hugoLockRecords.cpp
+++ b/storage/ndb/test/tools/hugoLockRecords.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/tools/hugoPkDelete.cpp
+++ b/storage/ndb/test/tools/hugoPkDelete.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/tools/hugoPkRead.cpp
+++ b/storage/ndb/test/tools/hugoPkRead.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/test/tools/restart.cpp
+++ b/storage/ndb/test/tools/restart.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/tools/NdbImport.cpp
+++ b/storage/ndb/tools/NdbImport.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2017, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/tools/NdbImport.hpp
+++ b/storage/ndb/tools/NdbImport.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2018, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/tools/NdbImportImpl.cpp
+++ b/storage/ndb/tools/NdbImportImpl.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2017, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/tools/NdbImportUtil.cpp
+++ b/storage/ndb/tools/NdbImportUtil.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2017, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/tools/NdbImportUtil.hpp
+++ b/storage/ndb/tools/NdbImportUtil.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2017, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/tools/ndb_config.cpp
+++ b/storage/ndb/tools/ndb_config.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/tools/ndb_import.cpp
+++ b/storage/ndb/tools/ndb_import.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2017, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/tools/restore/Restore.cpp
+++ b/storage/ndb/tools/restore/Restore.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/tools/restore/restore_main.cpp
+++ b/storage/ndb/tools/restore/restore_main.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/tools/waiter.cpp
+++ b/storage/ndb/tools/waiter.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2021, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks AB and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,


### PR DESCRIPTION
- Change company name from "Logical Clocks AB" and variants to
  "Hopsworks AB" in copyright notices, comments, documentation, code
  etc. except for links to github.
- Rename `lc_scripts/` to `hopsworks_scripts/`.
- Update `hopsworks_scripts/config_git` with the new company name.
- Add `.mailmap` file to change how @logicalclocks.com email addresses
  are displayed in historical commits.