### PR TITLE
RONDB-473: Fix of initialisation of transaction hash in DBLQH

### DIFF
--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhInit.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhInit.cpp
@@ -180,7 +180,7 @@ void Dblqh::initData()
   m_startup_report_frequency = 0;
 
   c_active_add_frag_ptr_i = RNIL;
-  for (Uint32 i = 0; i < 4096; i++) {
+  for (Uint32 i = 0; i < TRANSID_HASH_SIZE; i++) {
     ctransidHash[i] = RNIL;
   }//for
 


### PR DESCRIPTION
Dblqh.hpp initialised using a defined constant
DblqhInit.cpp initialised using a hardcoded value. Fixed such that DblqhInit.cpp also uses defined constant.