### PR TITLE
RONDB-395: New retriable error codes

### DIFF
--- a/storage/ndb/src/ndbapi/Ndb.cpp
+++ b/storage/ndb/src/ndbapi/Ndb.cpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2003, 2020, Oracle and/or its affiliates.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -1006,7 +1007,7 @@ Ndb::hupp(NdbTransaction* pBuddyTrans)
       // release the connection and return NULL
       closeTransaction(pCon);
       theImpl->decClientStat( TransStartCount, 1 ); /* Correct stats */
-      theError.code = 4006;
+      theError.code = 4042;
       DBUG_RETURN(NULL);
     }
     pCon->setTransactionId(pBuddyTrans->getTransactionId());

--- a/storage/ndb/src/ndbapi/ndberror.cpp
+++ b/storage/ndb/src/ndbapi/ndberror.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2004, 2020, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2021, Logical Clocks and/or its affiliates.
+   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -179,7 +179,7 @@ ErrorBundle ErrorCodes[] = {
   { 20013, DMEC, IE, "Query aborted due to invalid tree parameter specification: Incorrect key parameter count" },
   { 20014, DMEC, IE, "Query aborted due to internal error" },
   { 20015, DMEC, TR, "Query aborted due to out of row memory" },
-  { 20016, DMEC, NR, "Query aborted due to node failure" },
+  { 20016, HA_ERR_LOCK_WAIT_TIMEOUT, NR, "Query aborted due to node failure" },
   { 20017, DMEC, IE, "Query aborted due to invalid node count" },
   { 20018, DMEC, IE, "Query aborted due to index fragment not found" },
   { 20019, HA_ERR_NO_SUCH_TABLE, SE, "Query table not defined" },
@@ -363,6 +363,7 @@ ErrorBundle ErrorCodes[] = {
   { 410,  DMEC, OL, "REDO log files overloaded (decrease TimeBetweenLocalCheckpoints or increase NoOfFragmentLogFiles)" },
   { 1221, HA_ERR_LOCK_WAIT_TIMEOUT, OL, "REDO buffers overloaded (increase RedoBuffer)" },
   { 4006, DMEC, OL, "Connect failure - out of connection objects (increase MaxNoOfConcurrentTransactions)" }, 
+  { 4042, HA_ERR_LOCK_WAIT_TIMEOUT, NR, "Connect failure in scan - most likely a node failure" }, 
 
 
   /*


### PR DESCRIPTION
When a node failure happens, e.g. when running an OLTP RW transaction in Sysbench, we will often report error code 4006. This error code indicates overload and isn't necessarily leading to a retry by the application logic. There are two main error categories on the MySQL layer that leads to a retry. These are lock wait timeout and deadlock detected. Thus all failures of transaction due to node failures should be mapped to lock wait timeout.

The specific issue with 4006 is when we execute a transaction and we need to perform a scan as part of this transaction. In this case we need the scan to get a connection object from the same data node where the transaction coordinator resides. If not possible the transaction must fail. We will report a new error code 4042 that is mapped to lock wait timeout in this case.

We also map a node failure error from DBSPJ to lock wait timeout as well.