### PR TITLE
RONDB - 338: Optimise REST Server

### DIFF
--- a/storage/ndb/rest-server/rest-api-server/internal/handlers/pkread/encoding.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/handlers/pkread/encoding.go
@@ -219,7 +219,7 @@ func convertToJsonRaw(dataType uint32, value *string) *json.RawMessage {
 		valueBytes := json.RawMessage(*value)
 		return &valueBytes
 	} else {
-		quotedString := fmt.Sprintf("\"%s\"", *value)
+		quotedString := "\"" + *value + "\""
 		valueBytes := json.RawMessage(quotedString)
 		return &valueBytes
 	}

--- a/storage/ndb/rest-server/rest-api-server/internal/integrationtests/batchpkread/utils_grpc.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/integrationtests/batchpkread/utils_grpc.go
@@ -126,7 +126,7 @@ func validateBatchResponseValuesGRPC(t testing.TB, testInfo api.BatchOperationTe
 
 			var err error
 			if val != nil {
-				quotedVal := fmt.Sprintf("\"%s\"", *val) // you have to surround the string with "s
+				quotedVal := "\"" + *val + "\"" // you have to surround the string with "s
 				*val, err = strconv.Unquote(quotedVal)
 				if err != nil {
 					t.Fatalf("Unquote failed %v\n", err)

--- a/storage/ndb/rest-server/rest-api-server/internal/integrationtests/pkread/utils_grpc.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/integrationtests/pkread/utils_grpc.go
@@ -69,9 +69,9 @@ func handleGrpcRequest(
 }
 
 /*
-	Extracted this in case we want to reuse the Proto request struct and
-	avoid parsing the response, even though this does not make a noticeable
-	difference in performance tests.
+Extracted this in case we want to reuse the Proto request struct and
+avoid parsing the response, even though this does not make a noticeable
+difference in performance tests.
 */
 func sendGrpcRequestAndCheckStatus(
 	t testing.TB,
@@ -118,7 +118,7 @@ func validateResGRPC(
 
 		var err error
 		if val != nil {
-			quotedVal := fmt.Sprintf("\"%s\"", *val) // you have to surround the string with "s
+			quotedVal := "\"" + *val + "\"" // you have to surround the string with "s
 			*val, err = strconv.Unquote(quotedVal)
 			if err != nil {
 				t.Fatalf("Unquote failed %v\n", err)

--- a/storage/ndb/rest-server/rest-api-server/internal/servers/rest/batch_pk_read.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/servers/rest/batch_pk_read.go
@@ -30,6 +30,8 @@ import (
 	"hopsworks.ai/rdrs/pkg/api"
 )
 
+var operationUrl = regexp.MustCompile("^[a-zA-Z0-9$_]+/[a-zA-Z0-9$_]+/pk-read")
+
 func (h *RouteHandler) BatchPkRead(c *gin.Context) {
 	apiKey := c.GetHeader(config.API_KEY_NAME)
 
@@ -74,11 +76,8 @@ func parseOperation(operation *api.BatchSubOp, pkReadarams *api.PKReadParams) er
 		operation.RelativeURL = &trimmed
 	}
 
-	match, err := regexp.MatchString("^[a-zA-Z0-9$_]+/[a-zA-Z0-9$_]+/pk-read",
-		*operation.RelativeURL)
-	if err != nil {
-		return fmt.Errorf("error parsing relative URL: %w", err)
-	} else if !match {
+	match := operationUrl.MatchString(*operation.RelativeURL)
+	if !match {
 		return fmt.Errorf("invalid relative URL: %s", *operation.RelativeURL)
 	}
 	return makePKReadParams(operation, pkReadarams)

--- a/storage/ndb/rest-server/rest-api-server/pkg/api/pk-data-structs.go
+++ b/storage/ndb/rest-server/rest-api-server/pkg/api/pk-data-structs.go
@@ -161,7 +161,7 @@ func (r *PKReadResponseJSON) SetColumnData(column, value *string, dataType uint3
 			valueBytes := json.RawMessage(*value)
 			(*(*r).Data)[*column] = &valueBytes
 		} else {
-			quotedString := fmt.Sprintf("\"%s\"", *value)
+			quotedString := "\"" + *value + "\""
 			valueBytes := json.RawMessage(quotedString)
 			(*(*r).Data)[*column] = &valueBytes
 		}


### PR DESCRIPTION
For benchmarking REST batchpkread,

From
```log
    performance_test.go:149: -------------------------------------------------
    performance_test.go:143: Number of requests:         7843
    performance_test.go:144: Batch size (per requests):  100
    performance_test.go:145: Number of threads:          7
    performance_test.go:146: Throughput:                 79417.880637 pk lookups/second
    performance_test.go:147: 50th percentile latency:    8 ms
    performance_test.go:148: 99th percentile latency:    35 ms
    performance_test.go:149: -------------------------------------------------
BenchmarkSimple-8           9530           1462199 ns/op         2460698 B/op      13516 allocs/op
```

to:
```log
    performance_test.go:143: Number of requests:         8016
    performance_test.go:144: Batch size (per requests):  100
    performance_test.go:145: Number of threads:          7
    performance_test.go:146: Throughput:                 92915.990723 pk lookups/second
    performance_test.go:147: 50th percentile latency:    7 ms
    performance_test.go:148: 99th percentile latency:    29 ms
    performance_test.go:149: -------------------------------------------------
BenchmarkSimple-8          11149           1320736 ns/op         2147834 B/op      10115 allocs/op