### PR TITLE
RONDB-156: Fix issue with Query blocks

### DIFF
--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
@@ -5582,7 +5582,7 @@ void Dbtc::sendlqhkeyreq(Signal* signal,
       bool read_flag = (operation_type == ZREAD || operation_type == ZREAD_EX);
       if ((!read_flag) ||
           (!LqhKeyReq::getNoDiskFlag(lqhKeyReq->requestInfo)) ||
-          (!LqhKeyReq::getUtilFlag(lqhKeyReq->requestInfo)))
+          (LqhKeyReq::getUtilFlag(lqhKeyReq->requestInfo)))
 
       {
         jamDebug();


### PR DESCRIPTION
The queries towards the DBUTIL block should not use query blocks.
However the check was reversed and instead all queries not using
DBUTIL block didn't use query blocks.