### PR TITLE
RONDB-282: Parallel copy fragment process

### DIFF
--- a/storage/ndb/include/kernel/ndb_limits.h
+++ b/storage/ndb/include/kernel/ndb_limits.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2023, Logical Clocks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -192,10 +192,6 @@
 * This parameter is configurable, this is the default value.
 */
 #define MAX_SCAN_BATCH_SIZE 262144
-/*
- * Maximum number of Parallel Scan queries on one hash index fragment
- */
-#define MAX_PARALLEL_SCANS_PER_FRAG 12
 
 /**
  * Computed defines

--- a/storage/ndb/include/kernel/signaldata/GetCpuUsage.hpp
+++ b/storage/ndb/include/kernel/signaldata/GetCpuUsage.hpp
@@ -1,0 +1,81 @@
+/*
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
+
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#ifndef GET_CPU_USAGE_HPP
+#define GET_CPU_USAGE_HPP
+
+#define JAM_FILE_ID 49
+
+
+/**
+ * Get CPU measurement
+ */
+class GetCpuUsageReq {
+  
+  /**
+   * Receiver(s)
+   */
+  friend class Thrman;
+  
+  /**
+   * Sender
+   */
+  friend class Backup;
+  friend class Dblqh;
+
+public:
+  STATIC_CONST( SignalLength = 1 );
+public:
+  enum RequestType {
+    PerSecond = 0,
+    LastMeasure = 1
+  };
+  Uint32 requestType;
+};
+
+class GetCpuUsageConf {
+
+  /**
+   * Sender(s)
+   */
+  friend class Thrman;
+  
+  /**
+   * Receiver(s)
+   */
+  friend class Backup;
+  friend class Dblqh;
+
+public:
+  STATIC_CONST( SignalLength = 4 );
+  
+public:
+  Uint32 real_exec_time;
+  Uint32 os_exec_time;
+  Uint32 exec_time;
+  Uint32 block_exec_time;
+};
+#undef JAM_FILE_ID
+
+#endif

--- a/storage/ndb/include/ndb_version.h.in
+++ b/storage/ndb/include/ndb_version.h.in
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -723,5 +723,28 @@ bool
 ndbd_support_tc_hbrep_api(Uint32 x)
 {
   return x >= NDBD_SUPPORT_TC_HBREP_API;
+}
+
+static
+inline
+bool
+ndbd_support_parallel_copy_fragment(Uint32 x)
+{
+  const Uint32 major = (x >> 16) & 0xFF;
+  const Uint32 minor = (x >>  8) & 0xFF;
+  const Uint32 rel = x & 0xFF;
+  if (major > 22)
+  {
+    return true;
+  }
+  if ((major == 22) && (minor == 10) && (rel >= 1))
+  {
+    return true;
+  }
+  if ((major == 21) && (minor == 4) && (rel >= 13))
+  {
+    return true;
+  }
+  return false;
 }
 #endif

--- a/storage/ndb/src/kernel/blocks/backup/Backup.cpp
+++ b/storage/ndb/src/kernel/blocks/backup/Backup.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2022, Hopsworks and/or its affiliates.
+   Copyright (c) 2022, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -49,6 +49,8 @@
 #include <signaldata/FsRef.hpp>
 #include <signaldata/FsRemoveReq.hpp>
 #include <signaldata/FsReadWriteReq.hpp>
+
+#include <signaldata/GetCpuUsage.hpp>
 
 #include <signaldata/BackupImpl.hpp>
 #include <signaldata/BackupSignalData.hpp>
@@ -2007,10 +2009,13 @@ Backup::calculate_disk_write_speed(Signal *signal)
 
   /**
    * Get CPU usage for the thread */
+  GetCpuUsageReq* req = (GetCpuUsageReq*)signal->getDataPtrSend();
+  req->requestType = GetCpuUsageReq::PerSecond;
   EXECUTE_DIRECT_MT(THRMAN, GSN_GET_CPU_USAGE_REQ, signal,
                     1,
                     getThrmanInstance());
-  Uint32 cpu_usage = signal->theData[0];
+  GetCpuUsageConf *conf = (GetCpuUsageConf*)signal->getDataPtr();
+  Uint32 cpu_usage = conf->real_exec_time;
 
   /**
    * It is possible that the limits (max + min) have moved so that

--- a/storage/ndb/src/kernel/blocks/dbdih/Dbdih.hpp
+++ b/storage/ndb/src/kernel/blocks/dbdih/Dbdih.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -2062,6 +2062,7 @@ private:
 
   bool check_takeover_thread(TakeOverRecordPtr takeOverPtr,
                              FragmentstorePtr fragPtr,
+                             Uint32 tableId,
                              Uint32 fragmentReplicaInstanceKey);
   void send_continueb_start_next_copy(Signal *signal,
                                       TakeOverRecordPtr takeOverPtr);

--- a/storage/ndb/src/kernel/blocks/dbdih/DbdihMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbdih/DbdihMain.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -8202,6 +8202,7 @@ Dbdih::nr_start_logging(Signal* signal, TakeOverRecordPtr takeOverPtr)
     Uint32 instanceKey = dihGetInstanceKey(fragPtr);
     if (!check_takeover_thread(takeOverPtr,
                                fragPtr,
+                               tabPtr.i,
                                instanceKey))
     {
       jam();
@@ -8536,6 +8537,7 @@ Dbdih::execSTART_TOCONF(Signal* signal)
 bool
 Dbdih::check_takeover_thread(TakeOverRecordPtr takeOverPtr,
                              FragmentstorePtr fragPtr,
+                             Uint32 tableId,
                              Uint32 fragmentReplicaInstanceKey)
 {
   ndbassert(fragmentReplicaInstanceKey != 0);
@@ -8548,18 +8550,23 @@ Dbdih::check_takeover_thread(TakeOverRecordPtr takeOverPtr,
    * of LDM instances. So we take the instance key modulo the number
    * of LDM instances to get the thread id to handle this takeover
    * thread.
-   *
-   * For safety we will never run more parallelism than we have in the
-   * minimum node of the starting node and the copying node.
    */
   Uint32 nodes[MAX_REPLICAS];
   extractNodeInfo(jamBuffer(), fragPtr.p, nodes);
-  Uint32 lqhWorkers = getNodeInfo(takeOverPtr.p->toStartingNode).m_lqh_workers;
-  lqhWorkers = MIN(lqhWorkers,
-                   getNodeInfo(nodes[0]).m_lqh_workers);
-  lqhWorkers = MAX(lqhWorkers, 1);
-  Uint32 instanceId = fragmentReplicaInstanceKey % lqhWorkers;
-
+  Uint32 instanceId;
+  if (ndbd_support_parallel_copy_fragment(
+      getNodeInfo(takeOverPtr.p->toStartingNode).m_version))
+  {
+    instanceId = fragmentReplicaInstanceKey ^ tableId;
+  }
+  else
+  {
+    Uint32 lqhWorkers = getNodeInfo(takeOverPtr.p->toStartingNode).m_lqh_workers;
+    lqhWorkers = MIN(lqhWorkers,
+                     getNodeInfo(nodes[0]).m_lqh_workers);
+    lqhWorkers = MAX(lqhWorkers, 1);
+    instanceId = fragmentReplicaInstanceKey % lqhWorkers;
+  }
   if ((instanceId % takeOverPtr.p->m_number_of_copy_threads) ==
       takeOverPtr.p->m_copy_thread_id)
   {
@@ -8617,6 +8624,7 @@ void Dbdih::startNextCopyFragment(Signal* signal, Uint32 takeOverPtrI)
     Uint32 instanceKey = dihGetInstanceKey(fragPtr);
     if (!check_takeover_thread(takeOverPtr,
                                fragPtr,
+                               tabPtr.i,
                                instanceKey))
     {
       /**

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhInit.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhInit.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -76,6 +76,18 @@ Uint64 Dblqh::getTransactionMemoryNeed(
 
 void Dblqh::initData() 
 {
+#ifdef STATS_PARALLEL_COPY_FRAGMENT
+  c_outstanding_words_copy_fragreq = 0;
+  c_outstanding_rows_copy_fragreq = 0;
+  c_rows_copy_fragreq = 0;
+  c_words_copy_fragreq = 0;
+  c_total_words_copy_fragreq = 0;
+  c_total_rows_copy_fragreq = 0;
+#endif
+  c_active_copyFragReq = 0;
+  c_num_nodes_in_our_nodegroup = 0;
+  c_num_blocked_copy_fragment_processes = 0;
+
 #ifdef ERROR_INSERT
   c_master_node_id = RNIL;
 #endif
@@ -89,7 +101,6 @@ void Dblqh::initData()
   m_insert_size = 0;
   m_delete_size = 0;
 
-  c_copy_fragment_ongoing = false;
   c_copy_active_ongoing = false;
 
   c_gcp_stop_timer = 0;
@@ -195,12 +206,6 @@ void Dblqh::initData()
   c_fragmentsStarted = 0;
   c_fragmentsStartedWithCopy = 0;
 
-  c_fragCopyTable = RNIL;
-  c_fragCopyFrag = RNIL;
-  c_fragCopyRowsIns = 0;
-  c_fragCopyRowsDel = 0;
-  c_fragBytesCopied = 0;
-
   c_fragmentCopyStart = 0;
   c_fragmentsCopied = 0;
   c_totalCopyRowsIns = 0;
@@ -218,21 +223,8 @@ void Dblqh::initData()
   c_full_local_lcp_started = false;
   c_current_local_lcp_table_id = 0;
   c_copy_frag_live_node_halted = false;
-  c_copy_frag_live_node_performing_halt = false;
-  c_tc_connect_rec_copy_frag = RNIL;
-  memset(&c_halt_copy_fragreq_save,
-         0xFF,
-         sizeof(c_halt_copy_fragreq_save));
-
-  c_copy_frag_halted = false;
-  c_copy_frag_halt_process_locked = false;
   c_undo_log_overloaded = false;
   c_copy_fragment_in_progress = false;
-  c_copy_frag_halt_state = COPY_FRAG_HALT_STATE_IDLE;
-  memset(&c_prepare_copy_fragreq_save,
-         0xFF,
-         sizeof(c_prepare_copy_fragreq_save));
-
   m_node_restart_first_local_lcp_started = false;
   m_node_restart_lcp_second_phase_started = false;
   m_first_activate_fragment_ptr_i = RNIL;
@@ -726,12 +718,8 @@ Dblqh::Dblqh(Block_context& ctx,
                  &Dblqh::execSTART_FULL_LOCAL_LCP_ORD);
     addRecSignal(GSN_HALT_COPY_FRAG_REQ,
                  &Dblqh::execHALT_COPY_FRAG_REQ);
-    addRecSignal(GSN_HALT_COPY_FRAG_CONF,
-                 &Dblqh::execHALT_COPY_FRAG_CONF);
     addRecSignal(GSN_RESUME_COPY_FRAG_REQ,
                  &Dblqh::execRESUME_COPY_FRAG_REQ);
-    addRecSignal(GSN_RESUME_COPY_FRAG_CONF,
-                 &Dblqh::execRESUME_COPY_FRAG_CONF);
     m_is_query_block = false;
     m_is_in_query_thread = false;
     m_ldm_instance_used = this;

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhProxy.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhProxy.cpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -110,7 +110,8 @@ DblqhProxy::DblqhProxy(Block_context& ctx) :
   addRecSignal(GSN_LQH_TRANSCONF, &DblqhProxy::execLQH_TRANSCONF);
 
   // GSN_SUB_GCP_COMPLETE_REP
-  addRecSignal(GSN_SUB_GCP_COMPLETE_REP, &DblqhProxy::execSUB_GCP_COMPLETE_REP);
+  addRecSignal(GSN_SUB_GCP_COMPLETE_REP,
+               &DblqhProxy::execSUB_GCP_COMPLETE_REP);
 
   // GSN_UNDO_LOG_LEVEL_REP
   addRecSignal(GSN_UNDO_LOG_LEVEL_REP, &DblqhProxy::execUNDO_LOG_LEVEL_REP);
@@ -136,6 +137,11 @@ DblqhProxy::DblqhProxy(Block_context& ctx) :
 
   // GSN_INFO_GCP_STOP_TIMER
   addRecSignal(GSN_INFO_GCP_STOP_TIMER, &DblqhProxy::execINFO_GCP_STOP_TIMER);
+
+  // GSN_HALT_COPY_FRAG_REQ, GSN_RESUME_COPY_FRAG_REQ
+  addRecSignal(GSN_HALT_COPY_FRAG_REQ, &DblqhProxy::execHALT_COPY_FRAG_REQ);
+  addRecSignal(GSN_RESUME_COPY_FRAG_REQ,
+               &DblqhProxy::execRESUME_COPY_FRAG_REQ);
 }
 
 DblqhProxy::~DblqhProxy()
@@ -898,6 +904,32 @@ DblqhProxy::execUNDO_LOG_LEVEL_REP(Signal *signal)
   {
     jam();
     sendSignal(workerRef(i), GSN_UNDO_LOG_LEVEL_REP, signal,
+               signal->getLength(), JBB);
+  }
+}
+
+// GSN_HALT_COPY_FRAG_REQ
+void
+DblqhProxy::execHALT_COPY_FRAG_REQ(Signal *signal)
+{
+  jamEntry();
+  for (Uint32 i = 0; i < c_workers; i++)
+  {
+    jam();
+    sendSignal(workerRef(i), GSN_HALT_COPY_FRAG_REQ, signal,
+               signal->getLength(), JBB);
+  }
+}
+
+// GSN_RESUME_COPY_FRAG_REQ
+void
+DblqhProxy::execRESUME_COPY_FRAG_REQ(Signal *signal)
+{
+  jamEntry();
+  for (Uint32 i = 0; i < c_workers; i++)
+  {
+    jam();
+    sendSignal(workerRef(i), GSN_RESUME_COPY_FRAG_REQ, signal,
                signal->getLength(), JBB);
   }
 }

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhProxy.hpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhProxy.hpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -156,6 +156,10 @@ protected:
 
   // GSN_UNDO_LOG_LEVEL_REP
   void execUNDO_LOG_LEVEL_REP(Signal*);
+
+  // GSN_HALT_COPY_FRAG_REQ, GSN_RESUME_COPY_FRAG_REQ
+  void execHALT_COPY_FRAG_REQ(Signal*);
+  void execRESUME_COPY_FRAG_REQ(Signal*);
 
   // GSN_PREP_DROP_TAB_REQ
   struct Ss_PREP_DROP_TAB_REQ : SsParallel {

--- a/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2022, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -440,6 +440,7 @@ typedef Ptr<Fragoperrec> FragoperrecPtr;
     ScanLock() :
       m_magic(Magic::make(TYPE_ID))
     {
+      m_reserved = 0;
     }
 
     ~ScanLock()
@@ -447,6 +448,7 @@ typedef Ptr<Fragoperrec> FragoperrecPtr;
     }
 
     Uint32 m_accLockOp;
+    Uint32 m_reserved;
     union {
       Uint32 nextPool;
       Uint32 nextList;
@@ -457,8 +459,11 @@ typedef Ptr<Fragoperrec> FragoperrecPtr;
   typedef Ptr<ScanLock> ScanLockPtr;
   typedef TransientPool<ScanLock> ScanLock_pool;
   typedef DLFifoList<ScanLock_pool> ScanLock_fifo;
+  typedef DLList<ScanLock_pool> ScanLock_list;
   typedef LocalDLFifoList<ScanLock_pool> Local_ScanLock_fifo;
   ScanLock_pool c_scanLockPool;
+  ScanLock_list m_reserved_copy_frag_lock;
+
   /**
    * To ensure that we have a lock resource before we scan a row
    * in lock mode, we grab it before the scan and store the
@@ -547,6 +552,7 @@ typedef Ptr<Fragoperrec> FragoperrecPtr;
   typedef DLList<ScanOp_pool> ScanOp_list;
   typedef LocalDLList<ScanOp_pool> Local_ScanOp_list;
   ScanOp_pool c_scanOpPool;
+  ScanOp_list m_reserved_copy_frag;
 
   void scanReply(Signal*, ScanOpPtr scanPtr);
   void scanFirst(Signal*, ScanOpPtr scanPtr);
@@ -1506,14 +1512,23 @@ TupTriggerData_pool c_triggerPool;
     }
 
     Uint32 storedProcIVal;
-    Uint32 nextPool;
+    Uint32 lastSegment;
     Uint16 storedCode;
+    Uint8 copyOverwrite;
+    Uint8 copyOverwriteLen;
+    union {
+      Uint32 nextPool;
+      Uint32 nextList;
+    };
+    Uint32 prevList;
   };
   typedef Ptr<storedProc> StoredProcPtr;
   typedef TransientPool<storedProc> StoredProc_pool;
+  typedef DLList<StoredProc_pool> StoredProc_list;
   STATIC_CONST(DBTUP_STORED_PROCEDURE_TRANSIENT_POOL_INDEX = 1);
 
   StoredProc_pool c_storedProcPool;
+  StoredProc_list m_reserved_stored_proc_copy_frag;
   RSS_AP_SNAPSHOT(c_storedProcPool);
   Uint32 c_storedProcCountNonAPI;
   void storedProcCountNonAPI(BlockReference apiBlockref, int add_del);
@@ -3638,13 +3653,16 @@ private:
   void deleteScanProcedure(Signal* signal, Operationrec* regOperPtr);
   void allocCopyProcedure();
   void freeCopyProcedure();
-  void prepareCopyProcedure(Uint32 numAttrs, Uint16 tableBits);
-  void releaseCopyProcedure();
+  void prepareCopyProcedure(Uint32 numAttrs,
+                            Uint16 tableBits,
+                            StoredProcPtr & storedPtr);
+  void releaseCopyProcedure(StoredProcPtr storedPtr);
   void copyProcedure(Signal* signal,
                      TablerecPtr regTabPtr,
                      Operationrec* regOperPtr);
   void scanProcedure(Signal* signal,
                      Operationrec* regOperPtr,
+                     StoredProcPtr & storedPtr,
                      SectionHandle* handle,
                      bool isCopy);
   void storedProcBufferSeizeErrorLab(Signal* signal,
@@ -3863,7 +3881,6 @@ private:
 //---------------------------------------------------------------
 
   Uint32 c_lcp_scan_op;
-  Uint32 c_copy_frag_scan_op;
 
 // readAttributes and updateAttributes module
 //------------------------------------------------------------------------------------------------------
@@ -3952,10 +3969,6 @@ private:
   BlockReference cownref;
   Uint32 cownNodeId;
   Uint32 czero;
-  Uint32 cCopyProcedure;
-  Uint32 cCopyLastSeg;
-  Uint32 cCopyOverwrite;
-  Uint32 cCopyOverwriteLen;
 
  // A little bit bigger to cover overwrites in copy algorithms (16384 real size).
 #define ZATTR_BUFFER_SIZE 16384
@@ -4423,7 +4436,6 @@ private:
   TransientFastSlotPool* c_transient_pools[c_transient_pool_count];
   Bitmask<1> c_transient_pools_shrinking;
 
-  Uint32 c_copy_frag_scan_lock;
   void release_scan_lock(ScanLockPtr);
 
 public:

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupGen.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupGen.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2023, Logical Clocks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -73,11 +73,6 @@ void Dbtup::initData()
   c_maxTriggersPerTable = ZDEFAULT_MAX_NO_TRIGGERS_PER_TABLE;
   c_noOfBuildIndexRec = 32;
 
-  cCopyProcedure = RNIL;
-  cCopyLastSeg = RNIL;
-  cCopyOverwrite = 0;
-  cCopyOverwriteLen = 0;
-
   c_debug_count = 0;
 
   // Records with constant sizes
@@ -96,6 +91,9 @@ Dbtup::Dbtup(Block_context& ctx,
     c_pgman(0),
     c_acc(0),
     c_tux(0),
+    m_reserved_copy_frag(c_scanOpPool),
+    m_reserved_copy_frag_lock(c_scanLockPool),
+    m_reserved_stored_proc_copy_frag(c_storedProcPool),
     c_extent_hash(c_extent_pool),
     c_storedProcPool(),
     c_buildIndexList(c_buildIndexPool),
@@ -707,10 +705,14 @@ void Dbtup::execREAD_CONFIG_REQ(Signal* signal)
   ndbrequire(c_scanOpPool.seize(lcp));
   c_lcp_scan_op = lcp.i;
 
-  ScanOpPtr copy_frag;
-  ndbrequire(c_scanOpPool.seize(copy_frag));
-  c_copy_frag_scan_op = copy_frag.i;
-  copy_frag.p->m_state = ScanOp::First;
+  for (Uint32 i = 0; i < ZMAX_PARALLEL_COPY_FRAGMENT_OPS; i++)
+  {
+    ScanOpPtr copy_frag;
+    ndbrequire(c_scanOpPool.seize(copy_frag));
+    m_reserved_copy_frag.addFirst(copy_frag);
+    copy_frag.p->m_state = ScanOp::First;
+    copy_frag.p->m_bits = 0;
+  }
 
   czero = 0;
   cminusOne = czero - 1;
@@ -878,13 +880,15 @@ void Dbtup::initRecords(const ndb_mgm_configuration_iterator *mgm_cfg)
   {
     refresh_watch_dog();
   }
+  for (Uint32 i = 0; i < ZMAX_PARALLEL_COPY_FRAGMENT_OPS; i++)
   {
     ScanLockPtr lockPtr;
     ndbrequire(c_scanLockPool.seize(lockPtr));
     lockPtr.p->m_accLockOp = RNIL;
     lockPtr.p->prevList = RNIL;
     lockPtr.p->nextList = RNIL;
-    c_copy_frag_scan_lock = lockPtr.i;
+    lockPtr.p->m_reserved = 1;
+    m_reserved_copy_frag_lock.addFirst(lockPtr);
   }
 
   c_scanOpPool.init(

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupStoredProcDef.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupStoredProcDef.cpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -69,12 +70,14 @@ void Dbtup::execSTORED_PROCREQ(Signal* signal)
     storedProcCountNonAPI(apiBlockref, +1);
 #endif
     SectionHandle handle(this);
+    StoredProcPtr storedPtr;
     handle.m_ptr[0].i = signal->theData[6];
     handle.m_cnt = 1;
     getSections(handle.m_cnt, handle.m_ptr);
 
     scanProcedure(signal,
                   regOperPtr.p,
+                  storedPtr,
                   &handle,
                   false); // Not copy
     break;
@@ -130,18 +133,18 @@ void Dbtup::deleteScanProcedure(Signal* signal,
     ndbrequire(storedPtr.p->storedCode != ZSTORED_PROCEDURE_FREE);
     if (unlikely(storedPtr.p->storedCode == ZCOPY_PROCEDURE))
     {
-      releaseCopyProcedure();
+      releaseCopyProcedure(storedPtr);
     }
     else
     {
       /* ZSCAN_PROCEDURE */
       releaseSection(storedPtr.p->storedProcIVal);
+      storedPtr.p->storedCode = ZSTORED_PROCEDURE_FREE;
+      storedPtr.p->storedProcIVal = RNIL;
+      c_storedProcPool.release(storedPtr);
+      checkPoolShrinkNeed(DBTUP_STORED_PROCEDURE_TRANSIENT_POOL_INDEX,
+                          c_storedProcPool);
     }
-    storedPtr.p->storedCode = ZSTORED_PROCEDURE_FREE;
-    storedPtr.p->storedProcIVal= RNIL;
-    c_storedProcPool.release(storedPtr);
-    checkPoolShrinkNeed(DBTUP_STORED_PROCEDURE_TRANSIENT_POOL_INDEX,
-                        c_storedProcPool);
   }
   set_trans_state(regOperPtr, TRANS_IDLE);
   signal->theData[0] = 0; /* Success */
@@ -150,29 +153,32 @@ void Dbtup::deleteScanProcedure(Signal* signal,
 
 void Dbtup::scanProcedure(Signal* signal,
                           Operationrec* regOperPtr,
+                          StoredProcPtr & storedPtr,
                           SectionHandle* handle,
                           bool isCopy)
 {
-  /* Size a stored procedure record, and link the
+  /* Seize a stored procedure record, and link the
    * stored procedure AttrInfo section from it
    */
   ndbrequire( handle->m_cnt == 1 );
   ndbrequire( handle->m_ptr[0].p->m_sz > 0 );
 
-  StoredProcPtr storedPtr;
-  if (unlikely(!c_storedProcPool.seize(storedPtr)))
+  if (!isCopy)
   {
-    jam();
-    handle->clear();
-    storedProcBufferSeizeErrorLab(signal, 
-                                  regOperPtr,
-                                  RNIL,
-                                  ZOUT_OF_STORED_PROC_MEMORY_ERROR);
-    return;
+    if (unlikely(!c_storedProcPool.seize(storedPtr)))
+    {
+      jam();
+      handle->clear();
+      storedProcBufferSeizeErrorLab(signal, 
+                                    regOperPtr,
+                                    RNIL,
+                                    ZOUT_OF_STORED_PROC_MEMORY_ERROR);
+      return;
+    }
   }
-  Uint32 lenAttrInfo= handle->m_ptr[0].p->m_sz;
+  Uint32 lenAttrInfo = handle->m_ptr[0].p->m_sz;
   handle->clear();
-  storedPtr.p->storedCode = (isCopy)? ZCOPY_PROCEDURE : ZSCAN_PROCEDURE;
+  storedPtr.p->storedCode = (isCopy) ? ZCOPY_PROCEDURE : ZSCAN_PROCEDURE;
   storedPtr.p->storedProcIVal= handle->m_ptr[0].i;
 
   set_trans_state(regOperPtr, TRANS_IDLE);
@@ -200,50 +206,66 @@ void Dbtup::allocCopyProcedure()
    * TODO : Consider using read packed 'read all columns' word once
    * updatePacked supported.
    */
-  Uint32 iVal= RNIL;
-  Uint32 ahWord;
-
-  for (Uint32 attrNum=0; attrNum < MAX_ATTRIBUTES_IN_TABLE; attrNum++)
+  for (Uint32 i = 0; i < ZMAX_PARALLEL_COPY_FRAGMENT_OPS; i++)
   {
-    AttributeHeader::init(&ahWord, attrNum, 0);
-    ndbrequire(appendToSection(iVal, &ahWord, 1));
+    Uint32 iVal= RNIL;
+    Uint32 ahWord;
+
+    StoredProcPtr storedPtr;
+    ndbrequire(c_storedProcPool.seize(storedPtr));
+    for (Uint32 attrNum=0; attrNum < MAX_ATTRIBUTES_IN_TABLE; attrNum++)
+    {
+      AttributeHeader::init(&ahWord, attrNum, 0);
+      ndbrequire(appendToSection(iVal, &ahWord, 1));
+    }
+
+    /* Add space for extra attrs */
+    ahWord = 0;
+    for (Uint32 extra=0; extra < EXTRA_COPY_PROC_WORDS; extra++)
+      ndbrequire(appendToSection(iVal, &ahWord, 1));
+    storedPtr.p->storedProcIVal = iVal;
+    storedPtr.p->lastSegment = RNIL;
+    storedPtr.p->copyOverwrite = 0;
+    storedPtr.p->copyOverwriteLen = 0;
+    m_reserved_stored_proc_copy_frag.addFirst(storedPtr);
   }
-
-  /* Add space for extra attrs */
-  ahWord = 0;
-  for (Uint32 extra=0; extra < EXTRA_COPY_PROC_WORDS; extra++)
-    ndbrequire(appendToSection(iVal, &ahWord, 1));
-
-  cCopyProcedure= iVal;
-  cCopyLastSeg= RNIL;
-  cCopyOverwrite= 0;
-  cCopyOverwriteLen= 0;
 }
 
 void Dbtup::freeCopyProcedure()
 {
   /* Should only be called when shutting down node.
    */
-  releaseSection(cCopyProcedure);
-  cCopyProcedure=RNIL;
+  for (Uint32 i = 0; i < ZMAX_PARALLEL_COPY_FRAGMENT_OPS; i++)
+  {
+    StoredProcPtr storedPtr;
+    m_reserved_stored_proc_copy_frag.first(storedPtr);
+    if (storedPtr.p != nullptr)
+    {
+      releaseSection(storedPtr.p->storedProcIVal);
+      m_reserved_stored_proc_copy_frag.remove(storedPtr);
+    }
+  }
 }
 
 void Dbtup::prepareCopyProcedure(Uint32 numAttrs,
-                                 Uint16 tableBits)
+                                 Uint16 tableBits,
+                                 StoredProcPtr & storedPtr)
 {
   /* Set length of copy procedure section to the
    * number of attributes supplied
    */
+  ndbrequire(m_reserved_stored_proc_copy_frag.first(storedPtr));
+  m_reserved_stored_proc_copy_frag.remove(storedPtr);
   ndbassert(numAttrs <= MAX_ATTRIBUTES_IN_TABLE);
-  ndbassert(cCopyProcedure != RNIL);
-  ndbassert(cCopyLastSeg == RNIL);
-  ndbassert(cCopyOverwrite == 0);
-  ndbassert(cCopyOverwriteLen == 0);
+  ndbassert(storedPtr.p->storedProcIVal != RNIL);
+  ndbassert(storedPtr.p->lastSegment == RNIL);
+  ndbassert(storedPtr.p->copyOverwrite == 0);
+  ndbassert(storedPtr.p->copyOverwriteLen == 0);
   Ptr<SectionSegment> first;
-  g_sectionSegmentPool.getPtr(first, cCopyProcedure);
+  g_sectionSegmentPool.getPtr(first, storedPtr.p->storedProcIVal);
 
   /* Record original 'last segment' of section */
-  cCopyLastSeg= first.p->m_lastSegment;
+  storedPtr.p->lastSegment = first.p->m_lastSegment;
 
   /* Check table bits to see if we need to do extra reads */
   Uint32 extraAttrIds[EXTRA_COPY_PROC_WORDS];
@@ -268,14 +290,13 @@ void Dbtup::prepareCopyProcedure(Uint32 numAttrs,
 
   if (extraReads)
   {
-    cCopyOverwrite= numAttrs;
-    cCopyOverwriteLen = extraReads;
-
+    storedPtr.p->copyOverwrite = numAttrs;
+    storedPtr.p->copyOverwriteLen = extraReads;
     ndbrequire(writeToSection(first.i, numAttrs, extraAttrIds, extraReads));
   }
 
    /* Trim section size and lastSegment */
-  Ptr<SectionSegment> curr= first;  
+  Ptr<SectionSegment> curr = first;  
   while(newSize > SectionSegment::DataLength)
   {
     g_sectionSegmentPool.getPtr(curr, curr.p->m_nextSegment);
@@ -284,34 +305,37 @@ void Dbtup::prepareCopyProcedure(Uint32 numAttrs,
   first.p->m_lastSegment= curr.i;
 }
 
-void Dbtup::releaseCopyProcedure()
+void Dbtup::releaseCopyProcedure(StoredProcPtr storedPtr)
 {
   /* Return Copy Procedure section to original length */
-  ndbassert(cCopyProcedure != RNIL);
-  ndbassert(cCopyLastSeg != RNIL);
+  ndbassert(storedPtr.p->storedProcIVal != RNIL);
+  ndbassert(storedPtr.p->lastSegment != RNIL);
   
   Ptr<SectionSegment> first;
-  g_sectionSegmentPool.getPtr(first, cCopyProcedure);
+  g_sectionSegmentPool.getPtr(first, storedPtr.p->storedProcIVal);
   
   ndbassert(first.p->m_sz <= MAX_COPY_PROC_LEN);
-  first.p->m_sz= MAX_COPY_PROC_LEN;
-  first.p->m_lastSegment= cCopyLastSeg;
+  first.p->m_sz = MAX_COPY_PROC_LEN;
+  first.p->m_lastSegment = storedPtr.p->lastSegment;
   
-  if (cCopyOverwriteLen)
+  if (storedPtr.p->copyOverwriteLen)
   {
-    ndbassert(cCopyOverwriteLen <= EXTRA_COPY_PROC_WORDS);
+    ndbassert(storedPtr.p->copyOverwriteLen <= EXTRA_COPY_PROC_WORDS);
     Uint32 attrids[EXTRA_COPY_PROC_WORDS];
-    for (Uint32 i=0; i < cCopyOverwriteLen; i++)
+    for (Uint32 i=0; i < storedPtr.p->copyOverwriteLen; i++)
     {
-      AttributeHeader ah(cCopyOverwrite + i, 0);
+      AttributeHeader ah(storedPtr.p->copyOverwrite + i, 0);
       attrids[i] = ah.m_value;
     }
-    ndbrequire(writeToSection(first.i, cCopyOverwrite, attrids, cCopyOverwriteLen));
-    cCopyOverwriteLen= 0;
-    cCopyOverwrite= 0;
+    ndbrequire(writeToSection(first.i,
+                              storedPtr.p->copyOverwrite,
+                              attrids,
+                              storedPtr.p->copyOverwriteLen));
+    storedPtr.p->copyOverwriteLen = 0;
+    storedPtr.p->copyOverwrite = 0;
   }
-
-  cCopyLastSeg= RNIL;
+  storedPtr.p->lastSegment = RNIL;
+  m_reserved_stored_proc_copy_frag.addFirst(storedPtr);
 }
   
 
@@ -331,20 +355,23 @@ void Dbtup::copyProcedure(Signal* signal,
    * needs copied then we add that to the copy procedure
    * as well.
    */
+  StoredProcPtr storedPtr;
   prepareCopyProcedure(regTabPtr.p->m_no_of_attributes,
-                       regTabPtr.p->m_bits);
+                       regTabPtr.p->m_bits,
+                       storedPtr);
 
   SectionHandle handle(this);
   handle.m_cnt=1;
-  handle.m_ptr[0].i= cCopyProcedure;
+  handle.m_ptr[0].i = storedPtr.p->storedProcIVal;
   getSections(handle.m_cnt, handle.m_ptr);
 
   scanProcedure(signal,
                 regOperPtr,
+                storedPtr,
                 &handle,
                 true); // isCopy
   Ptr<SectionSegment> first;
-  g_sectionSegmentPool.getPtr(first, cCopyProcedure);
+  g_sectionSegmentPool.getPtr(first, storedPtr.p->storedProcIVal);
   signal->theData[2] = first.p->m_sz;
 }//Dbtup::copyProcedure()
 
@@ -359,4 +386,3 @@ void Dbtup::storedProcBufferSeizeErrorLab(Signal* signal,
   signal->theData[1] = errorCode;
   signal->theData[2] = storedProcPtr;
 }//Dbtup::storedSeizeAttrinbufrecErrorLab()
-

--- a/storage/ndb/src/kernel/blocks/thrman.cpp
+++ b/storage/ndb/src/kernel/blocks/thrman.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2020 Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -29,6 +29,7 @@
 #include <signaldata/Sync.hpp>
 #include <signaldata/DumpStateOrd.hpp>
 #include <signaldata/LoadOrd.hpp>
+#include <signaldata/GetCpuUsage.hpp>
 
 #include <EventLogger.hpp>
 #include <NdbSpin.h>
@@ -194,7 +195,7 @@ Thrman::set_configured_spintime(Uint32 val, bool specific)
                        instance(),
                        val);
 
-  m_configured_spintime = val;
+  m_configured_spintime_us = val;
   if (val == 0)
   {
     jam();
@@ -276,7 +277,7 @@ void
 Thrman::set_enable_adaptive_spinning(bool val)
 {
   m_enable_adaptive_spinning = val;
-  setSpintime(m_configured_spintime);
+  setSpintime(m_configured_spintime_us);
   if (instance() == m_main_thrman_instance)
   {
     g_eventLogger->info("(%u) %s adaptive spinning",
@@ -360,7 +361,7 @@ void Thrman::execREAD_CONFIG_REQ(Signal *signal)
         }
         val = 200;
         m_enable_adaptive_spinning = true;
-        m_configured_spintime = 100;
+        m_configured_spintime_us = 100;
       }
       else if (native_strcasecmp(conf, "latencyoptimisedspinning") == 0)
       {
@@ -372,7 +373,7 @@ void Thrman::execREAD_CONFIG_REQ(Signal *signal)
         }
         val = 1000;
         m_enable_adaptive_spinning = true;
-        m_configured_spintime = 200;
+        m_configured_spintime_us = 200;
       }
       else if (native_strcasecmp(conf, "databasemachinespinning") == 0)
       {
@@ -384,7 +385,7 @@ void Thrman::execREAD_CONFIG_REQ(Signal *signal)
         }
         val = 10000;
         m_enable_adaptive_spinning = true;
-        m_configured_spintime = MAX_SPIN_TIME;
+        m_configured_spintime_us = MAX_SPIN_TIME;
       }
       else
       {
@@ -638,11 +639,11 @@ Thrman::execSTTOR(Signal *signal)
     prev_1sec_tick = prev_50ms_tick;
     if (!m_enable_adaptive_spinning)
     {
-      m_configured_spintime = getConfiguredSpintime();
+      m_configured_spintime_us = getConfiguredSpintime();
       g_eventLogger->info("Using StaticSpinning with spintime %u us",
-                          m_configured_spintime);
+                          m_configured_spintime_us);
     }
-    m_current_spintime = 0;
+    m_current_spintime_us = 0;
     m_gain_spintime_in_us = 25;
 
     /* Initialise overload control variables */
@@ -1577,6 +1578,7 @@ Thrman::set_spin_stat(Uint32 spin_time, bool local_call)
    * efficiently measure stepping up or stepping down spinning in
    * steps of 50% at a time.
    */
+  used_spin_time *= 1000; // Nanoseconds
   Uint32 midpoint = (NUM_SPIN_INTERVALS / 2) - 1;
   for (Uint32 i = 0; i < NUM_SPIN_INTERVALS; i++)
   {
@@ -1611,7 +1613,8 @@ Thrman::set_spin_stat(Uint32 spin_time, bool local_call)
     {
       ndbrequire(i == midpoint);
     }
-    spin_stat.m_spin_interval[i] = Uint32(spin_time_limit);
+    /* Convert spin check intervals to nanoseconds */
+    spin_stat.m_spin_interval_ns[i] = Uint32(spin_time_limit);
   }
   mt_set_spin_stat(this, &spin_stat);
 }
@@ -1633,8 +1636,8 @@ Uint32 Thrman::calc_new_spin(ndb_spin_stat *spin_stat)
   {
     Uint32 events_in_this_slot = spin_stat->m_micros_sleep_times[i];
     if (events_in_this_slot == 0 ||
-        spin_stat->m_spin_interval[i] == 0 ||
-        spin_stat->m_spin_interval[i] > m_configured_spintime)
+        spin_stat->m_spin_interval_ns[i] == 0 ||
+        spin_stat->m_spin_interval_ns[i] > (m_configured_spintime_us * 1000))
     {
       /**
        * Ignore empty slots, they will not be choosen for sure.
@@ -1650,25 +1653,25 @@ Uint32 Thrman::calc_new_spin(ndb_spin_stat *spin_stat)
     remaining_events -= events_in_this_slot;
     Uint32 num_gained_spins = num_events - remaining_events;
 
-    Uint32 this_spin_cost = spin_stat->m_spin_interval[i];
-    Uint64 gained_time_in_us = Uint64(num_gained_spins) *
+    Uint32 this_spin_cost_ns = spin_stat->m_spin_interval_ns[i];
+    Uint64 gained_time_in_ns = Uint64(num_gained_spins) * Uint64(1000) *
                                  Uint64(m_gain_spintime_in_us);
 
     Uint64 spin_cost = 0;
-    Uint32 avg_spin_cost = spin_stat->m_spin_interval[0] / 2;
+    Uint32 avg_spin_cost = spin_stat->m_spin_interval_ns[0] / 2;
     spin_cost += Uint64(avg_spin_cost * spin_stat->m_micros_sleep_times[0]);
     for (Uint32 j = 1; j <= i; j++)
     {
-      Uint32 diff_time = spin_stat->m_spin_interval[j] -
-                           spin_stat->m_spin_interval[j - 1];
+      Uint32 diff_time = spin_stat->m_spin_interval_ns[j] -
+                           spin_stat->m_spin_interval_ns[j - 1];
       diff_time /= 2;
-      avg_spin_cost = diff_time + spin_stat->m_spin_interval[j - 1];
+      avg_spin_cost = diff_time + spin_stat->m_spin_interval_ns[j - 1];
       spin_cost += Uint64(avg_spin_cost * spin_stat->m_micros_sleep_times[j]);
     }
 
-    spin_cost += Uint64(this_spin_cost * remaining_events);
-    ndbrequire(gained_time_in_us);
-    Uint64 spin_overhead = Uint64(1000) * spin_cost / gained_time_in_us;
+    spin_cost += Uint64(this_spin_cost_ns * remaining_events);
+    ndbrequire(gained_time_in_ns);
+    Uint64 spin_overhead = (Uint64(1000) * spin_cost) / gained_time_in_ns;
     spin_overhead += 5;
     spin_overhead /= 10;
 
@@ -1699,12 +1702,13 @@ Uint32 Thrman::calc_new_spin(ndb_spin_stat *spin_stat)
        *
        * This means that we calculate the time estimated to continue spinning
        * before an event occurs based on that we know that we spent already
-       * this time spinning (m_spin_interval[i - 1]). We know that i >= 1 here.
+       * this time spinning (m_spin_interval_ns[i - 1]). We know that i >= 1
+       * here.
        *
-       * The extra gain we get by continuing to spin until m_spin_interval[i] is
-       * sum of gains from found + 1 to i. The extra cost is the added extra
-       * spin time imposed on all remaining_events. The added cost is
-       * m_spin_interval[i] - m_spin_interval[found].
+       * The extra gain we get by continuing to spin until
+       * m_spin_interval_ns[i] is sum of gains from found + 1 to i. The extra
+       * cost is the added extra spin time imposed on all remaining_events.
+       * The added cost is m_spin_interval_ns[i] - m_spin_interval_ns[found].
        *
        * We will ignore this check if there is only a single event in this
        * slot. This represents a too high risk of spinning for too long if the
@@ -1717,21 +1721,22 @@ Uint32 Thrman::calc_new_spin(ndb_spin_stat *spin_stat)
       {
         Uint64 events_in_slot = Uint64(spin_stat->m_micros_sleep_times[j]);
         extra_gain += events_in_slot;
-        Uint32 diff_time = spin_stat->m_spin_interval[j] -
-                             spin_stat->m_spin_interval[j - 1];
+        Uint32 diff_time = spin_stat->m_spin_interval_ns[j] -
+                             spin_stat->m_spin_interval_ns[j - 1];
         diff_time /= 2;
         Uint64 avg_spin_cost = Uint64(diff_time) +
-          Uint64(spin_stat->m_spin_interval[j - 1] -
-             spin_stat->m_spin_interval[found]);
+          Uint64(spin_stat->m_spin_interval_ns[j - 1] -
+             spin_stat->m_spin_interval_ns[found]);
         extra_cost += Uint64(avg_spin_cost *
                         spin_stat->m_micros_sleep_times[j]);
       }
-      extra_gain *= Uint64(m_gain_spintime_in_us);
+      /* Calculate in nanoseconds */
+      extra_gain *= Uint64(m_gain_spintime_in_us) * Uint64(1000);
       extra_gain *= Uint64(m_allowed_spin_overhead);
       extra_gain /= Uint64(100);
       extra_cost += Uint64(remaining_events) *
-                      Uint64(this_spin_cost -
-                             spin_stat->m_spin_interval[found]);
+                      Uint64(this_spin_cost_ns -
+                             spin_stat->m_spin_interval_ns[found]);
       if (extra_gain > extra_cost)
       {
         found = i;
@@ -1755,21 +1760,21 @@ Uint32 Thrman::calc_new_spin(ndb_spin_stat *spin_stat)
   Uint32 midpoint = (NUM_SPIN_INTERVALS / 2) - 1;
   if (num_events <= 3 ||
       (min_overhead > Uint64(m_allowed_spin_overhead) &&
-       (m_current_spintime == 0 ||
+       (m_current_spintime_us == 0 ||
         min_overhead >
          Uint64(m_allowed_spin_overhead +
                 EXTRA_OVERHEAD_ALLOWED_WHEN_ALREADY_SPINNING))))
   {
     /* Quickly shut down spin environment when no longer beneficial. */
-    if (m_current_spintime != 0)
+    if (m_current_spintime_us != 0)
     {
       DEB_SPIN(("(%u)New spintime = 0", instance()));
     }
-    m_current_spintime = 0;
+    m_current_spintime_us = 0;
   }
-  else if (m_current_spintime == 0 ||
-           m_current_spintime !=
-             spin_stat->m_spin_interval[midpoint])
+  else if (m_current_spintime_us == 0 ||
+           (m_current_spintime_us * 1000) !=
+             spin_stat->m_spin_interval_ns[midpoint])
   {
     /**
      * Immediately adjust to new spin environment when activity starts up
@@ -1778,8 +1783,8 @@ Uint32 Thrman::calc_new_spin(ndb_spin_stat *spin_stat)
      * the spintime, but still haven't changed the spin intervals, so
      * set it directly to the found spintime.
      */
-    m_current_spintime = spin_stat->m_spin_interval[found];
-    DEB_SPIN(("(%u)New spintime = %u", instance(), m_current_spintime));
+    m_current_spintime_us = spin_stat->m_spin_interval_ns[found] / 1000;
+    DEB_SPIN(("(%u)New spintime = %u", instance(), m_current_spintime_us));
   }
   else
   {
@@ -1791,13 +1796,15 @@ Uint32 Thrman::calc_new_spin(ndb_spin_stat *spin_stat)
      */
     if (found < midpoint)
     {
-      m_current_spintime = spin_stat->m_spin_interval[midpoint - 1];
+      m_current_spintime_us =
+        spin_stat->m_spin_interval_ns[midpoint - 1] / 1000;
     }
     else if (found > midpoint)
     {
-      m_current_spintime = spin_stat->m_spin_interval[midpoint + 1];
+      m_current_spintime_us =
+        spin_stat->m_spin_interval_ns[midpoint + 1] / 1000;
     }
-    DEB_SPIN(("(%u)2:New spintime = %u", instance(), m_current_spintime));
+    DEB_SPIN(("(%u)2:New spintime = %u", instance(), m_current_spintime_us));
   }
   if (num_events > MIN_EVENTS_TO_BE_NOT_IDLE)
   {
@@ -1810,15 +1817,15 @@ Uint32 Thrman::calc_new_spin(ndb_spin_stat *spin_stat)
     m_is_idle = true;
   }
   /* Never select a spintime less than 2 microseconds. */
-  if (m_current_spintime != 0 && m_current_spintime < 2)
+  if (m_current_spintime_us != 0 && m_current_spintime_us < 2)
   {
-    m_current_spintime = 2;
+    m_current_spintime_us = 2;
   }
   /**
    * Never go beyond the configured spin time. The adaptive part can only
    * decrease the spinning, not increase it.
    */
-  Uint32 max_spintime = m_configured_spintime;
+  Uint32 max_spintime = m_configured_spintime_us;
   if (m_current_cpu_usage > 90)
   {
     jam();
@@ -1854,9 +1861,9 @@ Uint32 Thrman::calc_new_spin(ndb_spin_stat *spin_stat)
     max_spintime /= 100; // 90%
   }
     
-  if (m_current_spintime > max_spintime)
+  if (m_current_spintime_us > max_spintime)
   {
-    m_current_spintime = max_spintime;
+    m_current_spintime_us = max_spintime;
   }
   if (num_events >= 3)
   {
@@ -1878,7 +1885,7 @@ Uint32 Thrman::calc_new_spin(ndb_spin_stat *spin_stat)
             ":ovh[14]=%llu,cost[14]=%llu",
             instance(),
             num_events,
-            m_current_spintime,
+            m_current_spintime_us,
             calc_spin_overhead[0],
             calc_spin_cost[0],
             calc_spin_overhead[1],
@@ -1910,7 +1917,7 @@ Uint32 Thrman::calc_new_spin(ndb_spin_stat *spin_stat)
             calc_spin_overhead[14],
             calc_spin_cost[14]));
   }
-  return m_current_spintime;
+  return m_current_spintime_us;
 }
 
 void
@@ -1931,7 +1938,7 @@ Thrman::check_spintime(bool local_call)
     jam();
     return;
   }
-  if (m_configured_spintime == 0)
+  if (m_configured_spintime_us == 0)
   {
     /* No configured spinning on the thread, so ignore check of spin time. */
     jam();
@@ -1967,35 +1974,35 @@ Thrman::check_spintime(bool local_call)
             " <= %u: %u, <= %u: %u, <= %u: %u, <= %u: %u"
             " <= %u: %u, <= %u: %u, <= %u: %u, <= MAX: %u",
             instance(),
-            spin_stat.m_spin_interval[0],
+            spin_stat.m_spin_interval_ns[0],
             spin_stat.m_micros_sleep_times[0],
-            spin_stat.m_spin_interval[1],
+            spin_stat.m_spin_interval_ns[1],
             spin_stat.m_micros_sleep_times[1],
-            spin_stat.m_spin_interval[2],
+            spin_stat.m_spin_interval_ns[2],
             spin_stat.m_micros_sleep_times[2],
-            spin_stat.m_spin_interval[3],
+            spin_stat.m_spin_interval_ns[3],
             spin_stat.m_micros_sleep_times[3],
-            spin_stat.m_spin_interval[4],
+            spin_stat.m_spin_interval_ns[4],
             spin_stat.m_micros_sleep_times[4],
-            spin_stat.m_spin_interval[5],
+            spin_stat.m_spin_interval_ns[5],
             spin_stat.m_micros_sleep_times[5],
-            spin_stat.m_spin_interval[6],
+            spin_stat.m_spin_interval_ns[6],
             spin_stat.m_micros_sleep_times[6],
-            spin_stat.m_spin_interval[7],
+            spin_stat.m_spin_interval_ns[7],
             spin_stat.m_micros_sleep_times[7],
-            spin_stat.m_spin_interval[8],
+            spin_stat.m_spin_interval_ns[8],
             spin_stat.m_micros_sleep_times[8],
-            spin_stat.m_spin_interval[9],
+            spin_stat.m_spin_interval_ns[9],
             spin_stat.m_micros_sleep_times[9],
-            spin_stat.m_spin_interval[10],
+            spin_stat.m_spin_interval_ns[10],
             spin_stat.m_micros_sleep_times[10],
-            spin_stat.m_spin_interval[11],
+            spin_stat.m_spin_interval_ns[11],
             spin_stat.m_micros_sleep_times[11],
-            spin_stat.m_spin_interval[12],
+            spin_stat.m_spin_interval_ns[12],
             spin_stat.m_micros_sleep_times[12],
-            spin_stat.m_spin_interval[13],
+            spin_stat.m_spin_interval_ns[13],
             spin_stat.m_micros_sleep_times[13],
-            spin_stat.m_spin_interval[14],
+            spin_stat.m_spin_interval_ns[14],
             spin_stat.m_micros_sleep_times[14],
             spin_stat.m_micros_sleep_times[15]));
   }
@@ -3359,6 +3366,24 @@ Thrman::sum_measures(MeasurementRecord *dest,
 }
 
 bool
+Thrman::calculate_cpu_load_last_measurement(MeasurementRecord *measure)
+{
+  MeasurementRecordPtr measurePtr;
+
+  memset(measure, 0, sizeof(MeasurementRecord));
+
+  c_next_50ms_measure.first(measurePtr);
+  if (measurePtr.p->m_first_measure_done)
+  {
+    jam();
+    sum_measures(measure, measurePtr.p);
+    return true;
+  }
+  jam();
+  return false;
+}
+
+bool
 Thrman::calculate_cpu_load_last_second(MeasurementRecord *measure)
 {
   MeasurementRecordPtr measurePtr;
@@ -3836,6 +3861,20 @@ Thrman::calculate_mean_send_thread_load(Uint32 num_milliseconds)
 }
 
 Uint64
+Thrman::get_os_measured_exec_time(MeasurementRecord *measurePtrP)
+{
+  Uint64 os_measured_exec_time = measurePtrP->m_user_time_os;
+  os_measured_exec_time += measurePtrP->m_kernel_time_os;
+  return os_measured_exec_time;
+}
+
+Uint64
+Thrman::get_measured_exec_time(MeasurementRecord *measurePtrP)
+{
+  return measurePtrP->m_exec_time_thread;
+}
+
+Uint64
 Thrman::get_real_exec_time(MeasurementRecord *measurePtrP)
 {
   /**
@@ -3852,23 +3891,91 @@ Thrman::get_real_exec_time(MeasurementRecord *measurePtrP)
   return (exec_time - spin_time);
 }
 
+Uint64
+Thrman::get_measured_block_exec_time(MeasurementRecord *measurePtrP)
+{
+  /**
+   * We count buffer full time as real execution time here
+   */
+  Uint64 real_exec_time = get_real_exec_time(measurePtrP);
+  Uint64 send_time = measurePtrP->m_send_time_thread;
+  if (real_exec_time < send_time)
+  {
+    jam();
+    return 0;
+  }
+  return (real_exec_time - send_time);
+}
+
 void
 Thrman::execGET_CPU_USAGE_REQ(Signal *signal)
 {
   MeasurementRecord curr_measure;
-  if (calculate_cpu_load_last_second(&curr_measure))
+  GetCpuUsageConf *conf = (GetCpuUsageConf*)signal->getDataPtrSend();
+  if (signal->theData[0] == 0)
   {
-    jam();
-    Uint64 real_exec_time = get_real_exec_time(&curr_measure);
-    Uint64 percentage = (Uint64(100) * real_exec_time) /
-                          curr_measure.m_elapsed_time;
-    signal->theData[0] = Uint32(percentage);
+    /**
+     * Backup block wants per second measure
+     */
+    if (calculate_cpu_load_last_second(&curr_measure))
+    {
+      jam();
+      if (curr_measure.m_elapsed_time != 0)
+      {
+        Uint64 real_exec_time = get_real_exec_time(&curr_measure);
+        Uint64 os_exec_time = get_os_measured_exec_time(&curr_measure);
+        Uint64 exec_time = get_measured_exec_time(&curr_measure);
+        Uint64 block_exec_time = get_measured_block_exec_time(&curr_measure);
+        Uint64 percentage = (Uint64(100) * real_exec_time) /
+                              curr_measure.m_elapsed_time;
+        conf->real_exec_time = Uint32(percentage);
+        percentage = (Uint64(100) * os_exec_time) /
+                      curr_measure.m_elapsed_time;
+        conf->os_exec_time = Uint32(percentage);
+        percentage = (Uint64(100) * exec_time) /
+                      curr_measure.m_elapsed_time;
+        conf->exec_time = Uint32(percentage);
+        percentage = (Uint64(100) * block_exec_time) /
+                      curr_measure.m_elapsed_time;
+        conf->block_exec_time = Uint32(percentage);
+        return;
+      }
+    }
   }
-  else
+  else if (signal->theData[0] == 1)
   {
-    jam();
-    signal->theData[0] = default_cpu_load;
+    /**
+     * LQH block wants the latest CPU measurement
+     */
+    if (calculate_cpu_load_last_measurement(&curr_measure))
+    {
+      if (curr_measure.m_elapsed_time != 0)
+      {
+        Uint64 real_exec_time = get_real_exec_time(&curr_measure);
+        Uint64 os_exec_time = get_os_measured_exec_time(&curr_measure);
+        Uint64 exec_time = get_measured_exec_time(&curr_measure);
+        Uint64 block_exec_time = get_measured_block_exec_time(&curr_measure);
+        Uint64 percentage = (Uint64(100) * real_exec_time) /
+                              curr_measure.m_elapsed_time;
+        conf->real_exec_time = Uint32(percentage);
+        percentage = (Uint64(100) * os_exec_time) /
+                      curr_measure.m_elapsed_time;
+        conf->os_exec_time = Uint32(percentage);
+        percentage = (Uint64(100) * exec_time) /
+                      curr_measure.m_elapsed_time;
+        conf->exec_time = Uint32(percentage);
+        percentage = (Uint64(100) * block_exec_time) /
+                      curr_measure.m_elapsed_time;
+        conf->block_exec_time = Uint32(percentage);
+        return;
+      }
+    }
   }
+  jam();
+  conf->real_exec_time = default_cpu_load;
+  conf->os_exec_time = 0;
+  conf->exec_time = default_cpu_load;
+  conf->block_exec_time = default_cpu_load;
 }
 
 void

--- a/storage/ndb/src/kernel/blocks/thrman.hpp
+++ b/storage/ndb/src/kernel/blocks/thrman.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
 
    This program is free software; you can redistribute it and/or modify
@@ -291,8 +291,8 @@ private:
     Uint64 avg_send_percentage;
   };
 
-  Uint32 m_configured_spintime;
-  Uint32 m_current_spintime;
+  Uint32 m_configured_spintime_us;
+  Uint32 m_current_spintime_us;
   Uint32 m_gain_spintime_in_us;
   Uint32 m_current_cpu_usage;
 
@@ -341,6 +341,9 @@ private:
   Uint32 calc_new_spin(ndb_spin_stat*);
   void measure_wakeup_time(Signal*, Uint32);
   Uint64 get_real_exec_time(MeasurementRecord *measurePtrP);
+  Uint64 get_os_measured_exec_time(MeasurementRecord *measurePtrP);
+  Uint64 get_measured_exec_time(MeasurementRecord *measurePtrP);
+  Uint64 get_measured_block_exec_time(MeasurementRecord *measurePtrP);
 
   void set_configured_spintime(Uint32 val, bool specific);
   void set_allowed_spin_overhead(Uint32 val);
@@ -402,6 +405,7 @@ private:
   bool calculate_stats_last_second(MeasureStats *stats);
   bool calculate_stats_last_100ms(MeasureStats *stats);
 
+  bool calculate_cpu_load_last_measurement(MeasurementRecord *measure);
   bool calculate_cpu_load_last_second(MeasurementRecord *measure);
   bool calculate_cpu_load_last_20seconds(MeasurementRecord *measure);
   bool calculate_cpu_load_last_400seconds(MeasurementRecord *measure);

--- a/storage/ndb/src/kernel/vm/mt.hpp
+++ b/storage/ndb/src/kernel/vm/mt.hpp
@@ -1,5 +1,5 @@
 /* Copyright (c) 2008, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -228,7 +228,7 @@ struct ndb_spin_stat
   Uint32 m_sleep_shorter_spin_time;
   Uint32 m_num_waits;
   Uint32 m_micros_sleep_times[NUM_SPIN_INTERVALS];
-  Uint32 m_spin_interval[NUM_SPIN_INTERVALS];
+  Uint32 m_spin_interval_ns[NUM_SPIN_INTERVALS];
 };
 
 void

--- a/storage/ndb/src/kernel/vm/pc.hpp
+++ b/storage/ndb/src/kernel/vm/pc.hpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -259,7 +260,9 @@ extern thread_local Uint32 NDB_THREAD_TLS_RES_OWNER;
 // parallelism of node recovery and the amount of scan 
 // operations needed for node recovery.
 /* ------------------------------------------------------------------ */
-#define MAX_NO_WORDS_OUTSTANDING_COPY_FRAGMENT 6000
+#define ZMAX_PARALLEL_COPY_FRAGMENT_OPS 8
+#define DEF_NO_WORDS_OUTSTANDING_COPY_FRAGMENT 6000
+#define MAX_NO_WORDS_OUTSTANDING_COPY_FRAGMENT 48000
 #define MAGIC_CONSTANT 56
 #define NODE_RECOVERY_SCAN_OP_RECORDS \
          (4 + ((4*MAX_NO_WORDS_OUTSTANDING_COPY_FRAGMENT)/ \


### PR DESCRIPTION
Copy fragment process have been limited to one fragment copy per LDM thread previously. The copy fragment is also limited by the parallelism such that at most 6000 words are allowed to be outstanding (a row counts for 56 words plus the row size in words).

This means that in particular initial node restart is fairly slow. Thus we should improve the parallelism while at the same time maintaining protection against overload of the live node which could be very busy serving readers and writers of the databases.

Actually this parallelism is already implemented in DBDIH. This means that we can already send up to 64 parallel copy fragment requests to a node. However DBLQH imposes a limit of one at a time and queues the other requests.

This patch ensures that we can run up to 8 parallel copy fragment processes per LDM thread. We will get data from THRMAN about CPU load due to this, we will use this both to limit the number of concurrent copy fragment processes and also to limit the parallelism per copy fragment process.

One problem when synchronising a node and there is a lot of disk columns, is that we might get overload on the UNDO log. This would cause failure of the node restart if not avoided. To avoid this we need to be able to halt the copy fragment process and later resume it again.

This functionality was already implemented. However the implementation isn't very likely to work. The new implementation is very simple. It sends a HALT_COPY_FRAG_REQ to the live node(s) performing the copying. It doesn't send anything back to the starting node. It is the responsibility of the live node to halt in a proper manner. Similarly the starting node will send RESUME_COPY_FRAG_REQ when it is ok to copy again. Currently the halt will halt all copy fragment processes even if they don't have any disk columns. It is likely that the disk columns tables are anyways the bottleneck for the node restart, so special handling wouldn't make any major difference.

To handle up to 8 parallel copy fragment processes per LDM thread requires that we have reserved 8 operation records, there is a scan record in DBTUP, there is a scan lock record in DBTUP, there is a stored procedure record in DBTUP, there is a scan record in DBLQH and there is a scan lock record in DBACC, all of them requires 8 reserved records such that we don't risk that the copy fragment processes runs out of memory.

A few tweaks were required to send COPY_FRAGREQ for NON_TRANSACCTIONAL use. This is part of restore fragment and is mainly used in initial node restart. Some tweaks were required here to ensure that we could start more in parallel.

Both TRANSACTIONAL and NON_TRANSACTIONAL COPY_FRAGREQ required limitations when running against an older node starting up.

A very important part of the work is to also adapt the speed of node recovery based on the CPU usage in the live node. We need to slow down when the CPU gets heavily used.

The speed of node recovery was previously limited to having 24 kBytes outstanding where 0 bytes in a row was counted as 224 bytes. This means effectively less than 50 rows at a time per thread was outstanding. We increased this substantially to now go up to 192 kBytes instead. Thus around 400 small rows can be outstanding. This should provide a good balance between latency of operations towards the live node and the speed of node recovery.

The CPUs have become much faster and on some fast CPUs adding microseconds wasn't good enough, we had to raise the level to handle nanoseconds. This had an impact on our measurements of CPU load which is a very important part of this patch for adaptive speed of node recovery.

As part of this patch we also disable ACC scans (previously done in 22.10 branch).