### PR TITLE
RONDB-428: App 3.0->3.2 Postmortem fixes

### DIFF
--- a/mysql-test/suite/ndb/t/ndb_alter_table_column_online.test
+++ b/mysql-test/suite/ndb/t/ndb_alter_table_column_online.test
@@ -119,8 +119,8 @@ SELECT * FROM t1 ORDER BY a;
 
 DROP TABLE t1;
 
---exec $NDB_RESTORE -b $the_backup_id -n 1 -m -r --print_meta --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r --print_meta --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $the_backup_id -n 1 -m -r --print_meta --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $the_backup_id -n 2 -r --print_meta --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
 --exec $NDB_RESTORE -b $the_backup_id -n 1 --rebuild-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
 
 SELECT * FROM t1 ORDER BY a;

--- a/mysql-test/suite/ndb/t/ndb_backup_restore.inc
+++ b/mysql-test/suite/ndb/t/ndb_backup_restore.inc
@@ -149,10 +149,10 @@ if (!$serialrestore)
   --exec $NDB_RESTORE -b $the_backup_id -n 1 -m $NDB_BACKUPS-$the_backup_id/ >> $NDB_TOOLS_OUTPUT 2>&1
 
   --echo "Restoring backup on node 1"
-  --exec $NDB_RESTORE -b $the_backup_id -n 1 -r $NDB_BACKUPS-$the_backup_id/ >> $NDB_TOOLS_OUTPUT 2>&1
+  --exec $NDB_RESTORE --allow-unique-indexes -b $the_backup_id -n 1 -r $NDB_BACKUPS-$the_backup_id/ >> $NDB_TOOLS_OUTPUT 2>&1
 
   --echo "Restoring backup on node 2"
-  --exec $NDB_RESTORE -b $the_backup_id -n 2 -r $NDB_BACKUPS-$the_backup_id/ >> $NDB_TOOLS_OUTPUT 2>&1
+  --exec $NDB_RESTORE --allow-unique-indexes -b $the_backup_id -n 2 -r $NDB_BACKUPS-$the_backup_id/ >> $NDB_TOOLS_OUTPUT 2>&1
 }
 if ($serialrestore)
 {
@@ -163,7 +163,7 @@ if ($serialrestore)
   let $current_part = $backup_parts;
   while ($current_part)
   {
-    --exec $NDB_RESTORE -b $the_backup_id -n 1 -r $NDB_BACKUPS-$the_backup_id/BACKUP-$the_backup_id-PART-$current_part-OF-$backup_parts >> $NDB_TOOLS_OUTPUT 2>&1
+    --exec $NDB_RESTORE --allow-unique-indexes -b $the_backup_id -n 1 -r $NDB_BACKUPS-$the_backup_id/BACKUP-$the_backup_id-PART-$current_part-OF-$backup_parts >> $NDB_TOOLS_OUTPUT 2>&1
     dec $current_part;
   }
 
@@ -171,7 +171,7 @@ if ($serialrestore)
   let $current_part = $backup_parts;
   while ($current_part)
   {
-    --exec $NDB_RESTORE -b $the_backup_id -n 2 -r $NDB_BACKUPS-$the_backup_id/BACKUP-$the_backup_id-PART-$current_part-OF-$backup_parts >> $NDB_TOOLS_OUTPUT 2>&1
+    --exec $NDB_RESTORE --allow-unique-indexes -b $the_backup_id -n 2 -r $NDB_BACKUPS-$the_backup_id/BACKUP-$the_backup_id-PART-$current_part-OF-$backup_parts >> $NDB_TOOLS_OUTPUT 2>&1
     dec $current_part;
   }
 }

--- a/mysql-test/suite/ndb/t/ndb_fk_restore.inc
+++ b/mysql-test/suite/ndb/t/ndb_fk_restore.inc
@@ -47,8 +47,8 @@ if (!$disable_indexes2) {
 -- exec $NDB_RESTORE --verbose=255 -b $the_backup_id -n 1 -m --print_meta $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
 
 -- echo # restore data
--- exec $NDB_RESTORE --verbose=255 -b $the_backup_id -n 1 -r $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
--- exec $NDB_RESTORE --verbose=255 -b $the_backup_id -n 2 -r $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+-- exec $NDB_RESTORE --allow-unique-indexes --verbose=255 -b $the_backup_id -n 1 -r $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+-- exec $NDB_RESTORE --allow-unique-indexes --verbose=255 -b $the_backup_id -n 2 -r $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
 
 }
 
@@ -59,8 +59,8 @@ if ($disable_indexes2) {
 
 # option --disable-indexes should have no effect here but we imitate MCM
 -- echo # restore data (disable indexes)
--- exec $NDB_RESTORE --verbose=255 -b $the_backup_id -n 1 -r --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
--- exec $NDB_RESTORE --verbose=255 -b $the_backup_id -n 2 -r --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+-- exec $NDB_RESTORE --allow-unique-indexes --verbose=255 -b $the_backup_id -n 1 -r --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+-- exec $NDB_RESTORE --allow-unique-indexes --verbose=255 -b $the_backup_id -n 2 -r --disable-indexes $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
 
 }
 

--- a/mysql-test/suite/ndb/t/ndb_metadata_upgrade_80_minor.test
+++ b/mysql-test/suite/ndb/t/ndb_metadata_upgrade_80_minor.test
@@ -62,8 +62,8 @@
 # INSERT INTO t5 VALUES (1,'Lipstick on a pig');
 #
 
---exec $NDB_RESTORE -b 1 -n 1 -m -r --backup-path=$NDB_SAVED_BACKUPS/metadata_upgrade_80_minor >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b 1 -n 2 -r --backup-path=$NDB_SAVED_BACKUPS/metadata_upgrade_80_minor >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b 1 -n 1 -m -r --backup-path=$NDB_SAVED_BACKUPS/metadata_upgrade_80_minor >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b 1 -n 2 -r --backup-path=$NDB_SAVED_BACKUPS/metadata_upgrade_80_minor >> $NDB_TOOLS_OUTPUT
 
 --echo Backup restored
 

--- a/mysql-test/suite/ndb/t/ndb_metadata_upgrade_80_minor_fk.test
+++ b/mysql-test/suite/ndb/t/ndb_metadata_upgrade_80_minor_fk.test
@@ -43,8 +43,8 @@
 # INSERT INTO self_ref VALUES(1,1), (2,1);
 #
 
---exec $NDB_RESTORE -b 1 -n 1 -m -r --backup-path=$NDB_SAVED_BACKUPS/metadata_upgrade_80_minor_fk >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b 1 -n 2 -r --backup-path=$NDB_SAVED_BACKUPS/metadata_upgrade_80_minor_fk >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b 1 -n 1 -m -r --backup-path=$NDB_SAVED_BACKUPS/metadata_upgrade_80_minor_fk >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b 1 -n 2 -r --backup-path=$NDB_SAVED_BACKUPS/metadata_upgrade_80_minor_fk >> $NDB_TOOLS_OUTPUT
 
 --echo Backup restored
 

--- a/mysql-test/suite/ndb/t/ndb_metadata_upgrade_advanced.test
+++ b/mysql-test/suite/ndb/t/ndb_metadata_upgrade_advanced.test
@@ -42,8 +42,8 @@
 
 # Case 1: Metadata upgrade during schema synchronization
 
---exec $NDB_RESTORE -b 1 -n 1 -m -r --disable-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b 1 -n 2 -r $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b 1 -n 1 -m -r --disable-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b 1 -n 2 -r $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
 --exec $NDB_RESTORE -b 1 -n 1 --rebuild-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
 
 --echo Backup from 7.5 restored
@@ -94,8 +94,8 @@ DROP TABLE t3;
 
 # Case 2: Metadata upgrade during discovery from NDB
 
---exec $NDB_RESTORE -b 1 -n 1 -m -r --disable-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b 1 -n 2 -r $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b 1 -n 1 -m -r --disable-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b 1 -n 2 -r $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
 --exec $NDB_RESTORE -b 1 -n 1 --rebuild-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
 
 SHOW CREATE TABLE t1;
@@ -146,8 +146,8 @@ DROP TABLE t3;
 --let $initial_synced_count = query_get_value(SHOW STATUS LIKE 'Ndb_metadata_synced_count', Value, 1)
 
 --echo Restore metadata and data but do not create indexes
---exec $NDB_RESTORE -b 1 -n 1 -m -r --disable-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b 1 -n 2 -r $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b 1 -n 1 -m -r --disable-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b 1 -n 2 -r $NDB_SAVED_BACKUPS/metadata_upgrade_advanced_backup >> $NDB_TOOLS_OUTPUT
 
 --disable_query_log
 # Suppress expected warnings due to missing indexes

--- a/mysql-test/suite/ndb/t/ndb_metadata_upgrade_fk.test
+++ b/mysql-test/suite/ndb/t/ndb_metadata_upgrade_fk.test
@@ -42,8 +42,8 @@
 # INSERT INTO self_ref VALUES(1,1), (2,1);
 #
 
---exec $NDB_RESTORE -b 1 -n 1 -m -r --disable-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b 1 -n 2 -r $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b 1 -n 1 -m -r --disable-indexes --allow-unique-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b 1 -n 2 -r --allow-unique-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
 --exec $NDB_RESTORE -b 1 -n 1 --rebuild-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
 
 --echo Backup from 7.5 restored
@@ -111,8 +111,8 @@ DROP TABLE child;
 DROP TABLE parent;
 DROP TABLE self_ref;
 
---exec $NDB_RESTORE -b 1 -n 1 -m -r --disable-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b 1 -n 2 -r $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b 1 -n 1 -m -r --disable-indexes --allow-unique-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b 1 -n 2 -r --allow-unique-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
 --exec $NDB_RESTORE -b 1 -n 1 --rebuild-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
 
 --echo Backup from 7.5 restored
@@ -169,8 +169,8 @@ DROP TABLE child;
 DROP TABLE parent;
 DROP TABLE self_ref;
 
---exec $NDB_RESTORE -b 1 -n 1 -m -r --disable-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b 1 -n 2 -r $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b 1 -n 1 -m -r --disable-indexes --allow-unique-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b 1 -n 2 -r --allow-unique-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
 --exec $NDB_RESTORE -b 1 -n 1 --rebuild-indexes $NDB_SAVED_BACKUPS/metadata_upgrade_fk_backup >> $NDB_TOOLS_OUTPUT
 
 --echo Backup from 7.5 restored

--- a/mysql-test/suite/ndb/t/ndb_mt_backup_ldms.test
+++ b/mysql-test/suite/ndb/t/ndb_mt_backup_ldms.test
@@ -140,7 +140,7 @@ drop table t9;
 --enable_query_log
 
 --echo Restore metadata using backup-part 1
---exec $NDB_RESTORE -b $the_backup_id -n 1 -m $NDB_BACKUPS-$the_backup_id/BACKUP-$the_backup_id-PART-1-OF-2 >> $NDB_TOOLS_OUTPUT 2>&1
+--exec $NDB_RESTORE --allow-unique-indexes -b $the_backup_id -n 1 -m $NDB_BACKUPS-$the_backup_id/BACKUP-$the_backup_id-PART-1-OF-2 >> $NDB_TOOLS_OUTPUT 2>&1
 
 --echo Restore data by restoring all backup parts serially
 let $node = 6;
@@ -151,7 +151,7 @@ while ($node)
   while ($part)
   {
     --echo Restore data of PART-$part-OF-$ldms on node $node
-    --exec $NDB_RESTORE -b $the_backup_id -n $node -r $NDB_BACKUPS-$the_backup_id/BACKUP-$the_backup_id-PART-$part-OF-$ldms >> $NDB_TOOLS_OUTPUT 2>&1
+    --exec $NDB_RESTORE --allow-unique-indexes -b $the_backup_id -n $node -r $NDB_BACKUPS-$the_backup_id/BACKUP-$the_backup_id-PART-$part-OF-$ldms >> $NDB_TOOLS_OUTPUT 2>&1
     dec $part;
   }
   dec $node;
@@ -187,13 +187,13 @@ drop table t9;
 --enable_query_log
 
 --echo Restore metadata using mt-restore
---exec $NDB_RESTORE -b $the_backup_id -n 1 -m $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT 2>&1
+--exec $NDB_RESTORE --allow-unique-indexes -b $the_backup_id -n 1 -m $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT 2>&1
 
 --echo Restore data using mt-restore of all backup parts
 let $node = 6;
 while ($node)
 {
-  --exec $NDB_RESTORE -b $the_backup_id -n $node -r $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT 2>&1
+  --exec $NDB_RESTORE --allow-unique-indexes -b $the_backup_id -n $node -r $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT 2>&1
   dec $node;
 }
 

--- a/mysql-test/suite/ndb/t/ndb_restore_conv_pk_slice_remap.test
+++ b/mysql-test/suite/ndb/t/ndb_restore_conv_pk_slice_remap.test
@@ -436,14 +436,14 @@ create table type2_4 (entry_key bigint unsigned not null,
 
 --echo Run normal restore for first set of content
 # Varying #slices for fun
---exec $NDB_RESTORE -b $first_backup_id -n 1 -r --allow-pk-changes --num-slices=3 --slice-id=0 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $first_backup_id -n 1 -r --allow-pk-changes --num-slices=3 --slice-id=1 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $first_backup_id -n 1 -r --allow-pk-changes --num-slices=3 --slice-id=2 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $first_backup_id -n 1 -r --allow-pk-changes --num-slices=3 --slice-id=0 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $first_backup_id -n 1 -r --allow-pk-changes --num-slices=3 --slice-id=1 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $first_backup_id -n 1 -r --allow-pk-changes --num-slices=3 --slice-id=2 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
 
---exec $NDB_RESTORE -b $first_backup_id -n 2 -r --allow-pk-changes --num-slices=4 --slice-id=0 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $first_backup_id -n 2 -r --allow-pk-changes --num-slices=4 --slice-id=1 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $first_backup_id -n 2 -r --allow-pk-changes --num-slices=4 --slice-id=2 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $first_backup_id -n 2 -r --allow-pk-changes --num-slices=4 --slice-id=3 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $first_backup_id -n 2 -r --allow-pk-changes --num-slices=4 --slice-id=0 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $first_backup_id -n 2 -r --allow-pk-changes --num-slices=4 --slice-id=1 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $first_backup_id -n 2 -r --allow-pk-changes --num-slices=4 --slice-id=2 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $first_backup_id -n 2 -r --allow-pk-changes --num-slices=4 --slice-id=3 $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
 
 --let next_entry_key=query_get_value(select auto_increment from information_schema.tables where table_schema='test' and table_name='idx_tbl', AUTO_INCREMENT, 1)
 --let next_type2_1=query_get_value(select auto_increment from information_schema.tables where table_schema='test' and table_name='type2_1', AUTO_INCREMENT, 1)
@@ -467,16 +467,16 @@ create table type2_4 (entry_key bigint unsigned not null,
 --echo Remap args : $remap_args
 
 --echo Run offset restore for second set of content
---exec $NDB_RESTORE -b $second_backup_id -n 1 -r --allow-pk-changes --num-slices=5 --slice-id=0 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $second_backup_id -n 1 -r --allow-pk-changes --num-slices=5 --slice-id=1 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $second_backup_id -n 1 -r --allow-pk-changes --num-slices=5 --slice-id=2 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $second_backup_id -n 1 -r --allow-pk-changes --num-slices=5 --slice-id=3 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $second_backup_id -n 1 -r --allow-pk-changes --num-slices=5 --slice-id=4 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $second_backup_id -n 1 -r --allow-pk-changes --num-slices=5 --slice-id=0 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $second_backup_id -n 1 -r --allow-pk-changes --num-slices=5 --slice-id=1 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $second_backup_id -n 1 -r --allow-pk-changes --num-slices=5 --slice-id=2 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $second_backup_id -n 1 -r --allow-pk-changes --num-slices=5 --slice-id=3 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $second_backup_id -n 1 -r --allow-pk-changes --num-slices=5 --slice-id=4 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
 
 
---exec $NDB_RESTORE -b $second_backup_id -n 2 -r --allow-pk-changes --num-slices=3 --slice-id=0 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $second_backup_id -n 2 -r --allow-pk-changes --num-slices=3 --slice-id=1 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $second_backup_id -n 2 -r --allow-pk-changes --num-slices=3 --slice-id=2 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $second_backup_id -n 2 -r --allow-pk-changes --num-slices=3 --slice-id=0 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $second_backup_id -n 2 -r --allow-pk-changes --num-slices=3 --slice-id=1 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE --allow-unique-indexes -b $second_backup_id -n 2 -r --allow-pk-changes --num-slices=3 --slice-id=2 $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
 
 --echo Combined dataset
 --echo -----------------

--- a/mysql-test/suite/ndb/t/ndb_restore_conv_remap.test
+++ b/mysql-test/suite/ndb/t/ndb_restore_conv_remap.test
@@ -246,8 +246,8 @@ drop table idx_tbl, type1_1, type1_2, type2_1, type2_2;
 
 --echo Run normal restore for first set of content
 --exec $NDB_RESTORE -b $first_backup_id -n 1 -m $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $first_backup_id -n 1 -r $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $first_backup_id -n 2 -r $NDB_BACKUPS-$first_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $first_backup_id -n 1 -r $NDB_BACKUPS-$first_backup_id --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $first_backup_id -n 2 -r $NDB_BACKUPS-$first_backup_id --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 --source suite/ndb/include/ndb_sync_metadata.inc
 
@@ -266,8 +266,8 @@ drop table idx_tbl, type1_1, type1_2, type2_1, type2_2;
 --echo Remap args : $remap_args
 
 --echo Run offset restore for second set of content
---exec $NDB_RESTORE -b $second_backup_id -n 1 -r $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $second_backup_id -n 2 -r $remap_args $NDB_BACKUPS-$second_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $second_backup_id -n 1 -r $remap_args $NDB_BACKUPS-$second_backup_id --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $second_backup_id -n 2 -r $remap_args $NDB_BACKUPS-$second_backup_id --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 --echo Combined dataset
 --echo -----------------

--- a/mysql-test/suite/ndb/t/ndb_restore_indexbuild.test
+++ b/mysql-test/suite/ndb/t/ndb_restore_indexbuild.test
@@ -74,8 +74,8 @@ drop table t1;
 drop database dbfrom;
 
 --exec $NDB_RESTORE -n 1 -b $the_backup_id --disable-indexes --rewrite-database=dbfrom,dbto -m $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -n 1 -b $the_backup_id --rebuild-indexes --rewrite-database=dbfrom,dbto --exclude-missing-tables -r $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -n 2 -b $the_backup_id --rebuild-indexes --rewrite-database=dbfrom,dbto --exclude-missing-tables -r $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -n 1 -b $the_backup_id --rebuild-indexes --rewrite-database=dbfrom,dbto --exclude-missing-tables -r $NDB_BACKUPS-$the_backup_id --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -n 2 -b $the_backup_id --rebuild-indexes --rewrite-database=dbfrom,dbto --exclude-missing-tables -r $NDB_BACKUPS-$the_backup_id --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 create database dbto;
 use dbto;

--- a/mysql-test/suite/ndb/t/ndb_restore_schema_rewrites.test
+++ b/mysql-test/suite/ndb/t/ndb_restore_schema_rewrites.test
@@ -98,7 +98,7 @@ CREATE TABLE db2.t0_data ENGINE=MYISAM AS SELECT * FROM db2.t0;
 
 # command shortcuts, cover rebuilding of indexes
 --let $restore_cmd=$NDB_RESTORE
---let $restore_cmd=$restore_cmd --disable-indexes --rebuild-indexes
+--let $restore_cmd=$restore_cmd --disable-indexes --rebuild-indexes --allow-unique-indexes
 --let $restore_cmd=$restore_cmd -b $the_backup_id -r
 --let $restore_cmd=$restore_cmd --backup_path=$NDB_BACKUPS-$the_backup_id
 

--- a/mysql-test/suite/ndb/t/ndb_restore_schema_subsets.test
+++ b/mysql-test/suite/ndb/t/ndb_restore_schema_subsets.test
@@ -64,8 +64,8 @@ SET GLOBAL ndb_metadata_check = false;
 --echo Check various include/exclude variants
 --echo **************************************
 --echo Normal full restore
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 use db1;
 # checksum table tab1, tab2;
@@ -82,8 +82,8 @@ drop table db1.tab1, db1.tab2, db2.tab1, db2.tab2;
 --echo ****************
 --echo Include only db2
 --echo ****************
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --include-databases db2>> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --include-databases db2 >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --include-databases db2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --include-databases db2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 use db1;
 --error ER_NO_SUCH_TABLE
@@ -100,8 +100,8 @@ drop table db2.tab1, db2.tab2;
 --echo ****************
 --echo Exclude only db2
 --echo ****************
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-databases db2>> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-databases db2 >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-databases db2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-databases db2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 use db1;
 # checksum table tab1, tab2;
@@ -119,7 +119,7 @@ drop table db1.tab1, db1.tab2;
 --echo ************
 --echo Exclude both
 --echo ************
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-databases db2,db1>> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-databases db2,db1 >> $NDB_TOOLS_OUTPUT
 --exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-databases db2,db1 >> $NDB_TOOLS_OUTPUT
 
 use db1;
@@ -137,8 +137,8 @@ show create table tab2;
 --echo Include only db1.tab1 and db2.tab2
 --echo **********************************
 
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --include-tables db1.tab1,db2.tab2 >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --include-tables db1.tab1,db2.tab2 >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --include-tables db1.tab1,db2.tab2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --include-tables db1.tab1,db2.tab2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 use db1;
 --error ER_NO_SUCH_TABLE
@@ -159,8 +159,8 @@ drop table db1.tab1, db2.tab2;
 --echo Exclude db1.tab1 and db2.tab2
 --echo *****************************
 --echo Should result in db1.tab2 and db2.tab1 being restored
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-tables db1.tab1,db2.tab2 >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-tables db1.tab1,db2.tab2 >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-tables db1.tab1,db2.tab2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-tables db1.tab1,db2.tab2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 use db1;
 --error ER_NO_SUCH_TABLE
@@ -182,7 +182,7 @@ drop table db1.tab2, db2.tab1;
 
 --echo Should result in only db1.tab1 being restored
 --exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-databases db1 --include-tables db1.tab1 >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id  --exclude-databases db1 --include-tables db1.tab1>> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-databases db1 --include-tables db1.tab1 >> $NDB_TOOLS_OUTPUT
 
 use db1;
 --error ER_NO_SUCH_TABLE
@@ -202,8 +202,8 @@ drop table db1.tab1;
 --echo Exclude db1.tab1, but include db1
 --echo *********************************
 --echo Should result in only db1.tab2 being restored
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id  --include-databases db1 --exclude-tables db1.tab1 >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id  --include-databases db1 --exclude_tables db1.tab1 >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --include-databases db1 --exclude-tables db1.tab1 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --include-databases db1 --exclude_tables db1.tab1 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 use db1;
 --error ER_NO_SUCH_TABLE
@@ -244,8 +244,8 @@ drop table db1.tab1;
 --echo Exclude db2, and include db2
 --echo ****************************
 --echo Should result in db2 only restored.
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-databases db2 --include-databases db2 >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-databases db2 --include-databases db2 >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-databases db2 --include-databases db2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-databases db2 --include-databases db2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 use db1;
 --error ER_NO_SUCH_TABLE
@@ -263,8 +263,8 @@ drop table db2.tab1, db2.tab2;
 --echo Include db1, and include db2.tab1
 --echo *********************************
 --echo Should result in all tables in db1 and db2.tab1 being restored.
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --include-databases db1 --include-tables db2.tab1 >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --include-databases db1 --include-tables db2.tab1 >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --include-databases db1 --include-tables db2.tab1 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --include-databases db1 --include-tables db2.tab1 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 use db1;
 show create table tab1;
@@ -301,8 +301,8 @@ show create table tab2;
 --echo Exclude unknown table
 --echo *********************
 --echo Should result in everything restored
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-tables db1.unhappy_customer >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-tables db1.unhappy_customer >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-tables db1.unhappy_customer --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-tables db1.unhappy_customer --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 show databases like "db%";
 
@@ -322,8 +322,8 @@ drop table db2.tab1, db2.tab2;
 --echo Check accumulative include arguments
 --echo ************************************
 --echo Should result in both db1.tab1 and db1.tab2 restored.
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --include-tables db1.tab1 --include-tables db1.tab2 >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --include-tables db1.tab1 --include-tables db1.tab2 >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --include-tables db1.tab1 --include-tables db1.tab2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --include-tables db1.tab1 --include-tables db1.tab2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 use db1;
 show create table tab1;
@@ -342,8 +342,8 @@ drop table db1.tab1, db1.tab2;
 --echo Check accumulative exclude arguments
 --echo ************************************
 --echo Should result in both db2.tab1 and db2.tab2 restored.
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-tables db1.tab1 --exclude-tables db1.tab2 >> $NDB_TOOLS_OUTPUT
---exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-tables db1.tab1 --exclude-tables db1.tab2 >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r -m  $NDB_BACKUPS-$the_backup_id --exclude-tables db1.tab1 --exclude-tables db1.tab2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
+--exec $NDB_RESTORE -b $the_backup_id -n 2 -r     $NDB_BACKUPS-$the_backup_id --exclude-tables db1.tab1 --exclude-tables db1.tab2 --allow-unique-indexes >> $NDB_TOOLS_OUTPUT
 
 use db1;
 --error ER_NO_SUCH_TABLE

--- a/mysql-test/suite/ndb/t/ndb_restore_schema_tolerance.test
+++ b/mysql-test/suite/ndb/t/ndb_restore_schema_tolerance.test
@@ -250,7 +250,7 @@ drop table test.t1;
 --source suite/ndb/include/ndb_restore_check_warn.inc
 
 --echo # restore data : should warn since unique indexes to be restored
---exec $NDB_RESTORE -b $the_backup_id -n 1 -r $NDB_BACKUPS-$the_backup_id > $dump_file 2>&1
+--exec $NDB_RESTORE -b $the_backup_id -n 1 -r $NDB_BACKUPS-$the_backup_id --allow-unique-indexes > $dump_file 2>&1
 --source suite/ndb/include/ndb_restore_check_warn.inc
 
 --echo # restore epoch : should not warn

--- a/storage/ndb/tools/restore/Restore.hpp
+++ b/storage/ndb/tools/restore/Restore.hpp
@@ -676,7 +676,6 @@ public:
          ATTRIBUTE_FORMAT(printf, 2, 3);
   void setThreadPrefix(const char* prefix);
   const char* getThreadPrefix() const;
-private:
   NdbMutex *m_mutex;
 };
 
@@ -684,6 +683,7 @@ NdbOut& operator<<(NdbOut& ndbout, const TableS&);
 NdbOut& operator<<(NdbOut& ndbout, const TupleS&);
 NdbOut& operator<<(NdbOut& ndbout, const LogEntry&);
 NdbOut& operator<<(NdbOut& ndbout, const RestoreMetaData&);
+NdbOut& operator<<(NdbOut& ndbout, const AttributeS&);
 
 bool readSYSTAB_0(const TupleS & tup, Uint32 * syskey, Uint64 * nextid);
 

--- a/storage/ndb/tools/restore/consumer.hpp
+++ b/storage/ndb/tools/restore/consumer.hpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -67,6 +68,7 @@ public:
   NODE_GROUP_MAP *m_nodegroup_map;
   uint            m_nodegroup_map_len;
   virtual bool has_temp_error() {return false;}
+  virtual bool has_data_error() {return false;}
   virtual bool table_equal(const TableS &) { return true; }
   virtual bool table_compatible_check(TableS &) {return true;}
   virtual bool check_blobs(TableS &) {return true;}

--- a/storage/ndb/tools/restore/consumer_restore.cpp
+++ b/storage/ndb/tools/restore/consumer_restore.cpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2004, 2020, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -4034,15 +4035,19 @@ void BackupRestore::cback(int result, restore_callback_t *cb)
       tuple_a(cb); // retry
     else
     {
-      restoreLogger.log_error("Restore: Failed to restore data due to a unrecoverable error. Exiting...");
+      restoreLogger.log_error("Restore: Failed to restore data due to an "
+                              "unrecoverable error. Exiting...");
       cb->next = m_free_callback;
       m_free_callback = cb;
+      set_fatal_error(true);
       return;
     }
   }
   else if (get_fatal_error()) // fatal error in other restore-thread
   {
-    restoreLogger.log_error("Restore: Failed to restore data due to a unrecoverable error. Exiting...");
+    restoreLogger.log_error("Restore: Failed to restore data due to an "
+                            "unrecoverable error in another restore thread. "
+                            "Exiting...");
     cb->next = m_free_callback;
     m_free_callback = cb;
     return;

--- a/storage/ndb/tools/restore/consumer_restore.cpp
+++ b/storage/ndb/tools/restore/consumer_restore.cpp
@@ -4067,7 +4067,7 @@ void BackupRestore::cback(int result, restore_callback_t *cb)
       {
         restoreLogger.log_error("Restore: Failed to restore data due to an "
                                 "unrecoverable error. Will continue due to "
-                                "--continue-on-data-errors.");
+                                "--continue-on-data-errors being set.");
       }
       else
       {
@@ -4884,7 +4884,8 @@ void BackupRestore::cback_logentry(int result, restore_callback_t *cb)
       {
         restoreLogger.log_error("Restore: Failed to restore data from a log "
                                 "entry due to an unrecoverable error. Will "
-                                "continue due to  --continue-on-data-errors.");
+                                "continue due to --continue-on-data-errors "
+                                "being set.");
       }
       else
       {

--- a/storage/ndb/tools/restore/consumer_restore.hpp
+++ b/storage/ndb/tools/restore/consumer_restore.hpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2004, 2020, Oracle and/or its affiliates.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -69,7 +70,8 @@ public:
                 Uint32 parallelism) :
     m_ndb(NULL),
     m_cluster_connection(conn),
-    m_fatal_error(false)
+    m_fatal_error(false),
+    m_data_error(false)
 #ifdef ERROR_INSERT
     ,m_error_insert(0)
 #endif
@@ -226,6 +228,8 @@ public:
                             Uint64 next_val);
   bool get_fatal_error();
   void set_fatal_error(bool);
+  bool has_data_error() override;
+  void set_data_error(bool);
 
   Ndb * m_ndb;
   Ndb_cluster_connection * m_cluster_connection;
@@ -273,6 +277,7 @@ public:
   bool m_temp_error;
   Uint64 m_pk_update_warning_count;
   bool m_fatal_error;
+  bool m_data_error;
 
   /**
    * m_new_table_ids[X] = Y;

--- a/storage/ndb/tools/restore/consumer_restore.hpp
+++ b/storage/ndb/tools/restore/consumer_restore.hpp
@@ -118,6 +118,8 @@ public:
   void tuple_free() override;
   virtual void tuple_a(restore_callback_t *cb);
   virtual void tuple_SYSTAB_0(restore_callback_t *cb, const TableS &);
+  void logErrorWithTuple(const char* prefix, TupleS const *tup);
+  void logErrorWithLogEntry(const char* prefix, LogEntry const *le);
   virtual void cback(int result, restore_callback_t *cb);
   virtual void cback_logentry(int result, restore_callback_t *cb);
   virtual bool errorHandler(restore_callback_t *cb);

--- a/storage/ndb/tools/restore/consumer_restorem.cpp
+++ b/storage/ndb/tools/restore/consumer_restorem.cpp
@@ -1,5 +1,6 @@
 /*
    Copyright (C) 2004-2006 MySQL AB, 2009 Sun Microsystems, Inc.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
    Use is subject to license terms.
 
    This program is free software; you can redistribute it and/or modify
@@ -25,6 +26,8 @@
 
 #include "consumer_restore.hpp"
 #include <NdbSleep.h>
+
+#error This file should not be built. Many issues are unaddressed here, including but not limited to RONDB-428.
 
 extern FilteredNdbOut err;
 extern FilteredNdbOut info;

--- a/storage/ndb/tools/restore/restore_main.cpp
+++ b/storage/ndb/tools/restore/restore_main.cpp
@@ -145,6 +145,7 @@ static bool _preserve_trailing_spaces = false;
 static bool ga_disable_indexes = false;
 static bool ga_rebuild_indexes = false;
 bool ga_continue_on_data_errors = false;
+bool ga_allow_unique_indexes = false;
 bool ga_skip_unknown_objects = false;
 bool ga_skip_broken_objects = false;
 bool ga_allow_pk_changes = false;
@@ -460,6 +461,12 @@ static struct my_option my_long_options[] =
     "Continue after failing to restore data",
     (uchar**) &ga_continue_on_data_errors,
     (uchar**) &ga_continue_on_data_errors, 0,
+    GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0 },
+  { "allow-unique-indexes", NDB_OPT_NOSHORT,
+    "Attempt to restore despite unique indexes are present and risk causing "
+    "duplicate key errors",
+    (uchar**) &ga_allow_unique_indexes,
+    (uchar**) &ga_allow_unique_indexes, 0,
     GET_BOOL, NO_ARG, 0, 0, 0, 0, 0, 0 },
   { "skip-unknown-objects", 256, "Skip unknown object when parsing backup",
     (uchar**) &ga_skip_unknown_objects, (uchar**) &ga_skip_unknown_objects, 0,
@@ -3119,6 +3126,8 @@ main(int argc, char** argv)
     g_options.append(" --disable-indexes");
   if (ga_continue_on_data_errors)
     g_options.append(" --continue-on-data-errors");
+  if (ga_allow_unique_indexes)
+    g_options.append(" --allow-unique-indexes");
   if (ga_rebuild_indexes)
     g_options.append(" --rebuild-indexes");
   g_options.appfmt(" -p %d", ga_nParallelism);


### PR DESCRIPTION
I have tested these changes manually, and everything seems to work as expected. However,
* I have not been able to test the duplicate key error that was seen in production. Instead, I got an out of memory error that seems to result in the exact same code path in `ndb_restore`.
* There are at least 5 automatic tests that fail, presumably because the `ndb_restore` has changed its CLI interface and error messages.
  * ndb.ndb_restore_conv_remap
  * ndb.ndb_restore_schema_rewrites
  * ndb.ndb_restore_schema_subsets
  * ndb.ndb_restore_indexbuild
  * ndb.ndb_restore_schema_tolerance