### PR TITLE
Remove label and handle pk not in feature set

### DIFF
--- a/storage/ndb/rest-server/data-access-rondb/src/feature_store/feature_store.h
+++ b/storage/ndb/rest-server/data-access-rondb/src/feature_store/feature_store.h
@@ -45,6 +45,15 @@ typedef struct Training_Dataset_Join {
   char prefix[63+1];
 } Training_Dataset_Join;
 
+typedef struct Feature_Group {
+  int feature_store_id;
+  char name[1000+1];
+  int version;
+  int online_enabled;
+  int num_pk;
+  char** primary_key;
+} Feature_Group;
+
 /**
  * Find project ID using the feature store name
  * SELECT id AS project_id FROM project WHERE projectname = feature_store_name
@@ -76,7 +85,7 @@ RS_Status find_training_dataset_join_data(int feature_view_id, Training_Dataset_
  * Find feature group data
  * SELECT name, online_enabled, feature_store_id, version FROM feature_group WHERE id = {feature_group_id}
  */
-RS_Status find_feature_group_data(int feature_group_id, char *name, int *online_enabled, int *feature_store_id, int *feature_group_version);
+RS_Status find_feature_group_data(int feature_group_id, Feature_Group *fg);
 
 /**
  * Find feature store data

--- a/storage/ndb/rest-server/data-access-rondb/src/rdrs-const.h
+++ b/storage/ndb/rest-server/data-access-rondb/src/rdrs-const.h
@@ -80,6 +80,8 @@ extern "C" {
 #define FEATURE_GROUP_NAME_SIZE            63 + 1
 #define TRAINING_DATASET_FEATURE_NAME_SIZE 1000 + 2
 #define TRAINING_DATASET_FEATURE_TYPE_SIZE 1000 + 2
+#define ON_DEMAND_FEATURE_SIZE 1000 + 1
+#define CACHE_FEATURE_SIZE 63 + 1
 
 // Data types
 #define DECIMAL_MAX_SIZE_IN_BYTES           9 * 4   /*4 bytes per 9 digits. 65/9 + 1 * 4*/

--- a/storage/ndb/rest-server/rest-api-server/internal/feature_store/metadata.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/feature_store/metadata.go
@@ -29,6 +29,7 @@ import (
 	"hopsworks.ai/rdrs/internal/dal"
 	"hopsworks.ai/rdrs/internal/log"
 )
+const ERROR_NOT_FOUND = "Not Found"
 
 type FeatureViewMetadata struct {
 	FeatureStoreName     string
@@ -216,7 +217,7 @@ func GetFeatureViewMetadata(featureStoreName, featureViewName string, featureVie
 
 	fsID, err := dal.GetFeatureStoreID(featureStoreName)
 	if err != nil {
-		if strings.Contains(err.Error(), "Not Found") {
+		if strings.Contains(err.Error(), ERROR_NOT_FOUND) {
 			return nil, FS_NOT_EXIST
 		}
 		return nil, FS_NOT_EXIST.NewMessage(err.Error())
@@ -224,7 +225,7 @@ func GetFeatureViewMetadata(featureStoreName, featureViewName string, featureVie
 
 	fvID, err := dal.GetFeatureViewID(fsID, featureViewName, featureViewVersion)
 	if err != nil {
-		if strings.Contains(err.Error(), "Not Found") {
+		if strings.Contains(err.Error(), ERROR_NOT_FOUND) {
 			return nil, FV_NOT_EXIST
 		}
 		return nil, FV_READ_FAIL.NewMessage(err.VerboseError())
@@ -255,8 +256,7 @@ func GetFeatureViewMetadata(featureStoreName, featureViewName string, featureVie
 		} else {
 			featureGroup, err = dal.GetFeatureGroupData(tdf.FeatureGroupID)
 			if err != nil {
-				// FIXME: FS
-				if strings.Contains(err.Error(), "Not Found") {
+				if strings.Contains(err.Error(), ERROR_NOT_FOUND) {
 					return nil, FG_NOT_EXIST
 				}
 				return nil, FG_READ_FAIL.NewMessage(err.VerboseError())
@@ -270,7 +270,7 @@ func GetFeatureViewMetadata(featureStoreName, featureViewName string, featureVie
 		} else {
 			featureStoreName, err = dal.GetFeatureStoreName(featureGroup.FeatureStoreId)
 			if err != nil {
-				if strings.Contains(err.Error(), "Not Found") {
+				if strings.Contains(err.Error(), ERROR_NOT_FOUND) {
 					return nil, FS_NOT_EXIST
 				}
 				return nil, FS_READ_FAIL.NewMessage(err.VerboseError())

--- a/storage/ndb/rest-server/rest-api-server/internal/feature_store/metadata.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/feature_store/metadata.go
@@ -40,7 +40,8 @@ type FeatureViewMetadata struct {
 	FeatureGroupFeatures []*FeatureGroupFeatures
 	FeatureStoreNames    []*string // List of all feature store including shared feature store
 	NumOfFeatures        int
-	FeatureIndexLookup   map[string]int // key: fgId + fName
+	FeatureIndexLookup   map[string]int    // key: fgId + fName
+	PrimaryKeyMap        map[string]string // key: prefix + fName
 }
 
 type FeatureGroupFeatures struct {
@@ -49,6 +50,7 @@ type FeatureGroupFeatures struct {
 	FeatureGroupVersion int
 	FeatureGroupId      int
 	Features            []*FeatureMetadata
+	PrimaryKeyMap       map[string]string // key: prefix + fName
 }
 
 type FeatureMetadata struct {
@@ -72,10 +74,19 @@ func newFeatureViewMetadata(
 	featureViewId int,
 	featureViewVersion int,
 	features *[]*FeatureMetadata,
+	featureGroupPk *map[int][]string,
 ) *FeatureViewMetadata {
 	prefixColumns := make(map[string]*FeatureMetadata)
 	fgFeatures := make(map[int][]*FeatureMetadata)
+	var primaryKeyMap = make(map[string]string)
 	for _, feature := range *features {
+		// primary key has to be added before skipping label
+		for _, pk := range (*featureGroupPk)[feature.FeatureGroupId] {
+			primaryKeyMap[feature.Prefix+pk] = pk
+		}
+		if feature.Label {
+			continue
+		}
 		prefixFeatureName := feature.Prefix + feature.Name
 		prefixColumns[prefixFeatureName] = feature
 		var featureKey = feature.FeatureGroupId
@@ -83,12 +94,17 @@ func newFeatureViewMetadata(
 	}
 
 	var fgFeaturesArray = make([]*FeatureGroupFeatures, 0)
+
 	for _, value := range fgFeatures {
+		var fgPrimaryKeyMap = make(map[string]string)
 		var featureValue = value
 		var feature = featureValue[0]
+		for _, pk := range (*featureGroupPk)[feature.FeatureGroupId] {
+			fgPrimaryKeyMap[feature.Prefix+pk] = pk
+		}
 		var fgFeature = FeatureGroupFeatures{
 			feature.FeatureStoreName, feature.FeatureGroupName, feature.FeatureGroupVersion,
-			feature.FeatureGroupId, featureValue}
+			feature.FeatureGroupId, featureValue, fgPrimaryKeyMap}
 		fgFeaturesArray = append(fgFeaturesArray, &fgFeature)
 	}
 	less := func(i, j int) bool {
@@ -96,10 +112,14 @@ func newFeatureViewMetadata(
 	}
 	sort.Slice(*features, less)
 	featureIndex := make(map[string]int)
-
+	var featureCount = 0
 	for _, feature := range *features {
+		if feature.Label {
+			continue
+		}
 		featureIndexKey := GetFeatureIndexKeyByFeature(feature)
-		featureIndex[featureIndexKey] = feature.Index
+		featureIndex[featureIndexKey] = featureCount
+		featureCount++
 	}
 	var fsNames = []*string{}
 	var fsNameMap = make(map[string]bool)
@@ -125,6 +145,7 @@ func newFeatureViewMetadata(
 	metadata.NumOfFeatures = numOfFeature
 	metadata.FeatureIndexLookup = featureIndex
 	metadata.FeatureStoreNames = fsNames
+	metadata.PrimaryKeyMap = primaryKeyMap
 	return &metadata
 }
 
@@ -225,31 +246,40 @@ func GetFeatureViewMetadata(featureStoreName, featureViewName string, featureVie
 
 	features := make([]*FeatureMetadata, len(tdfs))
 	fsIdToName := make(map[int]string)
-
+	var featureGroupPk = make(map[int][]string)
+	var fgCache = make(map[int]*dal.FeatureGroup)
 	for i, tdf := range tdfs {
-		featureGroupName, _, fsId, fgVersion, err := dal.GetFeatureGroupData(tdf.FeatureGroupID)
-		if err != nil {
-			if strings.Contains(err.Error(), "Not Found") {
-				return nil, FG_NOT_EXIST
+		var featureGroup *dal.FeatureGroup
+		if fg, ok := fgCache[tdf.FeatureGroupID]; ok {
+			featureGroup = fg
+		} else {
+			featureGroup, err = dal.GetFeatureGroupData(tdf.FeatureGroupID)
+			if err != nil {
+				// FIXME: FS
+				if strings.Contains(err.Error(), "Not Found") {
+					return nil, FG_NOT_EXIST
+				}
+				return nil, FG_READ_FAIL.NewMessage(err.VerboseError())
 			}
-			return nil, FG_READ_FAIL.NewMessage(err.VerboseError())
+			fgCache[tdf.FeatureGroupID] = featureGroup
+			featureGroupPk[tdf.FeatureGroupID] = featureGroup.PrimaryKey
 		}
 		feature := FeatureMetadata{}
-		if featureStoreName, exist := fsIdToName[fsId]; exist {
+		if featureStoreName, exist := fsIdToName[featureGroup.FeatureStoreId]; exist {
 			feature.FeatureStoreName = featureStoreName
 		} else {
-			featureStoreName, err = dal.GetFeatureStoreName(fsId)
+			featureStoreName, err = dal.GetFeatureStoreName(featureGroup.FeatureStoreId)
 			if err != nil {
 				if strings.Contains(err.Error(), "Not Found") {
 					return nil, FS_NOT_EXIST
 				}
 				return nil, FS_READ_FAIL.NewMessage(err.VerboseError())
 			}
-			fsIdToName[fsId] = featureStoreName
+			fsIdToName[featureGroup.FeatureStoreId] = featureStoreName
 			feature.FeatureStoreName = featureStoreName
 		}
-		feature.FeatureGroupName = featureGroupName
-		feature.FeatureGroupVersion = fgVersion
+		feature.FeatureGroupName = featureGroup.Name
+		feature.FeatureGroupVersion = featureGroup.Version
 		feature.FeatureGroupId = tdf.FeatureGroupID
 		feature.Id = tdf.FeatureID
 		feature.Name = tdf.Name
@@ -267,6 +297,7 @@ func GetFeatureViewMetadata(featureStoreName, featureViewName string, featureVie
 		fvID,
 		featureViewVersion,
 		&features,
+		&featureGroupPk,
 	)
 	return featureViewMetadata, nil
 }

--- a/storage/ndb/rest-server/rest-api-server/internal/handlers/batchfeaturestore/handler.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/handlers/batchfeaturestore/handler.go
@@ -71,7 +71,7 @@ func (h *Handler) Validate(request interface{}) error {
 func checkFeatureStatus(fsReq *api.BatchFeatureStoreRequest, metadata *feature_store.FeatureViewMetadata, status *[]api.FeatureStatus) int {
 	var cnt = make(map[int]bool)
 	for i, entry := range *fsReq.Entries {
-		if fshandler.ValidatePrimaryKey(entry, &metadata.PrefixFeaturesLookup) != nil {
+		if fshandler.ValidatePrimaryKey(entry, &metadata.PrimaryKeyMap) != nil {
 			(*status)[i] = api.FEATURE_STATUS_ERROR
 			cnt[i] = true
 		}

--- a/storage/ndb/rest-server/rest-api-server/internal/integrationtests/batchfeaturestore/handler_test.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/integrationtests/batchfeaturestore/handler_test.go
@@ -290,6 +290,53 @@ func Test_GetFeatureVector_joinSameFg(t *testing.T) {
 	ValidateResponseWithData(t, &rows, &cols, fsResp)
 }
 
+func Test_GetFeatureVector_excludeLabelColumn(t *testing.T) {
+	rows, pks, cols, err := fshelper.GetSampleDataWithJoin("fsdb001", "sample_1_1", "fsdb001", "sample_2_1", "fg2_")
+	if err != nil {
+		t.Fatalf("Cannot get sample data with error %s ", err)
+	}
+	var exCols = make(map[string]bool)
+	exCols["data1"] = true
+
+	var fsReq = CreateFeatureStoreRequest(
+		"fsdb001",
+		"sample_1n2_label",
+		1,
+		pks,
+		*GetPkValues(&rows, &pks, &cols),
+		nil,
+		nil,
+	)
+	fsResp := GetFeatureStoreResponse(t, fsReq)
+	ValidateResponseWithDataExcludeCols(t, &rows, &cols, &exCols, fsResp)
+
+}
+
+func Test_GetFeatureVector_excludeLabelFg(t *testing.T) {
+	rows, pks, cols, err := fshelper.GetSampleDataWithJoin("fsdb001", "sample_1_1", "fsdb001", "sample_2_1", "fg2_")
+	if err != nil {
+		t.Fatalf("Cannot get sample data with error %s ", err)
+	}
+	var exCols = make(map[string]bool)
+	exCols["data1"] = true
+	exCols["id1"] = true
+	exCols["data2"] = true
+	exCols["ts"] = true
+
+	var fsReq = CreateFeatureStoreRequest(
+		"fsdb001",
+		"sample_1n2_labelonly",
+		1,
+		pks,
+		*GetPkValues(&rows, &pks, &cols),
+		nil,
+		nil,
+	)
+	fsResp := GetFeatureStoreResponse(t, fsReq)
+	ValidateResponseWithDataExcludeCols(t, &rows, &cols, &exCols, fsResp)
+
+}
+
 func Test_GetFeatureVector_Shared(t *testing.T) {
 	rows, pks, cols, err := fshelper.GetSampleDataWithJoin(testdbs.FSDB001, "sample_1_1", testdbs.FSDB002, "sample_2_1", "fg2_")
 	if err != nil {
@@ -547,7 +594,7 @@ func Test_GetFeatureVector_WrongPrimaryKey_TooManyPk(t *testing.T) {
 
 	var pkValues = *GetPkValues(&rows, &pks, &cols)
 	pks = append(pks, "ts")
-	for i := range(pkValues) {
+	for i := range pkValues {
 		pkValues[i] = append(pkValues[i], []byte(`"2022-01-01"`))
 	}
 	var fsReq = CreateFeatureStoreRequest(

--- a/storage/ndb/rest-server/rest-api-server/internal/integrationtests/batchfeaturestore/helper.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/integrationtests/batchfeaturestore/helper.go
@@ -90,12 +90,20 @@ func GetFeatureStoreResponseWithDetail(t *testing.T, req *api.BatchFeatureStoreR
 }
 
 func ValidateResponseWithData(t *testing.T, data *[][]interface{}, cols *[]string, resp *api.BatchFeatureStoreResponse) {
+	ValidateResponseWithDataExcludeCols(t, data, cols, nil, resp)
+}
+
+func ValidateResponseWithDataExcludeCols(t *testing.T, data *[][]interface{}, cols *[]string, exCols *map[string]bool, resp *api.BatchFeatureStoreResponse) {
 	for i, row := range *data {
 		var fsResp = &api.FeatureStoreResponse{}
 		fsResp.Metadata = resp.Metadata
 		fsResp.Features = resp.Features[i]
 		fsResp.Status = resp.Status[i]
-		fshelper.ValidateResponseWithData(t, &row, cols, fsResp)
+		if exCols == nil {
+			fshelper.ValidateResponseWithData(t, &row, cols, fsResp)
+		} else {
+			fshelper.ValidateResponseWithDataExcludeCols(t, &row, cols, exCols, fsResp)
+		}
 	}
 }
 

--- a/storage/ndb/rest-server/rest-api-server/internal/integrationtests/feature_store/handler_test.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/integrationtests/feature_store/handler_test.go
@@ -297,6 +297,54 @@ func Test_GetFeatureVector_JoinSameFg(t *testing.T) {
 	}
 }
 
+func Test_GetFeatureVector_excludeLabelColumn(t *testing.T) {
+	rows, pks, cols, err := GetSampleDataWithJoin("fsdb001", "sample_1_1", "fsdb001", "sample_2_1", "fg2_")
+	if err != nil {
+		t.Fatalf("Cannot get sample data with error %s ", err)
+	}
+	var exCols = make(map[string]bool)
+	exCols["data1"] = true
+	for _, row := range rows {
+		var fsReq = CreateFeatureStoreRequest(
+			"fsdb001",
+			"sample_1n2_label",
+			1,
+			pks,
+			*GetPkValues(&row, &pks, &cols),
+			nil,
+			nil,
+		)
+		fsResp := GetFeatureStoreResponse(t, fsReq)
+		ValidateResponseWithDataExcludeCols(t, &row, &cols, &exCols, fsResp)
+	}
+}
+
+func Test_GetFeatureVector_excludeLabelFg(t *testing.T) {
+	rows, pks, cols, err := GetSampleDataWithJoin("fsdb001", "sample_1_1", "fsdb001", "sample_2_1", "fg2_")
+	if err != nil {
+		t.Fatalf("Cannot get sample data with error %s ", err)
+	}
+	var exCols = make(map[string]bool)
+	exCols["data1"] = true
+	exCols["id1"] = true
+	exCols["data2"] = true
+	exCols["ts"] = true
+
+	for _, row := range rows {
+		var fsReq = CreateFeatureStoreRequest(
+			"fsdb001",
+			"sample_1n2_labelonly",
+			1,
+			pks,
+			*GetPkValues(&row, &pks, &cols),
+			nil,
+			nil,
+		)
+		fsResp := GetFeatureStoreResponse(t, fsReq)
+		ValidateResponseWithDataExcludeCols(t, &row, &cols, &exCols, fsResp)
+	}
+}
+
 func Test_GetFeatureVector_Shared(t *testing.T) {
 	rows, pks, cols, err := GetSampleDataWithJoin(testdbs.FSDB001, "sample_1_1", testdbs.FSDB002, "sample_2_1", "fg2_")
 	if err != nil {
@@ -357,7 +405,7 @@ func Test_GetFeatureVector_WrongPrimaryKey_NotExist(t *testing.T) {
 			nil,
 			nil,
 		)
-		GetFeatureStoreResponseWithDetail(t, fsReq, fsmetadata.FEATURE_NOT_EXIST.GetReason(), http.StatusBadRequest)
+		GetFeatureStoreResponseWithDetail(t, fsReq, fsmetadata.INCORRECT_PRIMARY_KEY.GetReason(), http.StatusBadRequest)
 	}
 }
 

--- a/storage/ndb/rest-server/rest-api-server/resources/testdbs/fixed/hopsworks.sql
+++ b/storage/ndb/rest-server/rest-api-server/resources/testdbs/fixed/hopsworks.sql
@@ -199,62 +199,125 @@ CREATE TABLE `feature_store` (
                                  CONSTRAINT `FK_883_662` FOREIGN KEY (`project_id`) REFERENCES `project` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=ndbcluster AUTO_INCREMENT=67 DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
 
--- CREATE TABLE `on_demand_feature_group` (
---                                                          `id`                      INT(11)         NOT NULL AUTO_INCREMENT,
---                                                          `query`                   VARCHAR(26000),
---                                                          `connector_id`            INT(11)         NOT NULL,
---                                                          `description`             VARCHAR(1000)   NULL,
---                                                          `inode_pid`               BIGINT(20)      NOT NULL,
---                                                          `inode_name`              VARCHAR(255)    NOT NULL,
---                                                          `partition_id`            BIGINT(20)      NOT NULL,
---                                                          `data_format`             VARCHAR(10),
---                                                          `path`                    VARCHAR(1000),
---                                                          PRIMARY KEY (`id`)
---                                                         --  CONSTRAINT `on_demand_conn_fk` FOREIGN KEY (`connector_id`) REFERENCES `feature_store_connector` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
---                                                         --  CONSTRAINT `on_demand_inode_fk` FOREIGN KEY (`inode_pid`, `inode_name`, `partition_id`) REFERENCES `hops`.`hdfs_inodes` (`parent_id`, `name`, `partition_id`) ON DELETE CASCADE ON UPDATE NO ACTION
--- ) ENGINE = ndbcluster DEFAULT CHARSET = latin1 COLLATE = latin1_general_cs;
+CREATE TABLE `on_demand_feature_group` (
+                                                         `id`                      INT(11)         NOT NULL AUTO_INCREMENT,
+                                                         `query`                   VARCHAR(26000),
+                                                         `connector_id`            INT(11)         NOT NULL,
+                                                         `description`             VARCHAR(1000)   NULL,
+                                                         `inode_pid`               BIGINT(20)      NOT NULL,
+                                                         `inode_name`              VARCHAR(255)    NOT NULL,
+                                                         `partition_id`            BIGINT(20)      NOT NULL,
+                                                         `data_format`             VARCHAR(10),
+                                                         `path`                    VARCHAR(1000),
+                                                         PRIMARY KEY (`id`)
+                                                        --  CONSTRAINT `on_demand_conn_fk` FOREIGN KEY (`connector_id`) REFERENCES `feature_store_connector` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+                                                        --  CONSTRAINT `on_demand_inode_fk` FOREIGN KEY (`inode_pid`, `inode_name`, `partition_id`) REFERENCES `hops`.`hdfs_inodes` (`parent_id`, `name`, `partition_id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE = ndbcluster DEFAULT CHARSET = latin1 COLLATE = latin1_general_cs;
 
--- CREATE TABLE `cached_feature_group` (
---                                                       `id`                             INT(11)         NOT NULL AUTO_INCREMENT,
---                                                       `offline_feature_group`          BIGINT(20)      NOT NULL,
---                                                       `timetravel_format`              INT NOT NULL DEFAULT 1,
---                                                       PRIMARY KEY (`id`)
---                                                     --   CONSTRAINT `cached_fg_hive_fk` FOREIGN KEY (`offline_feature_group`) REFERENCES `metastore`.`TBLS` (`TBL_ID`) ON DELETE CASCADE ON UPDATE NO ACTION
--- ) ENGINE = ndbcluster DEFAULT CHARSET = latin1 COLLATE = latin1_general_cs;
+CREATE TABLE `cached_feature_group` (
+                                                      `id`                             INT(11)         NOT NULL AUTO_INCREMENT,
+                                                      `offline_feature_group`          BIGINT(20)      NOT NULL,
+                                                      `timetravel_format`              INT NOT NULL DEFAULT 1,
+                                                      PRIMARY KEY (`id`)
+                                                    --   CONSTRAINT `cached_fg_hive_fk` FOREIGN KEY (`offline_feature_group`) REFERENCES `metastore`.`TBLS` (`TBL_ID`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE = ndbcluster DEFAULT CHARSET = latin1 COLLATE = latin1_general_cs;
 
--- CREATE TABLE `stream_feature_group` (
---                                                       `id`                             INT(11) NOT NULL AUTO_INCREMENT,
---                                                       `offline_feature_group`          BIGINT(20) NOT NULL,
---                                                       PRIMARY KEY (`id`)
---                                                     --   CONSTRAINT `stream_fg_hive_fk` FOREIGN KEY (`offline_feature_group`) REFERENCES `metastore`.`TBLS` (`TBL_ID`) ON DELETE CASCADE ON UPDATE NO ACTION
--- ) ENGINE = ndbcluster DEFAULT CHARSET = latin1 COLLATE = latin1_general_cs;
+CREATE TABLE `stream_feature_group` (
+                                                      `id`                             INT(11) NOT NULL AUTO_INCREMENT,
+                                                      `offline_feature_group`          BIGINT(20) NOT NULL,
+                                                      PRIMARY KEY (`id`)
+                                                    --   CONSTRAINT `stream_fg_hive_fk` FOREIGN KEY (`offline_feature_group`) REFERENCES `metastore`.`TBLS` (`TBL_ID`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE = ndbcluster DEFAULT CHARSET = latin1 COLLATE = latin1_general_cs;
 
--- CREATE TABLE `cached_feature` (
---   `id` int(11) NOT NULL AUTO_INCREMENT,
---   `cached_feature_group_id` int(11) NULL,
---   `stream_feature_group_id` int(11) NULL,
---   `name` varchar(63) COLLATE latin1_general_cs NOT NULL,
---   `description` varchar(256) NOT NULL DEFAULT '',
---   PRIMARY KEY (`id`),
---   KEY `cached_feature_group_fk` (`cached_feature_group_id`),
---   KEY `stream_feature_group_fk` (`stream_feature_group_id`),
---   CONSTRAINT `cached_feature_group_fk2` FOREIGN KEY (`cached_feature_group_id`) REFERENCES `cached_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
---   CONSTRAINT `stream_feature_group_fk2` FOREIGN KEY (`stream_feature_group_id`) REFERENCES `stream_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
--- ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
+INSERT INTO
+    `stream_feature_group`
+VALUES
+    (
+        2055, 148
+    ),
+    (
+        2056, 148
+    ),
+    (
+        2057, 149
+    ),
+    (
+        2058, 150
+    ),
+    (
+        2059, 151
+    ),
+    (
+        2060, 152
+    ),
+    (
+        2064, 156
+    ),
+    (
+        2065, 157
+    );
 
--- CREATE TABLE `on_demand_feature` (
---                                      `id` int(11) NOT NULL AUTO_INCREMENT,
---                                      `on_demand_feature_group_id` int(11) NULL,
---                                      `name` varchar(1000) COLLATE latin1_general_cs NOT NULL,
---                                      `primary_column` tinyint(1) NOT NULL DEFAULT '0',
---                                      `description` varchar(10000) COLLATE latin1_general_cs,
---                                      `type` varchar(1000) COLLATE latin1_general_cs NOT NULL,
---                                      `idx` int(11) NOT NULL DEFAULT 0,
---                                      `default_value` VARCHAR(400) NULL,
---                                      PRIMARY KEY (`id`),
---                                      KEY `on_demand_feature_group_fk` (`on_demand_feature_group_id`),
---                                      CONSTRAINT `on_demand_feature_group_fk1` FOREIGN KEY (`on_demand_feature_group_id`) REFERENCES `on_demand_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
--- ) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
+CREATE TABLE `on_demand_feature` (
+                                     `id` int(11) NOT NULL AUTO_INCREMENT,
+                                     `on_demand_feature_group_id` int(11) NULL,
+                                     `name` varchar(1000) COLLATE latin1_general_cs NOT NULL,
+                                     `primary_column` tinyint(1) NOT NULL DEFAULT '0',
+                                     `description` varchar(10000) COLLATE latin1_general_cs,
+                                     `type` varchar(1000) COLLATE latin1_general_cs NOT NULL,
+                                     `idx` int(11) NOT NULL DEFAULT 0,
+                                     `default_value` VARCHAR(400) NULL,
+                                     PRIMARY KEY (`id`),
+                                     KEY `on_demand_feature_group_fk` (`on_demand_feature_group_id`),
+                                     CONSTRAINT `on_demand_feature_group_fk1` FOREIGN KEY (`on_demand_feature_group_id`) REFERENCES `on_demand_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
+
+CREATE TABLE `cached_feature_extra_constraints` (
+                                                    `id` int(11) NOT NULL AUTO_INCREMENT,
+                                                    `cached_feature_group_id` int(11) NULL,
+                                                    `stream_feature_group_id` int(11) NULL,
+                                                    `name` varchar(63) COLLATE latin1_general_cs NOT NULL,
+                                                    `primary_column` tinyint(1) NOT NULL DEFAULT '0',
+                                                    `hudi_precombine_key` tinyint(1) NOT NULL DEFAULT '0',
+                                                    PRIMARY KEY (`id`),
+                                                    KEY `stream_feature_group_fk` (`stream_feature_group_id`),
+                                                    KEY `cached_feature_group_fk` (`cached_feature_group_id`),
+                                                    CONSTRAINT `stream_feature_group_fk1` FOREIGN KEY (`stream_feature_group_id`) REFERENCES `stream_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+                                                    CONSTRAINT `cached_feature_group_fk1` FOREIGN KEY (`cached_feature_group_id`) REFERENCES `cached_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+) ENGINE=ndbcluster DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
+
+INSERT INTO
+    `cached_feature_extra_constraints`
+VALUES
+    (
+        2054, NULL, 2055, 'id1', 1, 1
+    ),
+    (
+        2055, NULL, 2055, 'id2', 1, 0
+    ),
+    (
+        2056, NULL, 2056, 'id1', 1, 1
+    ),
+    (
+        2058, NULL, 2058, 'id1', 1, 1
+    ),
+    (
+        2059, NULL, 2059, 'id1', 1, 1
+    ),
+    (
+        2060, NULL, 2060, 'id1', 1, 1
+    ),
+    (
+        2064, NULL, 2064, 'id1', 1, 1
+    ),
+    (
+        2065, NULL, 2064, 'id2', 1, 0
+    ),
+    (
+        2066, NULL, 2065, 'id1', 1, 1
+    ),
+    (
+        2057, NULL, 2057, 'id1', 1, 1
+    );
 
 CREATE TABLE `feature_group` (
                                  `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -277,10 +340,10 @@ CREATE TABLE `feature_group` (
                                  KEY `cached_feature_group_fk` (`cached_feature_group_id`),
                                  KEY `stream_feature_group_fk` (`stream_feature_group_id`),
                                  CONSTRAINT `FK_1012_790` FOREIGN KEY (`creator`) REFERENCES `users` (`uid`) ON DELETE NO ACTION ON UPDATE NO ACTION,
-                                 CONSTRAINT `FK_656_740` FOREIGN KEY (`feature_store_id`) REFERENCES `feature_store` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
-                                --  CONSTRAINT `on_demand_feature_group_fk2` FOREIGN KEY (`on_demand_feature_group_id`) REFERENCES `on_demand_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
-                                --  CONSTRAINT `cached_feature_group_fk` FOREIGN KEY (`cached_feature_group_id`) REFERENCES `cached_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
-                                --  CONSTRAINT `stream_feature_group_fk` FOREIGN KEY (`stream_feature_group_id`) REFERENCES `stream_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
+                                 CONSTRAINT `FK_656_740` FOREIGN KEY (`feature_store_id`) REFERENCES `feature_store` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+                                 CONSTRAINT `on_demand_feature_group_fk2` FOREIGN KEY (`on_demand_feature_group_id`) REFERENCES `on_demand_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+                                 CONSTRAINT `cached_feature_group_fk` FOREIGN KEY (`cached_feature_group_id`) REFERENCES `cached_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+                                 CONSTRAINT `stream_feature_group_fk` FOREIGN KEY (`stream_feature_group_id`) REFERENCES `stream_feature_group` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION
 ) ENGINE=ndbcluster AUTO_INCREMENT=13 DEFAULT CHARSET=latin1 COLLATE=latin1_general_cs;
 
 CREATE TABLE `feature_view` (
@@ -431,6 +494,22 @@ VALUES
     ),
     (
         2085, 'sample_4', 66, Timestamp('2023-05-23 15:31:53'), 10000, 1, '', 250, 'sample_4_1', 250
+    ),
+    /**
+    SELECT `fg1`.`id1` `id1`, `fg1`.`ts` `ts`, `fg1`.`data1` `data1`, `fg1`.`data2` `data2`, `fg0`.`id1` `fg2_id1`, `fg0`.`ts` `fg2_ts`, `fg0`.`data1` `fg2_data1`, `fg0`.`data2` `fg2_data2`
+    FROM `test_ken`.`sample_1_1` `fg1`
+    INNER JOIN `test_ken`.`sample_2_1` `fg0` ON `fg1`.`id1` = `fg0`.`id1`
+    */
+    (
+	    3082, 'sample_1n2_label', 67, Timestamp('2023-06-05 13:13:35'), 10000, 1, '', 250, 'sample_1n2_label_1', 250
+    ),
+    /**
+    SELECT `fg1`.`data1` `data1`, `fg0`.`id1` `fg2_id1`, `fg0`.`ts` `fg2_ts`, `fg0`.`data1` `fg2_data1`, `fg0`.`data2` `fg2_data2`
+    FROM `test_ken`.`sample_1_1` `fg1`
+    INNER JOIN `test_ken`.`sample_2_1` `fg0` ON `fg1`.`id1` = `fg0`.`id1`
+    */
+    (
+        3083, 'sample_1n2_labelonly', 67, Timestamp('2023-06-05 13:15:14'), 10000, 1, '', 250, 'sample_1n2_labelonly_1', 250
     );
 
 INSERT INTO 
@@ -480,6 +559,18 @@ VALUES
     ),
     (
 	    2096, NULL, 2067, NULL, 0, 0, NULL, 2085
+    ),
+    (
+        3074, NULL, 2071, NULL, 0, 1, 'fg2_', 3082
+    ),
+    (
+        3075, NULL, 2069, NULL, 0, 0, NULL, 3082
+    ),
+    (
+        3076, NULL, 2069, NULL, 0, 0, NULL, 3083
+    ),
+    (
+        3077, NULL, 2071, NULL, 0, 1, 'fg2_', 3083
     );
 
 INSERT INTO
@@ -682,4 +773,43 @@ VALUES
     ),
     (
         2261, NULL, 2067, 'id2', 'string', 2096, 1, 0, NULL, 2085
+    ),
+    (
+        3077, NULL, 2069, 'data1', 'bigint', 3075, 2, 1, NULL, 3082
+    ),
+    (
+        3078, NULL, 2071, 'data2', 'string', 3074, 7, 0, NULL, 3082
+    ),
+    (
+        3080, NULL, 2069, 'ts', 'timestamp', 3075, 1, 0, NULL, 3082
+    ),
+    (
+        3081, NULL, 2069, 'data2', 'bigint', 3075, 3, 0, NULL, 3082
+    ),
+    (
+        3084, NULL, 2069, 'id1', 'bigint', 3075, 0, 0, NULL, 3082
+    ),
+    (
+        3087, NULL, 2071, 'data1', 'string', 3077, 3, 0, NULL, 3083
+    ),
+    (
+        3089, NULL, 2071, 'ts', 'date', 3077, 2, 0, NULL, 3083
+    ),
+    (
+        3079, NULL, 2071, 'ts', 'date', 3074, 5, 0, NULL, 3082
+    ),
+    (
+        3082, NULL, 2071, 'id1', 'bigint', 3074, 4, 0, NULL, 3082
+    ),
+    (
+        3083, NULL, 2071, 'data1', 'string', 3074, 6, 0, NULL, 3082
+    ),
+    (
+        3085, NULL, 2071, 'data2', 'string', 3077, 4, 0, NULL, 3083
+    ),
+    (
+        3086, NULL, 2071, 'id1', 'bigint', 3077, 1, 0, NULL, 3083
+    ),
+    (
+        3088, NULL, 2069, 'data1', 'bigint', 3076, 0, 1, NULL, 3083
     );


### PR DESCRIPTION
Changes:
1. Some features can be label which we do not want to return in the final feature vector. It is being removed now.
2. Before I assume that all primary key are selected in the feature set, but it is not always true. To be able to assign the primary key provided by users to the appropriate table in the rondb request, primary key columns of each table(feature group) are added to the metadata.