### PR TITLE
Catch rdrs go runtime error

### DIFF
--- a/storage/ndb/rest-server/rest-api-server/internal/handlers/handler.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/handlers/handler.go
@@ -36,10 +36,8 @@ func Handle(h Handler, apiKey *string, request interface{}, response interface{}
 		if r := recover(); r != nil {
 			statusCode = http.StatusInternalServerError
 			err = errors.New(`{"message": "Internal server error."}`)
-			if log.IsDebug() {
-				log.Debug(r.(error).Error())
-				log.Debug(string(debug.Stack()))
-			}
+			log.Error(r.(error).Error())
+			log.Error(string(debug.Stack()))
 		}
 	}()
 	if err := h.Validate(request); err != nil {

--- a/storage/ndb/rest-server/rest-api-server/internal/handlers/handler.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/handlers/handler.go
@@ -36,7 +36,7 @@ func Handle(h Handler, apiKey *string, request interface{}, response interface{}
 		if r := recover(); r != nil {
 			statusCode = http.StatusInternalServerError
 			err = errors.New(`{"message": "Internal server error."}`)
-			log.Error(r.(error).Error())
+			log.Errorf("%v", r)
 			log.Error(string(debug.Stack()))
 		}
 	}()


### PR DESCRIPTION
In general, when there are runtime errors, we should catch and log it and response with an error message.