### PR TITLE
RONDB-459: Fix for deactivate nodes

### DIFF
--- a/mysql-test/test_activate_rondb/config.ini
+++ b/mysql-test/test_activate_rondb/config.ini
@@ -11,11 +11,11 @@ TotalMemoryConfig=6G
 NoOfReplicas=3
 [MYSQLD DEFAULT]
 [NDB_MGMD]
-Hostname=192.168.0.101
+Hostname=192.168.0.103
 NodeId=65
 PortNumber=1186
 [NDB_MGMD]
-Hostname=192.168.0.104
+Hostname=192.168.0.103
 NodeId=66
 PortNumber=1187
 NodeActive=0

--- a/mysql-test/test_activate_rondb/test_execute.sh
+++ b/mysql-test/test_activate_rondb/test_execute.sh
@@ -1,7 +1,7 @@
 SLEEP_TIME="3"
 SLEEP_START_TIME="60"
 SLEEP_STOP_TIME="20"
-HOSTNAME_SERVER="192.168.0.101"
+HOSTNAME_SERVER="192.168.0.103"
 rm -rf $HOME/test_activate/ndb
 mkdir -p $HOME/test_activate
 mkdir -p $HOME/test_activate/ndb

--- a/storage/ndb/src/mgmclient/CommandInterpreter.cpp
+++ b/storage/ndb/src/mgmclient/CommandInterpreter.cpp
@@ -2350,6 +2350,40 @@ CommandInterpreter::executeStop(Vector<BaseString> &command_list,
     return -1;
   }
 
+  if (no_of_nodes > 0)
+  {
+    /* Check that nodes to stop are not already deactivated */
+    ndb_mgm_configuration * conf = ndb_mgm_get_configuration(m_mgmsrv,0);
+    if (conf == 0)
+    {
+      ndbout_c("Could not get configuration");
+      printError();
+      return -1;
+    }
+
+    for (Uint32 i = 0; i < no_of_nodes; i++)
+    {
+      int nodeId = node_ids[i];
+      ConfigValues::Iterator iter(conf->m_config);
+      bool ret = get_node_section(iter, nodeId, 0);
+      if (!ret)
+      {
+        printError();
+        ndbout_c("Failed to get configuration of node %d", nodeId);
+        ndb_mgm_destroy_configuration(conf);
+        return -1;
+      }
+      Uint32 is_active = 1;
+      iter.get(CFG_NODE_ACTIVE, &is_active);
+      if (!is_active)
+      {
+        ndbout_c("Node %d is deactivated, is already stopped",
+                 nodeId);
+        ndb_mgm_destroy_configuration(conf);
+        return -1;
+      }
+    }
+  }
   int result= ndb_mgm_stop4(m_mgmsrv, no_of_nodes, node_ids, abort,
                             force, &need_disconnect);
   if (result < 0)

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.hpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.hpp
@@ -429,7 +429,8 @@ private:
                    bool stop,
                    bool restart,
                    bool nostart,
-                   bool initialStart);
+                   bool initialStart,
+                   bool isShutdown);
 
   int sendall_STOP_REQ(NodeBitmask &stoppedNodes,
                        bool abort,


### PR DESCRIPTION
The method sendStopMgmd is used for both shutdown and stop of nodes. When deactivating a node we stop the node after deactivating it. In the case of deactivation of a MGM server we thus need to ensure that we stop a node even if it is deactivated since it is part of the deactivation. This required a new parameter to sendStopMgmd to decide whether to handle stop of deactivated nodes or not.

Added checks that we don't stop deactivated nodes, they should already be stopped.