### PR TITLE
RONDB-338: First Steps Profiling

### DIFF
--- a/storage/ndb/rest-server/data-access-rondb/src/rdrs-dal.cpp
+++ b/storage/ndb/rest-server/data-access-rondb/src/rdrs-dal.cpp
@@ -86,9 +86,6 @@ RS_Status init(const char *connection_string, unsigned int connection_pool_size,
 }
 
 RS_Status set_op_retry_props(const unsigned int retry_cont, const unsigned int rety_initial_delay) {
-  require(retry_cont >= 0);
-  require(rety_initial_delay >= 0);
-
   OP_RETRY_COUNT         = retry_cont;
   OP_RETRY_INITIAL_DELAY = rety_initial_delay;
 

--- a/storage/ndb/rest-server/rest-api-server/internal/integrationtests/initialiase_tests.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/integrationtests/initialiase_tests.go
@@ -111,7 +111,7 @@ func InitialiseTesting(conf config.AllConfigs, createOnlyTheseDBs ...string) (cl
 			cleanupServers()
 			releaseBuffers()
 			cleanupTLSCerts()
-			return cleanup, fmt.Errorf("could not create profile.out; error: %v ", err)
+			return cleanup, fmt.Errorf("could not create profile.out; error: %w ", err)
 		}
 		defer f.Close()
 		if err := pprof.StartCPUProfile(f); err != nil {
@@ -119,7 +119,7 @@ func InitialiseTesting(conf config.AllConfigs, createOnlyTheseDBs ...string) (cl
 			cleanupServers()
 			releaseBuffers()
 			cleanupTLSCerts()
-			return cleanup, fmt.Errorf("could not start CPU profile; error: %v ", err)
+			return cleanup, fmt.Errorf("could not start CPU profile; error: %w ", err)
 		}
 	}
 

--- a/storage/ndb/rest-server/rest-api-server/internal/integrationtests/initialiase_tests.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/integrationtests/initialiase_tests.go
@@ -18,8 +18,10 @@
 package integrationtests
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"runtime/pprof"
 	"time"
 
 	"hopsworks.ai/rdrs/internal/config"
@@ -29,6 +31,12 @@ import (
 	"hopsworks.ai/rdrs/internal/testutils"
 	"hopsworks.ai/rdrs/resources/testdbs"
 )
+
+var enableProfiling = flag.Bool("profile", false, "enable CPU profiling")
+
+func profilingEnabled() bool {
+	return *enableProfiling || (os.Getenv("PROFILE_CPU") == "1")
+}
 
 /*
 Wraps all unit tests in this package
@@ -85,10 +93,34 @@ func InitialiseTesting(conf config.AllConfigs, createOnlyTheseDBs ...string) (cl
 
 	conn, err := InitGRPCConnction()
 	if err != nil {
+		cleanupServers()
+		releaseBuffers()
+		cleanupTLSCerts()
 		return cleanup, err
 	}
 	cleanupGRPCConn := func() {
 		conn.Close()
+	}
+
+	// Check if profiling is enabled
+	if profilingEnabled() {
+		// Start profiling
+		f, err := os.Create("profile.out")
+		if err != nil {
+			cleanupGRPCConn()
+			cleanupServers()
+			releaseBuffers()
+			cleanupTLSCerts()
+			return cleanup, fmt.Errorf("could not create profile.out; error: %v ", err)
+		}
+		defer f.Close()
+		if err := pprof.StartCPUProfile(f); err != nil {
+			cleanupGRPCConn()
+			cleanupServers()
+			releaseBuffers()
+			cleanupTLSCerts()
+			return cleanup, fmt.Errorf("could not start CPU profile; error: %v ", err)
+		}
 	}
 
 	return func() {
@@ -97,6 +129,7 @@ func InitialiseTesting(conf config.AllConfigs, createOnlyTheseDBs ...string) (cl
 		defer releaseBuffers()
 		defer cleanupServers()
 		defer cleanupGRPCConn()
+		defer pprof.StopCPUProfile()
 
 		stats := newHeap.GetNativeBuffersStats()
 		if stats.BuffersCount != stats.FreeBuffers {

--- a/storage/ndb/rest-server/rest-api-server/internal/integrationtests/pkread/data_types_test.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/integrationtests/pkread/data_types_test.go
@@ -165,7 +165,7 @@ func TestDataTypesInt(t *testing.T) {
 		},
 	}
 
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesBigInt(t *testing.T) {
@@ -263,7 +263,7 @@ func TestDataTypesBigInt(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesTinyInt(t *testing.T) {
@@ -360,7 +360,7 @@ func TestDataTypesTinyInt(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesSmallInt(t *testing.T) {
@@ -457,7 +457,7 @@ func TestDataTypesSmallInt(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesMediumInt(t *testing.T) {
@@ -554,7 +554,7 @@ func TestDataTypesMediumInt(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesFloat(t *testing.T) {
@@ -613,7 +613,7 @@ func TestDataTypesFloat(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesDouble(t *testing.T) {
@@ -672,7 +672,7 @@ func TestDataTypesDouble(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesDecimal(t *testing.T) {
@@ -733,7 +733,7 @@ func TestDataTypesDecimal(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesBlobs(t *testing.T) {
@@ -794,7 +794,7 @@ func TestDataTypesBlobs(t *testing.T) {
 		},
 	}
 
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesChar(t *testing.T) {
@@ -959,7 +959,7 @@ func ArrayColumnTest(t *testing.T, table string, database string, isBinary bool,
 		},
 	}
 
-	integrationtests.PkTest(t, tests, isBinary)
+	integrationtests.PkTestWrapper(t, tests, isBinary)
 }
 
 func TestDataTypesDateColumn(t *testing.T) {
@@ -1047,7 +1047,7 @@ func TestDataTypesDateColumn(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesDatetimeColumn(t *testing.T) {
@@ -1182,7 +1182,7 @@ func TestDataTypesDatetimeColumn(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesTimeColumn(t *testing.T) {
@@ -1304,7 +1304,7 @@ func TestDataTypesTimeColumn(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesTimestampColumn(t *testing.T) {
@@ -1478,7 +1478,7 @@ func TestDataTypesTimestampColumn(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesYearColumn(t *testing.T) {
@@ -1567,7 +1567,7 @@ func TestDataTypesYearColumn(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }
 
 func TestDataTypesBitColumn(t *testing.T) {
@@ -1614,5 +1614,5 @@ func TestDataTypesBitColumn(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, true)
+	integrationtests.PkTestWrapper(t, tests, true)
 }

--- a/storage/ndb/rest-server/rest-api-server/internal/integrationtests/pkread/unload_schema_test.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/integrationtests/pkread/unload_schema_test.go
@@ -52,7 +52,7 @@ func TestUnloadSchema(t *testing.T) {
 		},
 	}
 
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 
 	err = testutils.RunQueries(testdbs.DB025UpdateScheme)
 	if err != nil {
@@ -72,5 +72,5 @@ func TestUnloadSchema(t *testing.T) {
 			RespKVs:        validateColumns,
 		},
 	}
-	integrationtests.PkTest(t, tests, false)
+	integrationtests.PkTestWrapper(t, tests, false)
 }

--- a/storage/ndb/rest-server/rest-api-server/internal/integrationtests/utils.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/integrationtests/utils.go
@@ -465,6 +465,7 @@ func pkRESTTest(t *testing.T, testInfo api.PKTestInfo, isBinaryData bool) {
 func BatchTest(t *testing.T, tests map[string]api.BatchOperationTestInfo, isBinaryData bool) {
 	for name, testInfo := range tests {
 		t.Run(name, func(t *testing.T) {
+			// This will mean that REST calls to Handler will be slightly faster
 			BatchRESTTest(t, testInfo, isBinaryData, true)
 			BatchGRPCTest(t, testInfo, isBinaryData, true)
 		})

--- a/storage/ndb/rest-server/rest-api-server/internal/testutils/clients.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/testutils/clients.go
@@ -26,6 +26,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"hopsworks.ai/rdrs/internal/config"
 )
@@ -59,6 +60,8 @@ func CreateGrpcConn(withAuth, withTLS bool) (*grpc.ClientConn, error) {
 			return nil, errors.New(fmt.Sprintf("failed to get TLS config for GRPC client. Error: %v", err))
 		}
 		grpcDialOptions = append(grpcDialOptions, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	} else {
+		grpcDialOptions = append(grpcDialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
 	// Set up a connection to the server


### PR DESCRIPTION
* Fix C compilation errors
* Enable profiling for `TestMain` functions
* Include gRPC requests in benchmarking unit tests
* Allow unit tests without TLS enabled (clearer profiling)