### PR TITLE
RONDB-342: Remove require for use of new hash function

### DIFF
--- a/storage/ndb/src/common/debugger/signaldata/DictTabInfo.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/DictTabInfo.cpp
@@ -210,6 +210,7 @@ DictTabInfo::Table::init(){
   FullyReplicatedTriggerId = RNIL;
   PartitionCount = 0;
   HashFunctionFlag = 0;
+  UseVarSizedDiskDataFlag = 0;
 }
 
 void

--- a/storage/ndb/src/common/util/rondb_hash.cpp
+++ b/storage/ndb/src/common/util/rondb_hash.cpp
@@ -37,7 +37,6 @@ rondb_calc_hash(Uint32 hash_val[4],
   if (likely(use_new))
   {
     Uint64 hash;
-    require(false);
     hash = rondb_xxhash_std(key, keylen);
     hash_val[0] = hash & 0xFFFFFFFF;
     hash_val[1] = hash >> 32;


### PR DESCRIPTION
Added initialisation of DictTabInfo object of both HashFunctionFlag and UseVarSizeDiskDataFlag. This is important to ensure that they have a well defined value if creating tables from an NDB API using version 21.04.14. Otherwise those versions would get a random setting of this variable.