### PR TITLE
RONDB-364: Add service-name parameter to ndb_mgmd and ndbmtd

### DIFF
--- a/storage/ndb/include/portlib/NdbConfig.h
+++ b/storage/ndb/include/portlib/NdbConfig.h
@@ -1,7 +1,7 @@
 /*
    Copyright (C) 2003-2006 MySQL AB
     Use is subject to license terms.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -42,6 +42,8 @@ char* NdbConfig_TraceFileName(int node_id, int file_no);
 char* NdbConfig_NextTraceFileName(int node_id);
 char* NdbConfig_PidFileName(int node_id);
 char* NdbConfig_StdoutFileName(int node_id);
+void NdbConfig_SetServiceName(const char *service_name);
+char* NdbConfig_GetServiceName();
 
 #ifdef	__cplusplus
 }

--- a/storage/ndb/src/common/portlib/NdbConfig.cpp
+++ b/storage/ndb/src/common/portlib/NdbConfig.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -30,6 +30,7 @@
 
 static const char *datadir_path= 0;
 static const char *pid_file_dir_path= 0;
+static char *glob_service_name= 0;
 
 const char *
 NdbConfig_get_path(int *_len)
@@ -123,12 +124,33 @@ NdbConfig_NdbCfgName(int with_ndb_home){
   return buf;
 }
 
+void
+NdbConfig_SetServiceName(const char *service_name)
+{
+  int len = strlen(service_name);
+  if (len > 127)
+  {
+    len = 127;
+  }
+  glob_service_name = (char*)malloc(len + 1);
+  strncpy(glob_service_name, service_name, size_t(len + 1));
+  glob_service_name[len] = 0;
+}
+
+char*
+NdbConfig_GetServiceName()
+{
+  return glob_service_name;
+}
+
 static
 char *get_prefix_buf(int len, int node_id, bool pidfile)
 {
-  char tmp_buf[sizeof("ndb_pid#############")+1];
+  char tmp_buf[128];
   char *buf;
-  if (node_id > 0)
+  if (glob_service_name != 0)
+    strncpy(tmp_buf, glob_service_name, sizeof(tmp_buf));
+  else if (node_id > 0)
     snprintf(tmp_buf, sizeof(tmp_buf), "ndb_%u", node_id);
   else
     snprintf(tmp_buf, sizeof(tmp_buf), "ndb_pid%u",

--- a/storage/ndb/src/kernel/blocks/ndbfs/Ndbfs.cpp
+++ b/storage/ndb/src/kernel/blocks/ndbfs/Ndbfs.cpp
@@ -49,6 +49,7 @@
 #include <portlib/NdbDir.hpp>
 #include <NdbOut.hpp>
 #include <Configuration.hpp>
+#include <NdbConfig.h>
 
 #include <EventLogger.hpp>
 
@@ -281,7 +282,15 @@ Ndbfs::execREAD_CONFIG_REQ(Signal* signal)
     m_ctx.m_config.getOwnConfigIterator();
   ndbrequire(p != 0);
   BaseString tmp;
-  tmp.assfmt("ndb_%u_fs%s", getOwnNodeId(), DIR_SEPARATOR);
+  char *service_name = NdbConfig_GetServiceName();
+  if (service_name == 0)
+  {
+    tmp.assfmt("ndb_%u_fs%s", getOwnNodeId(), DIR_SEPARATOR);
+  }
+  else
+  {
+    tmp.assfmt("%s_fs%s", service_name, DIR_SEPARATOR);
+  }
   m_base_path[FsOpenReq::BP_FS].assfmt("%s%s",
                                        m_ctx.m_config.fileSystemPath(),
                                        tmp.c_str());

--- a/storage/ndb/src/kernel/main.cpp
+++ b/storage/ndb/src/kernel/main.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -26,6 +26,7 @@
 #include <ndb_global.h>
 #include <ndb_opts.h>
 #include <kernel/NodeBitmask.hpp>
+#include <NdbConfig.h>
 #include <portlib/ndb_daemon.h>
 #include "util/ndb_openssl_evp.h"
 
@@ -46,6 +47,7 @@ static int opt_daemon, opt_no_daemon, opt_foreground,
   opt_initialstart, opt_verbose;
 static const char* opt_nowait_nodes = 0;
 static const char* opt_bind_address = 0;
+static const char* opt_service_name = 0;
 static int opt_report_fd;
 static int opt_initial;
 static int opt_no_start;
@@ -91,6 +93,10 @@ static struct my_option my_long_options[] =
     "Each node should be started with this option, as well as --nowait-nodes",
     (uchar**) &opt_initialstart, (uchar**) &opt_initialstart, 0,
     GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0 },
+  { "service-name", NDB_OPT_NOSHORT,
+    "Service name sets the file prefix on various files and directories",
+    (uchar**) &opt_service_name, (uchar**) &opt_service_name, 0,
+    GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0 },
   { "bind-address", NDB_OPT_NOSHORT,
     "Local bind address",
     (uchar**) &opt_bind_address, (uchar**) &opt_bind_address, 0,
@@ -210,6 +216,11 @@ real_main(int argc, char** argv)
                            opt_nowait_nodes);
       exit(-1);
     }
+  }
+
+  if (opt_service_name)
+  {
+    NdbConfig_SetServiceName(opt_service_name);
   }
 
  if(opt_angel_pid)

--- a/storage/ndb/src/mgmsrv/main.cpp
+++ b/storage/ndb/src/mgmsrv/main.cpp
@@ -105,6 +105,7 @@ bool g_StopLogging= false;
 static MgmtSrvr* mgm;
 static MgmtSrvr::MgmtOpts opts;
 static const char* opt_logname = "MgmtSrvr";
+static const char* opt_service_name = 0;
 static const char* opt_nowait_nodes = 0;
 
 static struct my_option my_long_options[] =
@@ -163,6 +164,10 @@ static struct my_option my_long_options[] =
     "Delete all binary config files and start from config.ini or my.cnf",
     (uchar**) &opts.initial, (uchar**) &opts.initial, 0,
     GET_BOOL, NO_ARG, 0, 0, 1, 0, 0, 0 },
+  { "service-name", NDB_OPT_NOSHORT,
+    "Service name sets the file prefix on various files and directories",
+    (uchar**) &opt_service_name, (uchar**) &opt_service_name, 0,
+    GET_STR, REQUIRED_ARG, 0, 0, 0, 0, 0, 0 },
   { "log-name", NDB_OPT_NOSHORT,
     "Name to use when logging messages for this node",
     (uchar**) &opt_logname, (uchar**) &opt_logname, 0,
@@ -380,6 +385,10 @@ static int mgmd_main(int argc, char** argv)
     }
   }
 
+  if (opt_service_name)
+  {
+    NdbConfig_SetServiceName(opt_service_name);
+  }
   if (opts.bind_address)
   {
     int len = strlen(opts.bind_address);


### PR DESCRIPTION
This parameter adds a --service-name parameter to ndb_mgmd and ndbmtd. E.g. --service-name=ndbmtd sets the file name of the pid file to ndbmtd.pid and node log to ndbmtd_out.log and similarly for trace files and other log files and the error file.