### PR TITLE
RONDB-213: Upgrade to use dbt2-0.37.50.20 for release builds

### DIFF
--- a/build_scripts/release_scripts/build_all.sh
+++ b/build_scripts/release_scripts/build_all.sh
@@ -3,7 +3,7 @@
 set -e
 
 export SYSBENCH_VERSION="sysbench-0.4.12.18"
-export DBT2_VERSION="dbt2-0.37.50.19"
+export DBT2_VERSION="dbt2-0.37.50.20"
 export DBT3_VERSION="dbt3-1.10"
 export RDRS_VERSION="0.1.0-22.10" 
 


### PR DESCRIPTION
Add --use-auto-increment to ndb_import calls
skip-run only skip DBT2 runs, not load phase
skip-load-dbt2 can still be used to skip load phase