### PR TITLE
RONDB-128: Loses transporter due to list management in setNeighbourNode

### DIFF
--- a/storage/ndb/src/kernel/vm/mt.cpp
+++ b/storage/ndb/src/kernel/vm/mt.cpp
@@ -2284,8 +2284,13 @@ public:
             {
               m_trp_state[prev_trp_id].m_next = m_trp_state[this_id].m_next;
             }
+            if (this_id == send_instance->m_last_trp)
+            {
+              send_instance->m_last_trp = prev_trp_id;
+            }
             break;
           }
+          prev_trp_id = next_trp_id;
           next_trp_id = m_trp_state[next_trp_id].m_next;
         }
         require(found);


### PR DESCRIPTION
This can lead to lost communication to a node not related to a neighbour
node when rearranging neighbour nodes.