### PR TITLE
RONDB-552: Make OS overhead configurable

### DIFF
--- a/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
+++ b/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
@@ -267,6 +267,8 @@
 #define CFG_DB_NUM_CPUS               676
 #define CFG_DB_AUTO_THREAD_CONFIG     677
 
+#define CFG_DB_OS_STATIC_OVERHEAD     694
+#define CFG_DB_OS_CPU_OVERHEAD        695
 #define CFG_DB_LOW_LATENCY            696
 #define CFG_DB_UNDO_BUFFER            697
 #define CFG_DB_TOTAL_MEMORY_CONFIG    698

--- a/storage/ndb/src/kernel/vm/Configuration.cpp
+++ b/storage/ndb/src/kernel/vm/Configuration.cpp
@@ -935,7 +935,9 @@ Configuration::get_and_set_long_message_buffer(
 }
 
 Uint64
-Configuration::compute_os_overhead(Uint64 total_memory)
+Configuration::compute_os_overhead(
+  Uint64 total_memory,
+  const ndb_mgm_configuration_iterator *p)
 {
   /**
    * This includes memory used by the OS for all sorts of internal operations.
@@ -952,10 +954,21 @@ Configuration::compute_os_overhead(Uint64 total_memory)
    * We remove 1% of the total memory, 100 MBytes per thread, in addition
    * we remove 1.4 GByte to handle smaller VM sizes.
    */
+  Uint64 os_static_overhead = 0;
+  ndb_mgm_get_int64_parameter(p, CFG_DB_OS_STATIC_OVERHEAD, &os_static_overhead);
+  Uint64 os_cpu_overhead = 0;
+  ndb_mgm_get_int64_parameter(p, CFG_DB_OS_CPU_OVERHEAD, &os_cpu_overhead);
+  if (os_static_overhead == 0)
+  {
+    os_static_overhead = Uint64(1400) * MBYTE64;
+  }
+  if (os_cpu_overhead == 0)
+  {
+    os_cpu_overhead = Uint64(100) * MBYTE64;
+  }
   Uint64 reserved_part = total_memory / Uint64(100);
   Uint32 num_threads = get_num_threads() + globalData.ndbMtRecoverThreads;
-  Uint64 os_static_overhead = Uint64(1400) * MBYTE64;
-  Uint64 os_cpu_overhead = Uint64(num_threads) * Uint64(100) * MBYTE64;
+  os_cpu_overhead *= Uint64(num_threads);
   return os_static_overhead + os_cpu_overhead + reserved_part;
 }
 
@@ -1121,7 +1134,7 @@ Configuration::calculate_automatic_memory(ndb_mgm_configuration_iterator *p)
   Uint64 os_overhead = 0;
   if (!total_memory_set)
   {
-    os_overhead = compute_os_overhead(total_memory);
+    os_overhead = compute_os_overhead(total_memory, p);
   }
   Uint64 send_buffer = get_send_buffer(p);
   Uint64 backup_page_memory = compute_backup_page_memory(p);

--- a/storage/ndb/src/kernel/vm/Configuration.hpp
+++ b/storage/ndb/src/kernel/vm/Configuration.hpp
@@ -213,7 +213,9 @@ private:
            const ndb_mgm_configuration_iterator *p);
   static Uint64 get_and_set_long_message_buffer(
            const ndb_mgm_configuration_iterator *p);
-  static Uint64 compute_os_overhead(Uint64 total_memory);
+  static Uint64 compute_os_overhead(
+    Uint64 total_memory,
+    const ndb_mgm_configuration_iterator *p);
   static Uint64 compute_static_overhead();
   static Uint64 compute_backup_page_memory(
                   const ndb_mgm_configuration_iterator *p);

--- a/storage/ndb/src/mgmsrv/ConfigInfo.cpp
+++ b/storage/ndb/src/mgmsrv/ConfigInfo.cpp
@@ -1013,15 +1013,27 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     "true" },
 
   {
-    CFG_DB_TOTAL_MEMORY_CONFIG,
-    "TotalMemoryConfig",
+    CFG_DB_OS_STATIC_OVERHEAD,
+    "OsStaticOverhead",
     DB_TOKEN,
-    "Specific amount of memory used",
+    "Avoid using this amount of memory by data node",
     ConfigInfo::CI_USED,
     false,
     ConfigInfo::CI_INT64,
-    "0",
-    "2G",
+    "1400M",
+    "400M",
+    "65536G" },
+
+  {
+    CFG_DB_OS_CPU_OVERHEAD,
+    "OsCpuOverhead",
+    DB_TOKEN,
+    "Avoid using this amount of memory multiplied by number of CPUs",
+    ConfigInfo::CI_USED,
+    false,
+    ConfigInfo::CI_INT64,
+    "100M",
+    "50M",
     "65536G" },
 
   {


### PR DESCRIPTION
Two new configuration parameters were introduced.
OsStaticOverhead and OsCpuOverhead

These variables are used to calculate OS overhead when calculating automatic memory. When using AutomaticMemoryConfig there are two modes, one is to set TotalMemoryConfig, in this case the user has decided how much the total memory should be and this is used and those parameters are ignored.

If the user has set to TotalMemoryConfig to 0 or simply not set it, then the calculation will be based on the amount of memory in the computer/VM/container it runs in. The default settings in this case is intended for a setup in a VM where the data nodes can use the entire VM except for some small processes used to monitor and change the cluster.

However in some cases the user might need to run also some heavier processes in their VM, in this case it is possible to increase either OsStaticOverhead or OsCpuOverhead or both.

OsCpuOverhead is multiplied by the number of CPUs.

It is necessary to leave memory both for the OS itself and for OS kernel buffers and for any applications that need to coexist with RonDB.

The default setting on OsStaticOverhead is 1400M and the default setting of OsCpuOverhead is 100M. In addition we will always avoid using 1% of the memory size.

Thus by default a node with 16 VCPUs and 128GB of memory will have OS overhead computed 1280M + 1400M + 16 * 100M = 4280M. Thus we will almost 124GB of memory for the data node in this case.

OsStaticOverhead cannot be decreased below 400M and OsCpuOverhead cannot be decreased below 50M.