### PR TITLE
RONDB-193: Exit from angel with error code when data node failed

### DIFF
--- a/storage/ndb/src/kernel/angel.cpp
+++ b/storage/ndb/src/kernel/angel.cpp
@@ -799,7 +799,7 @@ angel_run(const char* progname,
           reportShutdown(config, nodeid,
                          error_exit, 0, false, false,
                          child_error, child_signal, child_sphase);
-          angel_exit(0);
+          angel_exit(2);
         }
         // Fall-through
       case NRT_DoStart_Restart:
@@ -828,7 +828,7 @@ angel_run(const char* progname,
         reportShutdown(config, nodeid,
                        error_exit, 0, false, false,
                        child_error, child_signal, child_sphase);
-        angel_exit(0);
+        angel_exit(2);
       }
       else
       {
@@ -853,7 +853,7 @@ angel_run(const char* progname,
         reportShutdown(config, nodeid,
                        error_exit, 0, false, false,
                        child_error, child_signal, child_sphase);
-        angel_exit(0);
+        angel_exit(2);
       }
       g_eventLogger->info("Angel detected startup failure, count: %u",
                           failed_startups_counter);


### PR DESCRIPTION
Integration of RonDB with systemd units is easier if the angel process exits with proper error codes.

The current exit codes can happen from the angel process now: 0: This means a normal controlled stop, most likely caused by a shutdown from the management client.

1: Permanent failure when trying to startup the data node. Could be things like no management server running, error in configuration files and many other failures.

2: Data node failure, most likely caused by a programming error.