### PR TITLE
RONDB-248: Fix CLI arguments

### DIFF
--- a/storage/ndb/rest-server/rest-api-server/Makefile
+++ b/storage/ndb/rest-server/rest-api-server/Makefile
@@ -19,6 +19,7 @@ HOSTNAME=`hostname`
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 SERVER_BIN="rdrs"
 RDRS_LIB_DIR?=./../data-access-rondb/build
+RDRS_CONFIG_FILE=$(PWD)/resources/config/config_dockertest.json
 OUTPUT_DIR?=./bin/server/${SERVER_BIN}
 
 COVERAGE_OUTPUT_FILE?=./coverage.out
@@ -60,7 +61,7 @@ build_proto:
 test:
 	@go clean -testcache
 	@echo "Getting cross-package (integration) coverage and writing it to $(COVERAGE_OUTPUT_FILE)"
-	CGO_LDFLAGS="-g -O3 -L${RDRS_LIB_DIR} -lrdrclient" go test -p 1 -coverprofile $(COVERAGE_OUTPUT_FILE) -coverpkg ./... `go list ./... | grep -v cmd`
+	CGO_LDFLAGS="-g -O3 -L${RDRS_LIB_DIR} -lrdrclient" RDRS_CONFIG_FILE=$(RDRS_CONFIG_FILE) go test -p 1 -coverprofile $(COVERAGE_OUTPUT_FILE) -coverpkg ./... `go list ./... | grep -v cmd`
 
 print-func-coverage: test
 	go tool cover -func $(COVERAGE_OUTPUT_FILE) > $(COVERAGE_FUNC_OUTPUT_FILE)

--- a/storage/ndb/rest-server/rest-api-server/internal/config/constants.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/config/constants.go
@@ -35,7 +35,8 @@ const BATCH_HTTP_VERB = "POST"
 const STAT_HTTP_VERB = "GET"
 
 /*
- Env variables
+	Env variables
 */
 
+// This makes it easier to run tests with a given configuration file and not requiring a flag
 const CONFIG_FILE_PATH = "RDRS_CONFIG_FILE"

--- a/storage/ndb/rest-server/rest-api-server/internal/config/init_defaults.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/config/init_defaults.go
@@ -69,7 +69,7 @@ func newWithDefaults() AllConfigs {
 			Password: "rondb",
 		},
 		Security: Security{
-			EnableTLS:                        true,
+			EnableTLS:                        false,
 			RequireAndVerifyClientCert:       false,
 			CertificateFile:                  "",
 			PrivateKeyFile:                   "",

--- a/storage/ndb/rest-server/rest-api-server/internal/config/init_defaults.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/config/init_defaults.go
@@ -27,6 +27,15 @@ import (
 var globalConfig AllConfigs
 var mutex sync.Mutex
 
+/*
+	Order:
+	1. Read from ENV
+		if no ENV:
+			2. Set to defaults
+	3. Read CLI arguments
+		if no CLI:
+			4. Set to defaults
+*/
 func init() {
 	configFile := os.Getenv(CONFIG_FILE_PATH)
 	err := SetFromFileIfExists(configFile)

--- a/storage/ndb/rest-server/rest-api-server/resources/config/config_dockertest.json
+++ b/storage/ndb/rest-server/rest-api-server/resources/config/config_dockertest.json
@@ -16,7 +16,7 @@
         "RonDB": {
                 "Mgmds": [
                         {
-                                "IP": "localhost",
+                                "IP": "mgmd_1",
                                 "Port": 1186
                         }
                 ]
@@ -24,12 +24,12 @@
         "MySQL": {
                 "Servers": [
                         {
-                                "IP": "localhost",
+                                "IP": "mysqld_1",
                                 "Port": 3306
                         }
                 ],
-                "User": "rondb",
-                "Password": "rondb"
+                "User": "mysql",
+                "Password": "Abc123?e"
         },
         "Security": {
                 "EnableTLS": true,


### PR DESCRIPTION
* The default configuration needs to be valid, for the rdrs to work as a binary.
* Also created a default config file for Docker tests
* The `resource` directory will be used in later PRs