### PR TITLE
RONDB-537 Bugfix in setNeighbourNode

### DIFF
--- a/storage/ndb/src/kernel/vm/mt.cpp
+++ b/storage/ndb/src/kernel/vm/mt.cpp
@@ -2536,6 +2536,7 @@ public:
             }
             break;
           }
+          prev_trp_id = next_trp_id;
           next_trp_id = m_trp_state[next_trp_id].m_next;
         }
         require(found);


### PR DESCRIPTION
Description:
  In the setNeighbourNode() function, when removing a new neighbor transporter
  from the non-neighbor transport list, the prev_trp_id isn't updated correctly.