### PR TITLE
RONDB-431: Bug#26974491 FIXES DATA RESTORE WITH DISABLE INDEXES

### DIFF
--- a/mysql-test/suite/ndb/r/ndb_fk_restore.result
+++ b/mysql-test/suite/ndb/r/ndb_fk_restore.result
@@ -537,3 +537,50 @@ drop table db1.t1, db2.t1;
 # cleanup
 drop database db1;
 drop database db2;
+# Bug#26974491 FIXES DATA RESTORE WITH DISABLE INDEXES
+create database db3;
+use db3;
+create table t4 (
+id int primary key auto_increment
+) engine=ndb;
+create table t5 (
+id int primary key auto_increment,
+val int,
+constraint fkt3t2 foreign key (val) references t4 (id)
+)engine=ndb;
+insert into t4 values (1), (2), (3), (4), (5);
+insert into t5 values (1,1), (2,2), (3,3), (4,4), (5,5);
+# take backup and drop the tables
+drop table db3.t5, db3.t4;
+# Create more tables before restore in order to verify that ndb_restore restores foreign keys
+# appropriately even though the table ids of parent and child tables which make up the name
+# of the foreign key in the format, <parent_table_id>/<child_table_id>/fk_name are different
+# in backup files than the table ids restored.
+create table db3.t6 (
+id int primary key auto_increment
+) engine=ndb;
+create table db3.t7 (
+id int primary key auto_increment
+) engine=ndb;
+create table db3.t8 (
+id int primary key auto_increment
+) engine=ndb;
+create table db3.t9 (
+id int primary key auto_increment
+) engine=ndb;
+# Use case #1: Meta restore done with --disable-indexes (recommended)
+# Drop the tables to retore them again with a different use case
+drop table db3.t5, db3.t4;
+# Use case #2: Separate --disable-indexes step after metadata restore
+# Drop the tables to retore them again with a different use case
+drop table db3.t5, db3.t4;
+# Use case #3: Data restore with --disable-indexes
+# Drop the tables to retore them again with a different use case
+drop table db3.t5, db3.t4;
+# Use case #4: Data restore with --disable-indexes and Data restore with --rebuild-indexes
+# Drop the tables to retore them again with a different use case
+drop table db3.t5, db3.t4;
+# Use case #5: Both metadata and data restore with both --disable-indexes and --rebuild-indexes
+# cleanup
+drop table db3.t6, db3.t7, db3.t8, db3.t9;
+drop database db3;

--- a/mysql-test/suite/ndb/t/ndb_fk_restore.test
+++ b/mysql-test/suite/ndb/t/ndb_fk_restore.test
@@ -211,5 +211,84 @@ drop table db1.t1, db2.t1;
 drop database db1;
 drop database db2;
 
+--echo # Bug#26974491 FIXES DATA RESTORE WITH DISABLE INDEXES
+create database db3;
+use db3;
+create table t4 (
+  id int primary key auto_increment
+) engine=ndb;
+create table t5 (
+  id int primary key auto_increment,
+  val int,
+  constraint fkt3t2 foreign key (val) references t4 (id)
+)engine=ndb;
+insert into t4 values (1), (2), (3), (4), (5);
+insert into t5 values (1,1), (2,2), (3,3), (4,4), (5,5);
+
+-- echo # take backup and drop the tables
+-- source include/ndb_backup.inc
+drop table db3.t5, db3.t4;
+
+-- echo # Create more tables before restore in order to verify that ndb_restore restores foreign keys
+-- echo # appropriately even though the table ids of parent and child tables which make up the name
+-- echo # of the foreign key in the format, <parent_table_id>/<child_table_id>/fk_name are different
+-- echo # in backup files than the table ids restored.
+create table db3.t6 (
+  id int primary key auto_increment
+) engine=ndb;
+create table db3.t7 (
+  id int primary key auto_increment
+) engine=ndb;
+create table db3.t8 (
+  id int primary key auto_increment
+) engine=ndb;
+create table db3.t9 (
+  id int primary key auto_increment
+) engine=ndb;
+
+-- echo # Use case #1: Meta restore done with --disable-indexes (recommended)
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 1 --restore-meta --print_meta --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 1 --restore-data $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 2 --restore-data $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 2 --rebuild-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+
+-- echo # Drop the tables to retore them again with a different use case
+drop table db3.t5, db3.t4;
+
+-- echo # Use case #2: Separate --disable-indexes step after metadata restore
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 1 --restore-meta --print_meta $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 1 --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 1 --restore-data --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 2 --restore-data --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 2 --rebuild-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+
+-- echo # Drop the tables to retore them again with a different use case
+drop table db3.t5, db3.t4;
+
+-- echo # Use case #3: Data restore with --disable-indexes
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 1 --restore-meta --print_meta $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 1 --restore-data --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 2 --restore-data --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 2 --rebuild-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+
+-- echo # Drop the tables to retore them again with a different use case
+drop table db3.t5, db3.t4;
+
+-- echo # Use case #4: Data restore with --disable-indexes and Data restore with --rebuild-indexes
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 1 --restore-meta --print_meta $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 1 --restore-data --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 2 --restore-data --rebuild-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+
+-- echo # Drop the tables to retore them again with a different use case
+drop table db3.t5, db3.t4;
+
+-- echo # Use case #5: Both metadata and data restore with both --disable-indexes and --rebuild-indexes
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 1 --restore-meta --restore-data --disable-indexes --rebuild-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --show-part-id -b $the_backup_id -n 2 --restore-data $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+
+--echo # cleanup
+drop table db3.t6, db3.t7, db3.t8, db3.t9;
+drop database db3;
+
 --source suite/ndb/include/backup_restore_cleanup.inc
 --remove_file $NDB_TOOLS_OUTPUT

--- a/storage/ndb/tools/restore/consumer_restore.cpp
+++ b/storage/ndb/tools/restore/consumer_restore.cpp
@@ -3354,6 +3354,43 @@ BackupRestore::fk(Uint32 type, const void * ptr)
       }
       m_fks.push_back(fk_ptr);
       restoreLogger.log_info("Save FK %s", fk_ptr->getName());
+
+      if (m_disable_indexes)
+      {
+        // Extract foreign key name from format
+        // like 10/14/fk1 where 10,14 are old table ids
+        const char *fkname = 0;
+        Vector<BaseString> splitname;
+        BaseString tmpname(fk_ptr->getName());
+        int n = tmpname.split(splitname, "/");
+        if (n == 3)
+        {
+          fkname = splitname[2].c_str();
+        }
+        else
+        {
+          restoreLogger.log_error("Invalid foreign key name %s",
+                                  tmpname.c_str());
+          return false;
+        }
+        NdbDictionary::ForeignKey fk;
+        char fullname[MAX_TAB_NAME_SIZE];
+        sprintf(fullname, "%d/%d/%s", parent->getObjectId(),
+                child->getObjectId(), fkname);
+
+        // Drop foreign keys if they exist
+        if (dict->getForeignKey(fk, fullname) == 0)
+        {
+          restoreLogger.log_info("Dropping Foreign key %s", fkname);
+          if (dict->dropForeignKey(fk) != 0)
+          {
+            restoreLogger.log_error("Failed to drop fk '%s' : %u %s",
+                                    fk_ptr->getName(), dict->getNdbError().code,
+                                    dict->getNdbError().message);
+            return false;
+          }
+        }
+      }
     }
     return true;
     break;
@@ -3449,11 +3486,21 @@ BackupRestore::endOfTables(){
     }
     else if (m_disable_indexes)
     {
-      int res = dict->dropIndex(idx->getName(), prim->getName());
-      if (res == 0)
+      // Drop indexes if they exist
+      if(dict->getIndex(idx->getName(), prim->getName()))
       {
-      restoreLogger.log_info("Dropped index `%s` on `%s`",
+        if (dict->dropIndex(idx->getName(), prim->getName()) == 0)
+        {
+          restoreLogger.log_info("Dropped index `%s` on `%s`",
             split_idx[3].c_str(), table_name.c_str());
+        }
+        else
+        {
+          restoreLogger.log_info("Failed to drop index `%s` on `%s`: %u %s",
+                                 split_idx[3].c_str(), table_name.c_str(),
+                                 dict->getNdbError().code,
+                                 dict->getNdbError().message);
+        }
       }
     }
     Uint32 id = prim->getObjectId();


### PR DESCRIPTION
Fixes ndb_restore to drop foreign keys when used with the option, --disable-indexes.

When metadata restore was done with --disable-indexes, there was no attempt to create indexes or foreign keys dependent on them. But, when ndb_restore was used without --disable-indexes during metadata restore, indexes and foreign keys were created. When the same option was used later while data restore, there was an attempt to drop the indexes created in the previous step. But, it ignored the failure of drop index step whenever there was a foreign key dependent on the index and there was no attempt to drop the foreign keys in the first place. This caused problems while rebuilding indexes when there was an attempt to create foreign keys which already exist.

So, ndb_restore is fixed
1) To actively drop the restored foreign keys described in the backup when --disable-indexes is set.
2) To check for the existence of indexes before they are attempted to be dropped.
The checks have been added so that data node restores with --disable-indexes option for subsequent data nodes doesn't attempt to drop the non existent indexes.

Also, ndb_fk_restore test has been updated with all the use cases involving all the possible combinations of options, --disable-indexes and --rebuild-indexes.

Change-Id: I4e9ced7df74a083ce1b0fbfcf584810a83c4d19c