### PR TITLE
Revert "RONDB-230: Disabled debugging and fixed copyright hreaders"

### DIFF
--- a/storage/ndb/include/kernel/ProcessInfo.hpp
+++ b/storage/ndb/include/kernel/ProcessInfo.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2022, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -51,9 +51,9 @@ public:
   void setUriPath(Uint32 *signal_data);
   void setUriScheme(const char *);
   void setProcessName(const char *);
-  void setHostAddress(const struct sockaddr *);
+  void setHostAddress(const struct sockaddr *, socklen_t);
   void setHostAddress(const struct in6_addr *);
-  void setHostAddress(const struct in_addr *);
+  void setHostAddress4(const struct in_addr *);
   void setHostAddress(Uint32 *signal_data);
   void setHostAddress(const char *);
   void setPid();

--- a/storage/ndb/include/transporter/TransporterRegistry.hpp
+++ b/storage/ndb/include/transporter/TransporterRegistry.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -525,7 +525,8 @@ public:
     (void)nodeId;
     return m_use_only_ipv4;
   }
-  struct sockaddr_in6 get_connect_address(NodeId node_id) const;
+  struct in6_addr get_connect_address(NodeId node_id) const;
+  struct in_addr get_connect_address4(NodeId node_id) const;
   bool is_server(NodeId) const;
 
   Uint64 get_bytes_sent(NodeId nodeId) const;

--- a/storage/ndb/src/common/mgmcommon/ConfigRetriever.cpp
+++ b/storage/ndb/src/common/mgmcommon/ConfigRetriever.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/common/mgmcommon/DnsCache.cpp
+++ b/storage/ndb/src/common/mgmcommon/DnsCache.cpp
@@ -1,6 +1,5 @@
 /*
    Copyright (c) 2020 Oracle and/or its affiliates.
-   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -67,8 +66,7 @@ GlobalDnsCache::~GlobalDnsCache() {
     delete pair.second;
  }
 
-bool GlobalDnsCache::getAddress(struct in6_addr *result,
-                                const char *hostname) {
+bool GlobalDnsCache::getAddress(struct in6_addr *result, const char *hostname) {
   Guard locked(m_mutex);
   NDB_TICKS current_time = NdbTick_getCurrentTicks();
   auto pair = m_resolver_cache.find(hostname);
@@ -85,12 +83,7 @@ bool GlobalDnsCache::getAddress(struct in6_addr *result,
   }
 
   if (Ndb_getInAddr6(result, hostname) != 0)
-  {
-    if (Ndb_getInAddr((struct in_addr*)result, hostname) != 0)
-    {
-      return false;   // hostname not found in DNS
-    }
-  }
+    return false;   // hostname not found in DNS
 
   /* Hostname found; create a cache entry*/
   m_resolver_cache[hostname] = new CacheEntry(*result, current_time);
@@ -104,8 +97,7 @@ bool GlobalDnsCache::getAddress(struct in6_addr *result,
  */
 static GlobalDnsCache theGlobalCache;
 
-int LocalDnsCache::getAddress(struct in6_addr * result,
-                              const char *hostname) {
+int LocalDnsCache::getAddress(struct in6_addr * result, const char *hostname) {
   if(m_failed_lookups.count(hostname)) return -1;
 
   bool globalResult = theGlobalCache.getAddress(result, hostname);
@@ -113,3 +105,6 @@ int LocalDnsCache::getAddress(struct in6_addr * result,
   if(! globalResult) m_failed_lookups.insert(hostname);
   return globalResult ? 0 : -1;
 }
+
+
+

--- a/storage/ndb/src/common/transporter/Transporter.cpp
+++ b/storage/ndb/src/common/transporter/Transporter.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -78,6 +78,7 @@ Transporter::Transporter(TransporterRegistry &t_reg,
     m_bytes_sent(0), m_bytes_received(0),
     m_connect_count(0),
     m_overload_count(0), m_slowdown_count(0),
+    m_connect_address(IN6ADDR_ANY_INIT),
     isMgmConnection(_isMgmConnection),
     m_connected(false),
     m_type(_type),
@@ -91,8 +92,7 @@ Transporter::Transporter(TransporterRegistry &t_reg,
   DBUG_ENTER("Transporter::Transporter");
 
   // Initialize member variables
-  memset(&m_connect_address, 0, sizeof(struct sockaddr_in6));
-  m_connect_address.sin6_addr = IN6ADDR_ANY_INIT;
+  m_connect_address4.s_addr = 0;
   ndb_socket_invalidate(&theSocket);
   m_multi_transporter_instance = 0;
   m_recv_thread_idx = 0;
@@ -223,7 +223,14 @@ Transporter::connect_server(NDB_SOCKET_TYPE sockfd,
   }
 
   // Cache the connect address
-  ndb_socket_connect_address(sockfd, &m_connect_address);
+  if (m_use_only_ipv4)
+  {
+    ndb_socket_connect_address4(sockfd, &m_connect_address4);
+  }
+  else
+  {
+    ndb_socket_connect_address(sockfd, &m_connect_address);
+  }
 
   if (!connect_server_impl(sockfd))
   {
@@ -459,7 +466,14 @@ Transporter::connect_client(NDB_SOCKET_TYPE sockfd)
     DBUG_RETURN(false);
   }
   // Cache the connect address
-  ndb_socket_connect_address(sockfd, &m_connect_address);
+  if (m_use_only_ipv4)
+  {
+    ndb_socket_connect_address4(sockfd, &m_connect_address4);
+  }
+  else
+  {
+    ndb_socket_connect_address(sockfd, &m_connect_address);
+  }
 
   if (!connect_client_impl(sockfd))
   {

--- a/storage/ndb/src/common/transporter/Transporter.hpp
+++ b/storage/ndb/src/common/transporter/Transporter.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -309,7 +309,11 @@ protected:
   NDB_SOCKET_TYPE theSocket;
 private:
   SocketClient *m_socket_client;
-  struct sockaddr_in6 m_connect_address;
+  union
+  {
+    struct in6_addr m_connect_address;
+    struct in_addr m_connect_address4;
+  };
 
   virtual bool send_is_possible(int timeout_millisec) const = 0;
   virtual bool send_limit_reached(int bufsize) = 0;

--- a/storage/ndb/src/common/transporter/TransporterRegistry.cpp
+++ b/storage/ndb/src/common/transporter/TransporterRegistry.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -112,7 +112,7 @@ TransporterRegistry::is_server(NodeId node_id) const
 }
 
 
-struct sockaddr_in6
+struct in6_addr
 TransporterRegistry::get_connect_address(NodeId node_id) const
 {
   if (theNodeIdTransporters[node_id]->isMultiTransporter())
@@ -126,6 +126,22 @@ TransporterRegistry::get_connect_address(NodeId node_id) const
     }
   }
   return theNodeIdTransporters[node_id]->m_connect_address;
+}
+
+struct in_addr
+TransporterRegistry::get_connect_address4(NodeId node_id) const
+{
+  if (theNodeIdTransporters[node_id]->isMultiTransporter())
+  {
+    Multi_Transporter *multi_trp =
+      (Multi_Transporter*)theNodeIdTransporters[node_id];
+    if (multi_trp->get_num_active_transporters() > 0)
+    {
+      Transporter *trp = multi_trp->get_active_transporter(0);
+      return trp->m_connect_address4;
+    }
+  }
+  return theNodeIdTransporters[node_id]->m_connect_address4;
 }
 
 Uint64

--- a/storage/ndb/src/common/util/OwnProcessInfo.cpp
+++ b/storage/ndb/src/common/util/OwnProcessInfo.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2022, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2022, 2022, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -59,7 +59,7 @@ void setOwnProcessInfoServerAddress4(struct sockaddr * addr)
 {
   theApiMutex.lock();
   sockaddr_in *addr_in = (sockaddr_in *)addr;
-  singletonInfo.setHostAddress(&addr_in->sin_addr);
+  singletonInfo.setHostAddress4(&addr_in->sin_addr);
   theApiMutex.unlock();
 }
 

--- a/storage/ndb/src/common/util/ProcessInfo.cpp
+++ b/storage/ndb/src/common/util/ProcessInfo.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2022, 2023, Hopsworks and/or its affiliates. All rights reserved.
+   Copyright (c) 2022, 2022, Hopsworks and/or its affiliates. All rights reserved.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -182,36 +182,20 @@ void ProcessInfo::setHostAddress(const char * address_string) {
   }
 }
 
-void ProcessInfo::setHostAddress(const struct sockaddr *addr)
-{
-  const struct sockaddr_in6 *in6 = (const struct sockaddr_in6*)addr;
-  if (IN6_IS_ADDR_UNSPECIFIED(&in6->sin6_addr))
-  {
-    return;
-  }
-  if (addr->sa_family == AF_INET6)
-  {
-    setHostAddress(&in6->sin6_addr);
-  }
-  else
-  {
-    const struct sockaddr_in *in = (const struct sockaddr_in*)addr;
-    setHostAddress(&in->sin_addr);
-  }
-}
-
 void ProcessInfo::setHostAddress(Uint32 * signal_data) {
   setHostAddress((const char *) signal_data);
 }
 
 void ProcessInfo::setHostAddress(const struct in6_addr * addr) {
   /* If address passed in is a wildcard address, do not use it. */
-  Ndb_inet_ntop(AF_INET6, addr, host_address, AddressStringLength);
+  if (!IN6_IS_ADDR_UNSPECIFIED(addr))
+    Ndb_inet_ntop(AF_INET6, addr, host_address, AddressStringLength);
 }
 
-void ProcessInfo::setHostAddress(const struct in_addr * addr) {
+void ProcessInfo::setHostAddress4(const struct in_addr * addr) {
   /* If address passed in is a wildcard address, do not use it. */
-  Ndb_inet_ntop(AF_INET, addr, host_address, AddressStringLength);
+  if (!IN_IS_ADDR_UNSPECIFIED(addr))
+    Ndb_inet_ntop(AF_INET, addr, host_address, AddressStringLength);
 }
 
 void ProcessInfo::setAngelPid(Uint32 pid) {

--- a/storage/ndb/src/kernel/blocks/qmgr/QmgrMain.cpp
+++ b/storage/ndb/src/kernel/blocks/qmgr/QmgrMain.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -5393,35 +5393,24 @@ Qmgr::execAPI_VERSION_REQ(Signal * signal) {
     conf->mysql_version = nodeInfo.m_mysql_version;
     if (use_ipv4_socket(nodeId))
     {
-      struct sockaddr_in6 in =
-        globalTransporterRegistry.get_connect_address(nodeId);
-      require(in.sin6_family == AF_INET);
-      struct sockaddr_in *in4 = (struct sockaddr_in*)&in;
-      conf->m_inet_addr = in4->sin_addr.s_addr;
+      struct in_addr in =
+        globalTransporterRegistry.get_connect_address4(nodeId);
+      conf->m_inet_addr = in.s_addr;
       len = ApiVersionConf::SignalLengthIPv4;
     }
     else
     {
-      struct sockaddr_in6 in =
+      struct in6_addr in =
         globalTransporterRegistry.get_connect_address(nodeId);
-      if (in.sin6_family == AF_INET6)
+      memcpy(conf->m_inet6_addr, in.s6_addr, sizeof(conf->m_inet6_addr));
+      if (IN6_IS_ADDR_V4MAPPED(&in))
       {
-        memcpy(&conf->m_inet6_addr, &in.sin6_addr, sizeof(conf->m_inet6_addr));
-        if (IN6_IS_ADDR_V4MAPPED(&in.sin6_addr))
-        {
-          memcpy(&conf->m_inet_addr, &conf->m_inet6_addr[12], sizeof(in_addr));
-          len = ApiVersionConf::SignalLengthIPv4;
-        }
-        else
-        {
-          len = ApiVersionConf::SignalLength;
-        }
+        memcpy(&conf->m_inet_addr, &conf->m_inet6_addr[12], sizeof(in_addr));
+        len = ApiVersionConf::SignalLengthIPv4;
       }
       else
       {
-        struct sockaddr_in *in4 = (struct sockaddr_in*)&in;
-        conf->m_inet_addr = in4->sin_addr.s_addr;
-        len = ApiVersionConf::SignalLengthIPv4;
+        len = ApiVersionConf::SignalLength;
       }
     }
   }
@@ -9579,30 +9568,18 @@ Qmgr::execDBINFO_SCANREQ(Signal *signal)
              fallback-style report */
 
           char service_uri[INET6_ADDRSTRLEN + 6];
-          strcpy(service_uri, "ndb://");
           if (use_ipv4_socket(i))
           {
-            struct sockaddr_in6 in6 =
-              globalTransporterRegistry.get_connect_address(i);
-            require(in6.sin6_family == AF_INET);
-            struct sockaddr_in *in4 = (struct sockaddr_in*)&in6;
-            Ndb_inet_ntop(AF_INET, &in4->sin_addr, service_uri + 6, 46);
+            struct in_addr addr =
+              globalTransporterRegistry.get_connect_address4(i);
+            Ndb_inet_ntop(AF_INET, & addr, service_uri + 6, 46);
           }
           else
           {
-            struct sockaddr_in6 in6 =
+            struct in6_addr addr =
               globalTransporterRegistry.get_connect_address(i);
-            if (in6.sin6_family == AF_INET6)
-            {
-              struct in6_addr *addr = &in6.sin6_addr;
-              Ndb_inet_ntop(AF_INET6, addr, service_uri + 6, 46);
-            }
-            else
-            {
-              struct sockaddr_in *in4 = (struct sockaddr_in*)&in6;
-              struct in_addr *addr = &in4->sin_addr;
-              Ndb_inet_ntop(AF_INET, addr, service_uri + 6, 46);
-            }
+            strcpy(service_uri, "ndb://");
+            Ndb_inet_ntop(AF_INET6, & addr, service_uri + 6, 46);
           }
 
           Ndbinfo::Row row(signal, req);
@@ -9660,10 +9637,18 @@ Qmgr::execPROCESSINFO_REP(Signal *signal)
          of ProcessInfo::setHostAddress() is also available, which
          takes a struct sockaddr * and length.
       */
-
-      struct sockaddr_in6 in6 =
-        globalTransporterRegistry.get_connect_address(report->node_id);
-      processInfo->setHostAddress((struct sockaddr *)&in6);
+      if (use_ipv4_socket(report->node_id))
+      {
+        struct in_addr addr=
+          globalTransporterRegistry.get_connect_address4(report->node_id);
+        processInfo->setHostAddress4(& addr);
+      }
+      else
+      {
+        struct in6_addr addr=
+          globalTransporterRegistry.get_connect_address(report->node_id);
+        processInfo->setHostAddress(& addr);
+      }
     }
   }
   releaseSections(handle);

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -599,7 +599,7 @@ MgmtSrvr::start()
   /* Start mgm service */
   if (!start_mgm_service(m_local_config))
   {
-    g_eventLogger->error("Failed to start management service!");
+    g_eventLogger->error("Failed to start mangement service!");
     DBUG_RETURN(false);
   }
 
@@ -2945,13 +2945,6 @@ MgmtSrvr::status_mgmd(NodeId node_id,
                                  addr_buf,
                                  addr_buf_size);
       }
-      else if (Ndb_getInAddr((struct in_addr*)&addr, *address) == 0)
-      {
-        *address = Ndb_inet_ntop(AF_INET,
-                                 static_cast<void*>(&addr),
-                                 addr_buf,
-                                 addr_buf_size);
-      }
     }
 
     node_status = NDB_MGM_NODE_STATUS_CONNECTED;
@@ -4094,7 +4087,7 @@ MgmtSrvr::get_connect_address(NodeId node_id,
 {
   assert(node_id < NDB_ARRAY_SIZE(m_connect_address));
 
-  if (!is_m_connect_address_set[node_id])
+  if (IN6_IS_ADDR_UNSPECIFIED(&m_connect_address[node_id]))
   {
     // No cached connect address available
     const trp_node &node= getNodeInfo(node_id);
@@ -4102,35 +4095,15 @@ MgmtSrvr::get_connect_address(NodeId node_id,
     {
       // Cache the connect address, it's valid until
       // node disconnects
-      is_m_connect_address_set[node_id] = true;
-      m_connect_address[node_id] =
-        theFacade->ext_get_connect_address(node_id);
-    }
-    else
-    {
-      addr_buf[0] = 0;
-      return addr_buf;
+      m_connect_address[node_id] = theFacade->ext_get_connect_address(node_id);
     }
   }
 
   // Return the cached connect address
-  if (m_connect_address[node_id].sin6_family == AF_INET6)
-  {
-    struct in6_addr *addr = &m_connect_address[node_id].sin6_addr;
-    return Ndb_inet_ntop(AF_INET6,
-                         static_cast<void*>(addr),
-                         addr_buf,
-                         addr_buf_size);
-  }
-  else
-  {
-    struct sockaddr_in *in4 = (struct sockaddr_in*)&m_connect_address[node_id];
-    struct in_addr *addr = &in4->sin_addr;
-    return Ndb_inet_ntop(m_connect_address[node_id].sin6_family,
-                         static_cast<void*>(addr),
-                         addr_buf,
-                         addr_buf_size);
-  }
+  return Ndb_inet_ntop(AF_INET6,
+                       static_cast<void*>(&m_connect_address[node_id]),
+                       addr_buf,
+                       addr_buf_size);
 }
 
 
@@ -4140,8 +4113,7 @@ MgmtSrvr::clear_connect_address_cache(NodeId nodeid)
   assert(nodeid < NDB_ARRAY_SIZE(m_connect_address));
   if (nodeid < NDB_ARRAY_SIZE(m_connect_address))
   {
-    memset(&m_connect_address[nodeid], 0, sizeof(struct sockaddr_in6));
-    is_m_connect_address_set[nodeid] = false;
+    m_connect_address[nodeid] = IN6ADDR_ANY_INIT;
   }
 }
 
@@ -4443,10 +4415,6 @@ inline struct in6_addr * get_in6_addr(const struct sockaddr *clnt_addr) {
   return clnt_addr ? &((sockaddr_in6*)clnt_addr)->sin6_addr : nullptr;
 }
 
-inline struct in_addr * get_in_addr(const struct sockaddr *clnt_addr) {
-  return &((sockaddr_in*)clnt_addr)->sin_addr;
-}
-
 inline bool is_loopback(const struct in6_addr *addr) {
   return (IN6_IS_ADDR_LOOPBACK(addr) ||
          (IN6_IS_ADDR_V4MAPPED(addr) && addr->s6_addr[12] == 0x7f));
@@ -4454,40 +4422,26 @@ inline bool is_loopback(const struct in6_addr *addr) {
 
 static HostnameMatch
 match_hostname(const struct sockaddr *clnt_addr,
-               const char *config_hostname)
+               const char *config_hostname,
+               LocalDnsCache & dnsCache)
 {
-  if (clnt_addr->sa_family == AF_INET6)
-  {
-    struct in6_addr resolved_addr;
-    struct in6_addr *clnt_in6_addr = get_in6_addr(clnt_addr);
-    if (Ndb_getInAddr6(&resolved_addr, config_hostname) != 0)
-      return HostnameMatch::no_resolve;
-    if (is_loopback(clnt_in6_addr)) {
-      if (SocketServer::tryBind(0, false, config_hostname)) {
-        return HostnameMatch::ok_exact_match;
-      }
-      return HostnameMatch::no_match;
-    }
-    // Bitwise comparison of the two IPv6 addresses
-    if (memcmp(&resolved_addr, clnt_in6_addr, sizeof(resolved_addr)) != 0)
-      return HostnameMatch::no_match;
-    return HostnameMatch::ok_exact_match;
-  }
-  else
-  {
-    struct in_addr resolved_addr;
-    struct in_addr tmp_addr;
-    struct in_addr *clnt_in_addr = get_in_addr(clnt_addr);
-    if (Ndb_getInAddr(&resolved_addr, config_hostname) != 0)
-      return HostnameMatch::no_resolve;
-    if (Ndb_getInAddr(&tmp_addr, "localhost") == 0 &&
-        memcmp(&tmp_addr, &resolved_addr, sizeof(tmp_addr)) == 0)
+  const struct in6_addr *clnt_in6_addr = get_in6_addr(clnt_addr);
+
+  if ((clnt_addr == nullptr) || is_loopback(clnt_in6_addr)) {
+    if (SocketServer::tryBind(0, false, config_hostname))
       return HostnameMatch::ok_exact_match;
-    // Bitwise comparison of the two IPv4 addresses
-    if (memcmp(&resolved_addr, clnt_in_addr, sizeof(resolved_addr)) != 0)
-      return HostnameMatch::no_match;
-    return HostnameMatch::ok_exact_match;
+    return HostnameMatch::no_match;
   }
+
+  struct in6_addr resolved_addr;
+  if(dnsCache.getAddress(&resolved_addr, config_hostname) != 0)
+    return HostnameMatch::no_resolve;
+
+  // Bitwise comparison of the two IPv6 addresses
+  if (memcmp(&resolved_addr, clnt_in6_addr, sizeof(resolved_addr)) != 0)
+    return HostnameMatch::no_match;
+
+  return HostnameMatch::ok_exact_match;
 }
 
 int
@@ -4500,7 +4454,8 @@ MgmtSrvr::find_node_type(NodeId node_id,
   const char* found_config_hostname= 0;
   unsigned type_c= (unsigned)type;
   bool found_unresolved_hosts = false;
-  bool use_ipv6 = (client_addr->sa_family == AF_INET6);
+  LocalDnsCache dnsCache;
+
   Guard g(m_local_config_mutex);
 
   ConfigIter iter(m_local_config, CFG_SECTION_NODE);
@@ -4536,26 +4491,20 @@ MgmtSrvr::find_node_type(NodeId node_id,
     {
       config_hostname= "";
       matchType = HostnameMatch::ok_wildcard;
-      DEBUG_FPRINTF((stderr, "nodeid: %u, wildcard\n", id));
     }
     else
     {
       found_config_hostname= config_hostname;
-      DEBUG_FPRINTF((stderr, "nodeid: %u, hostname: %s\n",
-                     id, config_hostname));
-      matchType = match_hostname(client_addr,
-                                 config_hostname);
+      matchType = match_hostname(client_addr, config_hostname, dnsCache);
     }
 
     switch(matchType)
     {
       case HostnameMatch::no_resolve:
-        DEBUG_FPRINTF((stderr, "nodeid: %u, no resolve\n", id));
         found_unresolved_hosts = true;
         break;
 
       case HostnameMatch::no_match:
-        DEBUG_FPRINTF((stderr, "nodeid: %u, no match\n", id));
         break;
 
       case HostnameMatch::ok_wildcard:
@@ -4565,7 +4514,6 @@ MgmtSrvr::find_node_type(NodeId node_id,
       case HostnameMatch::ok_exact_match:
       {
         unsigned int pos = 0;
-        DEBUG_FPRINTF((stderr, "nodeid: %u, match\n", id));
         // Insert this node into the list ahead of the non-exact matches
         for(; pos < nodes.size() && nodes[pos].exact_match ; pos++);
         nodes.push({id, config_hostname, true}, pos);
@@ -4582,38 +4530,22 @@ MgmtSrvr::find_node_type(NodeId node_id,
     return 0;
   }
 
-  char *addr_str = nullptr;
-  char addr_buf[NDB_ADDR_STRLEN];
-  if (found_unresolved_hosts ||
-      found_config_hostname)
-  {
-    if (use_ipv6)
-    {
-      struct in6_addr conn_addr =
-        ((struct sockaddr_in6*)(client_addr))->sin6_addr;
-      addr_str = Ndb_inet_ntop(AF_INET6,
-                               static_cast<void*>(&conn_addr),
-                               addr_buf,
-                               sizeof(addr_buf));
-    }
-    else
-    {
-      struct in_addr conn_addr =
-        ((struct sockaddr_in*)(client_addr))->sin_addr;
-      addr_str = Ndb_inet_ntop(AF_INET,
-                               static_cast<void*>(&conn_addr),
-                               addr_buf,
-                               sizeof(addr_buf));
-    }
-  }
-  if (found_unresolved_hosts)
-  {
+  if(found_unresolved_hosts) {
     error_code= NDB_MGM_ALLOCID_CONFIG_RETRY;
 
     BaseString type_string;
     const char *alias, *str;
+    char addr_buf[NDB_ADDR_STRLEN];
     alias= ndb_mgm_get_node_type_alias_string(type, &str);
     type_string.assfmt("%s(%s)", alias, str);
+
+    struct in6_addr conn_addr =
+      ((struct sockaddr_in6*)(client_addr))->sin6_addr;
+    char* addr_str =
+        Ndb_inet_ntop(AF_INET6,
+                      static_cast<void*>(&conn_addr),
+                      addr_buf,
+                      sizeof(addr_buf));
 
     error_string.appfmt("No configured host found of node type %s for "
                         "connection from ip %s. Some hostnames are currently "
@@ -4645,37 +4577,31 @@ MgmtSrvr::find_node_type(NodeId node_id,
     }
     if (found_config_hostname)
     {
-      char *loc_addr_str;
       char addr_buf[NDB_ADDR_STRLEN];
       {
         // Append error describing which host the faulty connection was from
+        struct in6_addr conn_addr =
+          ((struct sockaddr_in6*)(client_addr))->sin6_addr;
+        char* addr_str =
+            Ndb_inet_ntop(AF_INET6,
+                          static_cast<void*>(&conn_addr),
+                          addr_buf,
+                          sizeof(addr_buf));
         error_string.appfmt("Connection with id %d done from wrong host ip %s,",
                             node_id, addr_str);
       }
       {
         // Append error describing which was the expected host
-        int r_config_addr;
-        if (use_ipv6)
-        {
-          struct in6_addr config_addr;
-          r_config_addr = Ndb_getInAddr6(&config_addr, found_config_hostname);
-          loc_addr_str = Ndb_inet_ntop(AF_INET6,
-                                       static_cast<void*>(&config_addr),
-                                       addr_buf,
-                                       sizeof(addr_buf));
-        }
-        else
-        {
-          struct in_addr config_addr;
-          r_config_addr = Ndb_getInAddr(&config_addr, found_config_hostname);
-          loc_addr_str = Ndb_inet_ntop(AF_INET,
-                                       static_cast<void*>(&config_addr),
-                                       addr_buf,
-                                       sizeof(addr_buf));
-        }
+        struct in6_addr config_addr;
+        int r_config_addr= Ndb_getInAddr6(&config_addr, found_config_hostname);
+        char* addr_str =
+            Ndb_inet_ntop(AF_INET6,
+                          static_cast<void*>(&config_addr),
+                          addr_buf,
+                          sizeof(addr_buf));
         error_string.appfmt(" expected %s(%s).", found_config_hostname,
                             r_config_addr ?
-                            "lookup failed" : loc_addr_str);
+                            "lookup failed" : addr_str);
       }
       return -1;
     }
@@ -4686,6 +4612,13 @@ MgmtSrvr::find_node_type(NodeId node_id,
   // node_id == 0 and nodes.size() == 0
   if (found_config_hostname)
   {
+    char addr_buf[NDB_ADDR_STRLEN];
+    struct in6_addr conn_addr =
+      ((struct sockaddr_in6*)(client_addr))->sin6_addr;
+    char *addr_str = Ndb_inet_ntop(AF_INET6,
+                                   static_cast<void*>(&conn_addr),
+                                   addr_buf,
+                                   sizeof(addr_buf));
     error_string.appfmt("Connection done from wrong host ip %s.",
                         (client_addr) ? addr_str : "");
     return -1;
@@ -5065,34 +4998,18 @@ MgmtSrvr::alloc_node_id(NodeId& nodeid,
                         Uint32 timeout_s)
 {
   char addr_buf[NDB_ADDR_STRLEN];
-  char *addr_str;
-  if (client_addr->sa_family == AF_INET6)
-  {
-    struct in6_addr conn_addr = ((sockaddr_in6*)client_addr)->sin6_addr;
-    addr_str = Ndb_inet_ntop(AF_INET6,
-                             static_cast<void*>(&conn_addr),
-                             addr_buf,
-                             sizeof(addr_buf));
-  }
-  else
-  {
-    struct in_addr conn_addr = ((sockaddr_in*)client_addr)->sin_addr;
-    addr_str = Ndb_inet_ntop(AF_INET,
-                             static_cast<void*>(&conn_addr),
-                             addr_buf,
-                             sizeof(addr_buf));
-  }
+  struct in6_addr conn_addr = ((sockaddr_in6*)client_addr)->sin6_addr;
+  const char* type_str = ndb_mgm_get_node_type_string(type);
+  char* addr_str = Ndb_inet_ntop(AF_INET6,
+                                 static_cast<void*>(&conn_addr),
+                                 addr_buf,
+                                 sizeof(addr_buf));
 
-  const char *type_str = ndb_mgm_get_node_type_string(type);
   error_code = 0;
   g_eventLogger->debug("Trying to allocate nodeid for %s" \
                        "(nodeid: %u, type: %s)",
                        addr_str, (unsigned)nodeid, type_str);
 
-  DEBUG_FPRINTF((stderr, "Allocate nodeid %u for %s type: %s\n",
-                 (unsigned)nodeid,
-                 addr_str,
-                 type_str));
 
   if (alloc_node_id_impl(nodeid, type, client_addr,
                          error_code, error_string,

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.hpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2023, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -482,8 +482,7 @@ private:
 
   bool m_need_restart;
 
-  struct sockaddr_in6 m_connect_address[MAX_NODES];
-  bool is_m_connect_address_set[MAX_NODES];
+  struct in6_addr m_connect_address[MAX_NODES];
   const char *get_connect_address(NodeId node_id,
                                   char *addr_buf,
                                   size_t addr_buf_size);

--- a/storage/ndb/src/ndbapi/TransporterFacade.cpp
+++ b/storage/ndb/src/ndbapi/TransporterFacade.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -4540,7 +4540,7 @@ TransporterFacade::ext_set_max_api_reg_req_interval(Uint32 interval)
   theClusterMgr->set_max_api_reg_req_interval(interval);
 }
 
-struct sockaddr_in6
+struct in6_addr
 TransporterFacade::ext_get_connect_address(Uint32 nodeId)
 {
   return theTransporterRegistry->get_connect_address(nodeId);

--- a/storage/ndb/src/ndbapi/TransporterFacade.hpp
+++ b/storage/ndb/src/ndbapi/TransporterFacade.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -122,7 +122,7 @@ public:
    * These are functions used by ndb_mgmd
    */
   void ext_set_max_api_reg_req_interval(Uint32 ms);
-  struct sockaddr_in6 ext_get_connect_address(Uint32 nodeId);
+  struct in6_addr ext_get_connect_address(Uint32 nodeId);
   bool ext_isConnected(NodeId aNodeId);
   void ext_doConnect(int aNodeId);
 


### PR DESCRIPTION
This reverts commit 58f68edea5debff0d9d38b833ebfbdc25cf4ba80.

Revert "RONDB-230: Fix get_connect_address initialisation" This reverts commit b2b2020e24f8f385e8461845ab164a3e910a90e1.

Revert "RONDB-230: More work on details in support disabled IPv6" This reverts commit af002226ed2231a386e2b2cb0f751e4b49aa0290.

Revert "RONDB-230: Changed handling of SocketClient, simpler fix" This reverts commit d543c05b776f9a6d86fbce95adb043cc46f580a1.

Revert "RONDB-230: Handle failure when IPv6 disabled at boot" This reverts commit 5206e1a6bddabc18e5e111c8d2504650b33f7dbf.