### PR TITLE
RONDB-556: All block threads can become query workers

### DIFF
--- a/mysql-test/include/default_ndbd.cnf
+++ b/mysql-test/include/default_ndbd.cnf
@@ -49,7 +49,7 @@ DiskIOThreadPool=1
 #
 # (Option is ignored for non-MT'ed NDB)
 #
-ThreadConfig=main={count=1},tc={count=3},ldm={count=4},recover={count=2},io={count=1},rep={count=1},recv={count=2},send={count=2}
+ThreadConfig=main={count=1},tc={count=3},ldm={count=4},io={count=1},rep={count=1},recv={count=2},send={count=2}
 
 [api]
 UseOnlyIPv4=1

--- a/mysql-test/suite/ndb/r/ndbinfo_plans.result
+++ b/mysql-test/suite/ndb/r/ndbinfo_plans.result
@@ -64,7 +64,7 @@ ndb$backup_id	1	20
 ndb$blocks	30	20
 ndb$columns	540	44
 ndb$config_nodes	34	28
-ndb$config_params	177	120
+ndb$config_params	179	120
 ndb$config_values	344	24
 ndb$counters	200	24
 ndb$dblqh_tcconnect_state	19	52
@@ -105,8 +105,8 @@ ndb$tables	51	40
 ndb$tc_time_track_stats	384	104
 ndb$test	8000	24
 ndb$threadblocks	126	16
-ndb$threads	30	40
-ndb$threadstat	26	144
+ndb$threads	26	40
+ndb$threadstat	22	144
 ndb$transactions	5	44
 ndb$transporters	32	64
 

--- a/mysql-test/suite/ndb/t/ndb_blob_big.cnf
+++ b/mysql-test/suite/ndb/t/ndb_blob_big.cnf
@@ -3,7 +3,7 @@
 [cluster_config]
 # Bigger (imaginary) Redo space
 Diskless=1
-ThreadConfig=ldm={count=1},main={count=0},rep={count=0},tc={count=0},query={count=0},recv={count=1}
+ThreadConfig=ldm={count=1},main={count=0},rep={count=0},tc={count=0},recv={count=1}
 NoOfFragmentLogFiles = 64
 FragmentLogFileSize = 48M
 MinFreePct = 0

--- a/storage/ndb/include/kernel/BlockThreadBitmask.hpp
+++ b/storage/ndb/include/kernel/BlockThreadBitmask.hpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2019, 2023, Oracle and/or its affiliates.
+   Copyright (c) 2023, 2023, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -32,10 +33,7 @@
 
 #define JAM_FILE_ID 513
 
-static constexpr Uint32 NDB_MAX_BLOCK_THREADS = NDBMT_MAIN_THREADS +
-                                                MAX_NDBMT_TC_THREADS +
-                                                MAX_NDBMT_RECEIVE_THREADS +
-                                                MAX_NDBMT_LQH_THREADS;
+static constexpr Uint32 NDB_MAX_BLOCK_THREADS = NDBMT_MAX_BLOCK_INSTANCES;
 
 static constexpr Uint32 NDB_BLOCK_THREAD_BITMASK_SIZE =
     ndb_ceil_div(NDB_MAX_BLOCK_THREADS, 32U);

--- a/storage/ndb/include/kernel/ndb_limits.h
+++ b/storage/ndb/include/kernel/ndb_limits.h
@@ -46,10 +46,10 @@
 #define MAX_BACKUPS   0xFFFFFFFF
 #define MAX_INSTANCE_KEYS 1024
 #define MAX_NUM_CPUS 2500
-#define MAX_USED_NUM_CPUS 1024
+#define MAX_USED_NUM_CPUS 800
 #define MAX_QUERY_THREAD_PER_LDM 3
 #define MIN_RR_GROUP_SIZE 4
-#define MAX_RR_GROUP_SIZE 8
+#define MAX_RR_GROUP_SIZE 16
 
 /**************************************************************************
  * IT SHOULD BE (MAX_NDB_NODES - 1).
@@ -314,41 +314,20 @@
 
 #define NDBMT_MAIN_THREADS         2 /* Without receiver threads */
 
-#if NDB_VERSION_D < NDB_MAKE_VERSION(7,2,0)
-#define NDB_MAX_LOG_PARTS          4
-#define MAX_NDBMT_TC_THREADS       2
-#define MAX_NDBMT_RECEIVE_THREADS  1
-#define MAX_NDBMT_SEND_THREADS     0
-#elif NDB_VERSION_D < NDB_MAKE_VERSION(8,0,23)
 #define NDB_MAX_LOG_PARTS         32
-#define MAX_NDBMT_TC_THREADS      32
-#define MAX_NDBMT_RECEIVE_THREADS 16 
-#define MAX_NDBMT_SEND_THREADS    16
-#else
-#define NDB_MAX_LOG_PARTS         32
-#define MAX_NDBMT_TC_THREADS      160
-#define MAX_NDBMT_RECEIVE_THREADS 80
+#define MAX_NDBMT_RECEIVE_THREADS 360
+#define MAX_NDBMT_TC_WORKERS      MAX_NDBMT_RECEIVE_THREADS
 #define MAX_NDBMT_SEND_THREADS    80
-#endif
 
-#define MAX_NDBMT_LQH_WORKERS 332 
-#define MAX_NDBMT_LQH_THREADS 332
-#define MAX_NDBMT_QUERY_THREADS 332
+#define MAX_NDBMT_LQH_WORKERS 360
+#define MAX_NDBMT_QUERY_WORKERS 722
 
-#define NDBMT_MAX_BLOCK_INSTANCES (MAX_NDBMT_LQH_THREADS + \
-                                   MAX_NDBMT_QUERY_THREADS + \
-                                   MAX_NDBMT_TC_THREADS + \
-                                   MAX_NDBMT_RECEIVE_THREADS + \
-                                   NDBMT_MAIN_THREADS)
+#define NDBMT_MAX_BLOCK_INSTANCES (MAX_NDBMT_QUERY_WORKERS)
 /* Proxy block 0 is not a worker */
 #define NDBMT_MAX_WORKER_INSTANCES (NDBMT_MAX_BLOCK_INSTANCES - 1)
 
-#define MAX_THREADS_TO_WATCH (MAX_NDBMT_LQH_THREADS + \
-                              MAX_NDBMT_QUERY_THREADS + \
-                              MAX_NDBMT_TC_THREADS + \
-                              MAX_NDBMT_SEND_THREADS + \
-                              MAX_NDBMT_RECEIVE_THREADS + \
-                              NDBMT_MAIN_THREADS)
+#define MAX_THREADS_TO_WATCH (MAX_NDBMT_QUERY_WORKERS + \
+                              MAX_NDBMT_SEND_THREADS)
 
 #define NDB_FILE_BUFFER_SIZE (256*1024)
 

--- a/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
+++ b/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
@@ -270,6 +270,10 @@
 #define CFG_DB_TRANS_ERROR_LOGLEVEL 679
 #define CFG_DB_ENCRYPTED_FILE_SYSTEM  680
 
+/* Start RonDB only configuration parameters */
+#define CFG_DB_USE_TC_THREADS         689
+#define CFG_DB_USE_LDM_THREADS        690
+
 #define CFG_DB_OS_STATIC_OVERHEAD     691
 #define CFG_DB_OS_CPU_OVERHEAD        692
 
@@ -281,6 +285,7 @@
 #define CFG_DB_UNDO_BUFFER            697
 #define CFG_DB_TOTAL_MEMORY_CONFIG    698
 #define CFG_DB_AUTO_MEMORY_CONFIG     699
+/* End RonDB only configuration parameters */
 
 #define CFG_NODE_ARBIT_RANK           200
 #define CFG_NODE_ARBIT_DELAY          201

--- a/storage/ndb/include/mgmcommon/thr_config.hpp
+++ b/storage/ndb/include/mgmcommon/thr_config.hpp
@@ -55,9 +55,7 @@ public:
     T_TC    = 6, /* TC+SPJ */
     T_SEND  = 7, /* No blocks */
     T_IXBLD = 8, /* File thread during offline index build */
-    T_QUERY = 9, /* Query threads */
-    T_RECOVER=10,/* Recover threads */
-    T_END  = 11
+    T_END  = 9
   };
 
   THRConfig();
@@ -67,18 +65,21 @@ public:
   int setLockExecuteThreadToCPU(const char * val);
   int setLockIoThreadsToCPU(unsigned val);
 
-  int do_parse(unsigned realtime,
-               unsigned spintime,
-               unsigned num_cpus,
-               unsigned &num_rr_groups);
-  int do_parse(const char * ThreadConfig,
-               unsigned realtime,
-               unsigned spintime);
-  int do_parse(unsigned MaxNoOfExecutionThreads,
-               unsigned __ndbmt_lqh_threads,
-               unsigned __ndbmt_classic,
-               unsigned realtime,
-               unsigned spintime);
+  int do_parse_auto(unsigned realtime,
+                    unsigned spintime,
+                    unsigned num_cpus,
+                    unsigned &num_rr_groups,
+                    unsigned max_threads,
+                    bool use_tc_threads,
+                    bool use_ldm_threads);
+  int do_parse_thrconfig(const char * ThreadConfig,
+                         unsigned realtime,
+                         unsigned spintime);
+  int do_parse_classic(unsigned MaxNoOfExecutionThreads,
+                       unsigned __ndbmt_lqh_threads,
+                       unsigned __ndbmt_classic,
+                       unsigned realtime,
+                       unsigned spintime);
 
   const char * getConfigString();
 
@@ -144,11 +145,9 @@ protected:
   void bind_unbound(Vector<T_Thread> & vec, unsigned cpu);
 
   void compute_automatic_thread_config(
-    Uint32 num_cpus,
+    Uint32 & num_cpus,
     Uint32 & tc_threads,
     Uint32 & ldm_threads,
-    Uint32 & query_threads,
-    Uint32 & recover_threads,
     Uint32 & main_threads,
     Uint32 & rep_threads,
     Uint32 & send_threads,

--- a/storage/ndb/include/portlib/NdbHW.hpp
+++ b/storage/ndb/include/portlib/NdbHW.hpp
@@ -81,7 +81,6 @@ struct ndb_hwinfo
   Uint32 num_cpu_per_core;
   Uint32 num_shared_l3_caches;
   Uint32 num_virt_l3_caches;
-  Uint32 num_cpus_per_group;
 
   char cpu_model_name[128];
 
@@ -150,12 +149,15 @@ extern "C"
    * Round Robin groups of LDM groups that are contained in the same
    * virtual L3 cache groups.
    */
-  Uint32 Ndb_CreateCPUMap(Uint32 num_ldm_instances,
-                          Uint32 num_query_threads_per_ldm);
+  Uint32 Ndb_CreateCPUMap(Uint32 num_query_instances, Uint32 max_threads);
+  void Ndb_InitRRGroups(Uint32 *rr_group,
+                        Uint32 num_rr_groups,
+                        Uint32 num_query_instances,
+                        Uint32 max_threads);
   Uint32 Ndb_GetFirstCPUInMap();
   Uint32 Ndb_GetNextCPUInMap(Uint32 cpu_id);
 
-  Uint32 Ndb_GetRRGroups(Uint32 ldm_threads);
+  Uint32 Ndb_GetRRGroups(Uint32 query_instances);
 
   /**
    * Get the CPU id of all the CPUs in the CPU core of the

--- a/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
+++ b/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
@@ -747,12 +747,12 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     "MaxSendDelay",
     DB_TOKEN,
     "Max number of microseconds to delay sending in ndbmtd",
-    ConfigInfo::CI_DEPRECATED,
+    ConfigInfo::CI_USED,
     false,
     ConfigInfo::CI_INT,
+    "125",
     "0",
-    "0",
-    "11000" },
+    "1000" },
 
   {
     CFG_DB_SCHED_SPIN_TIME,
@@ -2125,6 +2125,32 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     "0",
     "0",
     STR_VALUE(MAX_USED_NUM_CPUS)
+  },
+
+  {
+    CFG_DB_USE_TC_THREADS,
+    "UseTcThreads",
+    DB_TOKEN,
+    "Use TC threads in automatic thread configuration",
+    ConfigInfo::CI_USED,
+    CI_RESTART_SYSTEM | CI_RESTART_INITIAL,
+    ConfigInfo::CI_BOOL,
+    "true",
+    "false",
+    "true"
+  },
+
+  {
+    CFG_DB_USE_LDM_THREADS,
+    "UseLdmThreads",
+    DB_TOKEN,
+    "Use LDM threads in automatic thread configuration",
+    ConfigInfo::CI_USED,
+    CI_RESTART_SYSTEM | CI_RESTART_INITIAL,
+    ConfigInfo::CI_BOOL,
+    "true",
+    "false",
+    "true"
   },
 
   {
@@ -6073,7 +6099,7 @@ checkThreadConfig(InitConfigFileParser::Context & ctx, const char * unused)
   }
   else if (ctx.m_currentSection->get("ThreadConfig", &thrconfig))
   {
-    int ret = tmp.do_parse(thrconfig, realtimeScheduler, spinTimer);
+    int ret = tmp.do_parse_thrconfig(thrconfig, realtimeScheduler, spinTimer);
     if (ret)
     {
       ctx.reportError("Unable to parse ThreadConfig: %s",
@@ -6098,7 +6124,7 @@ checkThreadConfig(InitConfigFileParser::Context & ctx, const char * unused)
   }
   else if (maxExecuteThreads || lqhThreads || classic)
   {
-    int ret = tmp.do_parse(
+    int ret = tmp.do_parse_classic(
         maxExecuteThreads, lqhThreads, classic, realtimeScheduler, spinTimer);
     if (ret)
     {

--- a/storage/ndb/src/common/mgmcommon/thr_config.cpp
+++ b/storage/ndb/src/common/mgmcommon/thr_config.cpp
@@ -55,8 +55,6 @@ static const struct ParseEntries m_parse_entries[] =
   { "tc",    THRConfig::T_TC   },
   { "send",  THRConfig::T_SEND },
   { "idxbld",THRConfig::T_IXBLD},
-  { "query", THRConfig::T_QUERY},
-  { "recover",THRConfig::T_RECOVER}
 };
 
 /**
@@ -73,16 +71,14 @@ static const struct THRConfig::Entries m_entries[] =
 { 
   //type                min max                       exec thread   permanent default_count
   { THRConfig::T_MAIN,  0, 1,                         true,         true,     1 },
-  { THRConfig::T_LDM,   0, MAX_NDBMT_LQH_THREADS,     true,         true,     1 },
+  { THRConfig::T_LDM,   0, MAX_NDBMT_LQH_WORKERS,     true,         true,     1 },
   { THRConfig::T_RECV,  1, MAX_NDBMT_RECEIVE_THREADS, true,         true,     1 },
   { THRConfig::T_REP,   0, 1,                         true,         true,     1 },
   { THRConfig::T_IO,    1, 1,                         false,        true,     1 },
   { THRConfig::T_WD,    1, 1,                         false,        true,     1 },
-  { THRConfig::T_TC,    0, MAX_NDBMT_TC_THREADS,      true,         true,     0 },
+  { THRConfig::T_TC,    0, MAX_NDBMT_TC_WORKERS,      true,         true,     0 },
   { THRConfig::T_SEND,  0, MAX_NDBMT_SEND_THREADS,    true,         true,     0 },
   { THRConfig::T_IXBLD, 0, 1,                         false,        false,    0 },
-  { THRConfig::T_QUERY, 0, MAX_NDBMT_QUERY_THREADS,   true,         true,     0 },
-  { THRConfig::T_RECOVER, 0, MAX_NDBMT_QUERY_THREADS, false,        false,    0 }
 };
 
 static const struct ParseParams m_params[] =
@@ -294,15 +290,11 @@ computeThreadConfig(Uint32 MaxNoOfExecutionThreads,
   recvthreads = table[P].recv;
 }
 
-static Uint32 g_num_query_threads_per_ldm = 0;
-
 void
 THRConfig::compute_automatic_thread_config(
-  Uint32 num_cpus,
+  Uint32 & num_cpus,
   Uint32 & tc_threads,
   Uint32 & ldm_threads,
-  Uint32 & query_threads,
-  Uint32 & recover_threads,
   Uint32 & main_threads,
   Uint32 & rep_threads,
   Uint32 & send_threads,
@@ -347,228 +339,17 @@ THRConfig::compute_automatic_thread_config(
     { 31, 15 },
     { 32, 16 },
     { 33, 16 },
-    { 34, 16 },
-    { 35, 16 },
-    { 36, 17 },
-    { 37, 17 },
-    { 38, 17 },
-    { 39, 17 },
-    { 40, 18 },
-    { 41, 18 },
-    { 42, 18 },
-    { 43, 18 },
-    { 44, 19 },
-    { 45, 19 },
-    { 46, 19 },
-    { 47, 19 },
-    { 48, 20 },
-    { 49, 20 },
-    { 50, 20 },
-    { 51, 20 },
-    { 52, 21 },
-    { 53, 21 },
-    { 54, 21 },
-    { 55, 21 },
-    { 56, 22 },
-    { 57, 22 },
-    { 58, 22 },
-    { 59, 22 },
-    { 60, 23 },
-    { 61, 23 },
-    { 62, 23 },
-    { 63, 23 },
-    { 64, 24 },
-    { 65, 24 },
-    { 66, 24 },
-    { 67, 24 },
-    { 68, 24 },
-    { 69, 24 },
-    { 70, 24 },
-    { 71, 24 },
-    { 72, 25 },
-    { 73, 25 },
-    { 74, 25 },
-    { 75, 25 },
-    { 76, 25 },
-    { 77, 25 },
-    { 78, 25 },
-    { 79, 25 },
-    { 80, 26 },
-    { 81, 26 },
-    { 82, 26 },
-    { 83, 26 },
-    { 84, 26 },
-    { 85, 26 },
-    { 86, 26 },
-    { 87, 26 },
-    { 88, 27 },
-    { 89, 27 },
-    { 90, 27 },
-    { 91, 27 },
-    { 92, 27 },
-    { 93, 27 },
-    { 94, 27 },
-    { 95, 27 },
-    { 96, 28 },
-    { 97, 28 },
-    { 98, 28 },
-    { 99, 28 },
-    { 100, 28 },
-    { 101, 28 },
-    { 102, 28 },
-    { 103, 28 },
-    { 104, 29 },
-    { 105, 29 },
-    { 106, 29 },
-    { 107, 29 },
-    { 108, 29 },
-    { 109, 29 },
-    { 110, 29 },
-    { 111, 29 },
-    { 112, 30 },
-    { 113, 30 },
-    { 114, 30 },
-    { 115, 30 },
-    { 116, 30 },
-    { 117, 30 },
-    { 118, 30 },
-    { 119, 30 },
-    { 120, 31 },
-    { 121, 31 },
-    { 122, 31 },
-    { 123, 31 },
-    { 124, 31 },
-    { 125, 31 },
-    { 126, 31 },
-    { 127, 31 },
-    { 128, 32 },
-    { 129, 32 },
-    { 130, 32 },
-    { 131, 32 },
-    { 132, 32 },
-    { 133, 32 },
-    { 134, 32 },
-    { 135, 32 },
-    { 136, 32 },
-    { 137, 32 },
-    { 138, 32 },
-    { 139, 32 },
-    { 140, 33 },
-    { 141, 33 },
-    { 142, 33 },
-    { 143, 33 },
-    { 144, 33 },
-    { 145, 33 },
-    { 146, 33 },
-    { 147, 33 },
-    { 148, 33 },
-    { 149, 33 },
-    { 150, 33 },
-    { 151, 33 },
-    { 152, 34 },
-    { 153, 34 },
-    { 154, 34 },
-    { 155, 34 },
-    { 156, 34 },
-    { 157, 34 },
-    { 158, 34 },
-    { 159, 34 },
-    { 160, 34 },
-    { 161, 34 },
-    { 162, 34 },
-    { 163, 34 },
-    { 164, 35 },
-    { 165, 35 },
-    { 166, 35 },
-    { 167, 35 },
-    { 168, 35 },
-    { 169, 35 },
-    { 170, 35 },
-    { 171, 35 },
-    { 172, 35 },
-    { 173, 35 },
-    { 174, 35 },
-    { 175, 35 },
-    { 176, 36 },
-    { 177, 36 },
-    { 178, 36 },
-    { 179, 36 },
-    { 180, 36 },
-    { 181, 36 },
-    { 182, 36 },
-    { 183, 36 },
-    { 184, 36 },
-    { 185, 36 },
-    { 186, 36 },
-    { 187, 36 },
-    { 188, 37 },
-    { 189, 37 },
-    { 190, 37 },
-    { 191, 37 },
-    { 192, 37 },
-    { 193, 37 },
-    { 194, 37 },
-    { 195, 37 },
-    { 196, 37 },
-    { 197, 37 },
-    { 198, 37 },
-    { 199, 37 },
-    { 200, 38 },
-    { 201, 38 },
-    { 202, 38 },
-    { 203, 38 },
-    { 204, 38 },
-    { 205, 38 },
-    { 206, 38 },
-    { 207, 38 },
-    { 208, 38 },
-    { 209, 38 },
-    { 210, 38 },
-    { 211, 38 },
-    { 212, 39 },
-    { 213, 39 },
-    { 214, 39 },
-    { 215, 39 },
-    { 216, 39 },
-    { 217, 39 },
-    { 218, 39 },
-    { 219, 39 },
-    { 220, 39 },
-    { 221, 39 },
-    { 222, 39 },
-    { 223, 39 },
-    { 224, 40 },
-    { 225, 40 },
-    { 226, 40 },
-    { 227, 40 },
-    { 228, 40 },
-    { 229, 40 },
-    { 230, 40 },
-    { 231, 40 },
-    { 232, 40 },
-    { 233, 40 },
-    { 234, 40 },
-    { 235, 40 },
-    { 236, 40 },
-    { 237, 40 },
-    { 238, 40 },
-    { 239, 40 },
-    { 240, 41 },
-    { 241, 41 },
-    { 242, 41 },
-    { 243, 41 },
-    { 244, 41 },
-    { 245, 41 },
-    { 246, 41 },
-    { 247, 41 },
-    { 248, 41 },
-    { 249, 41 },
-    { 250, 41 },
-    { 251, 41 },
-    { 252, 41 },
-    { 253, 41 },
-    { 254, 41 },
-    { 255, 41 }
+    { 34, 17 },
+    { 35, 17 },
+    { 36, 18 },
+    { 37, 18 },
+    { 38, 19 },
+    { 39, 19 },
+    { 40, 20 },
+    { 41, 20 },
+    { 42, 21 },
+    { 43, 21 },
+    { 44, 22 }
   };
 
   static const struct entry
@@ -577,95 +358,35 @@ THRConfig::compute_automatic_thread_config(
     Uint32 main_threads;
     Uint32 rep_threads;
     Uint32 ldm_threads;
-    Uint32 query_threads;
     Uint32 tc_threads;
     Uint32 send_threads;
     Uint32 recv_threads;
   } table[] = {
-    { 0, 0, 0, 0, 0, 0, 0, 1 }, // 1 CPU
-    { 1, 0, 0, 0, 0, 0, 0, 2 }, // 2-3 CPUs
-    { 2, 1, 0, 2, 0, 0, 0, 1 }, // 4-5 CPUs
-    { 3, 0, 0, 2, 2, 0, 1, 1 }, // 6-7 CPUs
-    { 4, 0, 0, 2, 2, 2, 1, 1 }, // 8-9 CPUs
-    { 5, 0, 0, 3, 3, 2, 1, 1 }, // 10-11 CPUs
-    { 6, 1, 0, 3, 3, 2, 1, 2 }, // 12-13 CPUs
-    { 7, 1, 0, 4, 4, 2, 1, 2 }, // 14-15 CPUs
-    { 8, 1, 0, 4, 4, 4, 1, 2 }, // 16-17 CPUs
-    { 9, 1, 0, 5, 5, 4, 1, 2 }, // 18-19 CPUs
-    { 10, 1, 1, 5, 5, 5, 1, 2 }, // 20-21 CPUs
-    { 11, 1, 1, 5, 5, 5, 2, 3 }, // 22-23 CPUs
-    { 12, 1, 1, 6, 6, 5, 2, 3 }, // 24-25 CPUs
-    { 13, 1, 1, 6, 6, 6, 2, 4 }, // 26-27 CPUs
-    { 14, 1, 1, 7, 7, 6, 2, 4 }, // 28-29 CPUs
-    { 15, 1, 1, 7, 7, 8, 2, 4 }, // 30-31 CPUs
-    { 16, 1, 1, 8, 8, 8, 2, 4 }, // 32-35 CPUs
-    { 17, 1, 1, 9, 9, 9, 2, 5 }, // 36-39 CPUs
-    { 18, 1, 1, 10, 10, 10, 3, 5 }, // 40-43 CPUs
-    { 19, 1, 1, 11, 11, 11, 3, 6 }, // 44-47 CPUs
-    { 20, 1, 1, 12, 12, 12, 4, 6 }, // 48-51 CPUs
-    { 21, 1, 1, 13, 13, 13, 4, 7 }, // 52-55 CPUs
-    { 22, 1, 1, 14, 14, 14, 5, 7 }, // 56-59 CPUs
-    { 23, 1, 1, 15, 15, 15, 5, 8 }, // 60-63 CPUs
-    { 24, 1, 1, 16, 16, 16, 6, 8 }, // 64-71 CPUs
-    { 25, 1, 1, 18, 18, 18, 7, 9 }, // 72-79 CPUs
-    { 26, 1, 1, 20, 20, 20, 8, 10 }, // 80-87 CPUs
-    { 27, 1, 1, 22, 22, 22, 9, 11 }, // 88-95 CPUs
-    { 28, 1, 1, 24, 24, 24, 10, 12 }, // 96-103 CPUs
-    { 29, 1, 1, 26, 26, 26, 11, 13 }, // 104-111 CPUs
-    { 30, 1, 1, 28, 28, 28, 12, 14 }, // 112-119 CPUs
-    { 31, 1, 1, 30, 30, 30, 13, 15 }, // 120-127 CPUs
-    { 32, 1, 1, 32, 32, 32, 14, 16 }, // 128-139 CPUs
-    { 33, 1, 1, 35, 35, 35, 15, 18 }, // 140-151 CPUs
-    { 34, 1, 1, 38, 38, 38, 17, 19 }, // 152-163 CPUs
-    { 35, 1, 1, 41, 41, 41, 18, 21 }, // 164-175 CPUs
-    { 36, 1, 1, 44, 44, 44, 20, 22 }, // 176-187 CPUs
-    { 37, 1, 1, 47, 47, 47, 21, 24 }, // 188-199 CPUs
-    { 38, 1, 1, 50, 50, 50, 23, 25 }, // 200-211 CPUs
-    { 39, 1, 1, 53, 53, 53, 24, 27 }, // 212-223 CPUs
-    { 40, 1, 1, 56, 56, 56, 26, 28 }, // 224-239 CPUs
-    { 41, 1, 1, 60, 60, 60, 28, 30 }, // 240-255 CPUs
-    { 42, 1, 1, 64, 64, 64, 30, 32 }, // 256-271 CPUs
-    { 43, 1, 1, 68, 68, 68, 32, 34 }, // 272-287 CPUs
-    { 44, 1, 1, 72, 72, 72, 34, 36 }, // 288-303 CPUs
-    { 45, 1, 1, 76, 76, 76, 36, 38 }, // 304-319 CPUs
-    { 46, 1, 1, 80, 80, 80, 38, 40 }, // 320-335 CPUs
-    { 47, 1, 1, 84, 84, 84, 40, 42 }, // 336-351 CPUs
-    { 48, 1, 1, 88, 88, 88, 42, 44 }, // 352-367 CPUs
-    { 49, 1, 1, 92, 92, 92, 44, 46 }, // 368-383 CPUs
-    { 50, 1, 1, 96, 96, 96, 46, 48 }, // 384-399 CPUs
-    { 51, 1, 1, 100, 100, 100, 48, 50 }, // 400-415 CPUs
-    { 52, 1, 1, 104, 104, 104, 50, 52 }, // 416-431 CPUs
-    { 53, 1, 1, 108, 108, 108, 52, 54 }, // 432-447 CPUs
-    { 54, 1, 1, 112, 112, 112, 54, 56 }, // 448-463 CPUs
-    { 55, 1, 1, 116, 116, 116, 56, 58 }, // 464-479 CPUs
-    { 56, 1, 1, 120, 120, 120, 58, 60 }, // 480-495 CPUs
-    { 57, 1, 1, 124, 124, 124, 60, 62 }, // 496-511 CPUs
-    { 58, 1, 1, 128, 128, 128, 62, 64 }, // 512-527 CPUs
-    { 59, 1, 1, 132, 132, 132, 64, 66 }, // 528-543 CPUs
-    { 60, 1, 1, 136, 136, 136, 66, 68 }, // 544-559 CPUs
-    { 61, 1, 1, 140, 140, 140, 68, 70 }, // 560-575 CPUs
-    { 62, 1, 1, 144, 144, 144, 70, 72 }, // 576-591 CPUs
-    { 63, 1, 1, 148, 148, 148, 72, 74 }, // 592-607 CPUs
-    { 64, 1, 1, 152, 152, 152, 74, 76 }, // 608-623 CPUs
-    { 65, 1, 1, 156, 156, 156, 76, 78 }, // 624-639 CPUs
-    { 66, 1, 1, 160, 160, 160, 78, 80 }, // 640-655 CPUs
-    { 67, 1, 1, 164, 164, 164, 80, 82 }, // 656-671 CPUs
-    { 68, 1, 1, 168, 168, 168, 82, 84 }, // 672-687 CPUs
-    { 69, 1, 1, 172, 172, 172, 84, 86 }, // 688-703 CPUs
-    { 70, 1, 1, 176, 176, 176, 86, 88 }, // 704-719 CPUs
-    { 71, 1, 1, 180, 180, 180, 88, 90 }, // 720-735 CPUs
-    { 72, 1, 1, 184, 184, 184, 90, 92 }, // 736-751 CPUs
-    { 73, 1, 1, 188, 188, 188, 92, 94 }, // 752-767 CPUs
-    { 74, 1, 1, 192, 192, 192, 94, 96 }, // 768-783 CPUs
-    { 75, 1, 1, 196, 196, 196, 96, 98 }, // 784-799 CPUs
-    { 76, 1, 1, 200, 200, 200, 98, 100 }, // 800-815 CPUs
-    { 77, 1, 1, 204, 204, 204, 100, 102 }, // 816-831 CPUs
-    { 78, 1, 1, 208, 208, 208, 102, 104 }, // 832-847 CPUs
-    { 79, 1, 1, 212, 212, 212, 104, 106 }, // 848-863 CPUs
-    { 80, 1, 1, 216, 216, 216, 106, 108 }, // 864-879 CPUs
-    { 81, 1, 1, 220, 220, 220, 108, 110 }, // 880-895 CPUs
-    { 82, 1, 1, 224, 224, 224, 110, 112 }, // 896-911 CPUs
-    { 83, 1, 1, 228, 228, 228, 112, 114 }, // 912-927 CPUs
+    { 0, 0, 0, 0, 0, 0, 1 }, // 1 CPU
+    { 1, 0, 0, 1, 0, 0, 1 }, // 2-3 CPUs
+    { 2, 0, 0, 2, 1, 0, 1 }, // 4-5 CPUs
+    { 3, 0, 0, 3, 1, 1, 1 }, // 6-7 CPUs
+    { 4, 0, 0, 4, 2, 1, 1 }, // 8-9 CPUs
+    { 5, 1, 0, 5, 2, 1, 1 }, // 10-11 CPUs
+    { 6, 1, 0, 6, 3, 1, 1 }, // 12-13 CPUs
+    { 7, 1, 0, 7, 3, 1, 2 }, // 14-15 CPUs
+    { 8, 1, 0, 8, 4, 1, 2 }, // 16-17 CPUs
+    { 9, 1, 1, 8, 4, 1, 3 }, // 18-19 CPUs
+    { 10, 1, 1, 9, 5, 1, 3 }, // 20-21 CPUs
+    { 11, 1, 1, 10, 5, 2, 3 }, // 22-23 CPUs
+    { 12, 1, 1, 11, 6, 2, 3 }, // 24-25 CPUs
+    { 13, 1, 1, 12, 6, 2, 4 }, // 26-27 CPUs
+    { 14, 1, 1, 13, 7, 2, 4 }, // 28-29 CPUs
+    { 15, 1, 1, 15, 7, 2, 4 }, // 30-31 CPUs
+    { 16, 1, 1, 16, 8, 2, 4 }, // 32-33 CPUs
+    { 17, 1, 1, 17, 8, 2, 5 }, // 34-35 CPUs
+    { 18, 1, 1, 18, 9, 2, 5 }, // 36-37 CPUs
+    { 19, 1, 1, 19, 9, 3, 5 }, // 38-39 CPUs
+    { 20, 1, 1, 20, 10, 3, 5 }, // 40-41 CPUs
+    { 21, 1, 1, 21, 10, 3, 6 }, // 42-43 CPUs
+    { 21, 1, 1, 22, 11, 3, 6 }, // 44-45 CPUs
+    { 21, 1, 1, 23, 12, 3, 6 }, // 46-47 CPUs
+    { 22, 1, 1, 24, 12, 4, 6 }, // 48
   };
   Uint32 cpu_cnt;
   if (num_cpus == 0)
@@ -677,6 +398,7 @@ THRConfig::compute_automatic_thread_config(
       cpu_cnt = hwinfo->cpu_cnt_max;
       cpu_cnt = MIN(cpu_cnt, MAX_USED_NUM_CPUS);
     }
+    num_cpus = cpu_cnt;
 #if 0
     /* Consistency check of above tables */
     Uint32 expected_map_id = 0;
@@ -732,7 +454,6 @@ THRConfig::compute_automatic_thread_config(
      * as recover thread, thus we can decrease the amount of recover
      * threads with the amount of LDM threads.
      */
-    g_num_query_threads_per_ldm = 1;
   }
   else
   {
@@ -741,48 +462,32 @@ THRConfig::compute_automatic_thread_config(
 
   require(cpu_cnt > 0);
   Uint32 used_map_id;
-  if (cpu_cnt >= 256)
+  if (cpu_cnt > 48)
   {
-    used_map_id = 42;
-    Uint32 extra_map_id = (cpu_cnt - 256) / 16;
-    used_map_id += extra_map_id;
-    used_map_id = MIN(used_map_id, 83);
+    main_threads = 1;
+    rep_threads = 1;
+    ldm_threads = cpu_cnt / 2;
+    tc_threads = cpu_cnt / 4;
+    recv_threads = cpu_cnt / 8;
+    send_threads = cpu_cnt / 12;
+
+    Uint32 rem_threads = cpu_cnt -
+      (ldm_threads + 2 + tc_threads + recv_threads + send_threads);
+    ldm_threads += rem_threads;
   }
   else
   {
     used_map_id = map_table[cpu_cnt - 1].mapped_id;
-  }
-  main_threads = table[used_map_id].main_threads;
-  rep_threads = table[used_map_id].rep_threads;
-  ldm_threads = table[used_map_id].ldm_threads;
-  query_threads = table[used_map_id].query_threads;
-  tc_threads = table[used_map_id].tc_threads;
-  send_threads = table[used_map_id].send_threads;
-  recv_threads = table[used_map_id].recv_threads;
-  ldm_threads += query_threads;
-  query_threads = 0;
-
-  recover_threads = cpu_cnt - ldm_threads;
-
-  if (cpu_cnt < 5)
-  {
-    main_threads = 0;
-    recover_threads = 0;
-    ldm_threads = 0;
-    recv_threads = cpu_cnt;
-  }
-
-  Uint32 tot_threads = main_threads;
-  tot_threads += rep_threads;
-  tot_threads += ldm_threads;
-  tot_threads += tc_threads;
-  tot_threads += recv_threads;
-
-  if (tot_threads > NDBMT_MAX_BLOCK_INSTANCES)
-  {
-    /* Have to ensure total number of block instances are not beyond limit */
-    recover_threads -=
-      (tot_threads - NDBMT_MAX_BLOCK_INSTANCES);
+    main_threads = table[used_map_id].main_threads;
+    rep_threads = table[used_map_id].rep_threads;
+    ldm_threads = table[used_map_id].ldm_threads;
+    tc_threads = table[used_map_id].tc_threads;
+    send_threads = table[used_map_id].send_threads;
+    recv_threads = table[used_map_id].recv_threads;
+    if (cpu_cnt % 2 != 0)
+    {
+      ldm_threads++;
+    }
   }
 }
 
@@ -800,39 +505,57 @@ THRConfig::get_shared_ldm_instance(Uint32 instance, Uint32 num_ldm_threads)
 }
 
 int
-THRConfig::do_parse(unsigned realtime,
-                    unsigned spintime,
-                    unsigned num_cpus,
-                    unsigned &num_rr_groups)
+THRConfig::do_parse_auto(unsigned realtime,
+                         unsigned spintime,
+                         unsigned num_cpus,
+                         unsigned &num_rr_groups,
+                         unsigned max_threads,
+                         bool use_tc_threads,
+                         bool use_ldm_threads)
 {
   Uint32 tc_threads = 0;
   Uint32 ldm_threads = 0;
-  Uint32 query_threads = 0;
-  Uint32 recover_threads = 0;
   Uint32 main_threads = 0;
   Uint32 rep_threads = 0;
   Uint32 send_threads = 0;
   Uint32 recv_threads = 0;
+  Uint32 config_num_cpus = num_cpus;
   compute_automatic_thread_config(num_cpus,
                                   tc_threads,
                                   ldm_threads,
-                                  query_threads,
-                                  recover_threads,
                                   main_threads,
                                   rep_threads,
                                   send_threads,
                                   recv_threads);
+  if (!use_tc_threads)
+  {
+    recv_threads += tc_threads;
+    tc_threads = 0;
+  }
+  if (!use_ldm_threads)
+  {
+    /**
+     * No LDM threads is equal to only recv threads, thus
+     * also no TC and main threads is implied by this.
+     */
+    recv_threads += ldm_threads;
+    ldm_threads = 0;
+    recv_threads += tc_threads;
+    tc_threads = 0;
+    recv_threads += main_threads;
+    main_threads = 0;
+    recv_threads += rep_threads;
+    rep_threads = 0;
+  }
   g_eventLogger->info("Auto thread config uses:\n"
                       " %u LDM+Query threads,\n"
                       " %u tc threads,\n"
-                      " %u Recover threads,\n"
                       " %u main threads,\n"
                       " %u rep threads,\n"
                       " %u recv threads,\n"
                       " %u send threads",
                       ldm_threads,
                       tc_threads,
-                      recover_threads,
                       main_threads,
                       rep_threads,
                       recv_threads,
@@ -871,14 +594,6 @@ THRConfig::do_parse(unsigned realtime,
   {
     add(T_TC, realtime, spintime);
   }
-  if (recover_threads > query_threads)
-  {
-    Uint32 num_recover_threads_only = recover_threads - query_threads;
-    for (Uint32 i = 0; i < num_recover_threads_only; i++)
-    {
-      add(T_RECOVER, realtime, spintime);
-    }
-  }
   for (Uint32 i = 0; i < send_threads; i++)
   {
     add(T_SEND, realtime, spintime);
@@ -887,36 +602,87 @@ THRConfig::do_parse(unsigned realtime,
   {
     add(T_RECV, realtime, spintime);
   }
+  Uint32 num_query_instances =
+    ldm_threads +
+    tc_threads +
+    recv_threads +
+    main_threads +
+    rep_threads;
+  Uint32 calc_num_cpus = num_query_instances + send_threads;
+  require(calc_num_cpus <= num_cpus);
+
   struct ndb_hwinfo *hwinfo = Ndb_GetHWInfo(false);
-  if (hwinfo->is_cpuinfo_available && num_cpus == 0)
+  if (hwinfo->is_cpuinfo_available && config_num_cpus == 0)
   {
     /**
      * With CPU information available we will perform CPU locking as well
      * in an automated fashion. We have prepared the HW information such
      * that we can simply assign the CPUs from the CPU map.
+     *
+     * We will assign 2 LDM threads, next 2 non-LDM threads and continue
+     * like that. The idea is that the 2 LDM threads will share the same
+     * CPU core if it is running on a hyperthreaded CPU. If it is running
+     * on a CPU with a single CPU per core it won't matter so much how
+     * we distribute threads inside L3 caches, it only matters which
+     * L3 cache the CPUs belong to.
      */
-    Uint32 thread_ldm_type = T_LDM;
-    if (ldm_threads == 0)
-    {
-      thread_ldm_type = T_RECV;
-    }
-    Uint32 num_query_threads_per_ldm = g_num_query_threads_per_ldm;
     num_rr_groups =
-      Ndb_CreateCPUMap(ldm_threads, num_query_threads_per_ldm);
+      Ndb_CreateCPUMap(num_query_instances, max_threads);
+    Uint32 count_ldm_threads = ldm_threads;
+    Uint32 count_tc_threads = tc_threads;
+    Uint32 count_recv_threads = recv_threads;
+    Uint32 count_main_threads = main_threads;
+    Uint32 count_rep_threads = rep_threads;
     g_eventLogger->info("Number of RR Groups = %u", num_rr_groups);
     Uint32 next_cpu_id = Ndb_GetFirstCPUInMap();
-    Uint32 num_database_threads = ldm_threads;
-    if (num_database_threads == 0)
+    for (Uint32 i = 0; i < num_cpus; i++)
     {
-      num_database_threads = recv_threads;
-      recv_threads = 0;
-    }
-    for (Uint32 i = 0; i < num_database_threads; i++)
-    {
+      Uint32 thread_type;
+      Uint32 inx = 0;
+      if (count_ldm_threads > 0)
+      {
+        thread_type = T_LDM;
+        count_ldm_threads--;
+        inx = count_ldm_threads;
+      }
+      else
+      {
+        if (count_recv_threads > 0)
+        {
+          thread_type = T_RECV;
+          count_recv_threads--;
+          inx = count_recv_threads;
+        }
+        else if (count_tc_threads > 0)
+        {
+          thread_type = T_TC;
+          count_tc_threads--;
+          inx = count_tc_threads;
+        }
+        else if (count_main_threads > 0)
+        {
+          thread_type = T_MAIN;
+          count_main_threads--;
+          inx = count_main_threads;
+        }
+        else if (count_rep_threads > 0)
+        {
+          thread_type = T_REP;
+          count_rep_threads--;
+          inx = count_rep_threads;
+        }
+        else
+        {
+          require(send_threads > 0);
+          thread_type = T_SEND;
+          send_threads--;
+          inx = send_threads;
+        }
+      }
       require(next_cpu_id != Uint32(RNIL));
-      m_threads[thread_ldm_type][i].m_bind_no = next_cpu_id;
-      m_threads[thread_ldm_type][i].m_bind_type = T_Thread::B_CPU_BIND;
-      m_threads[thread_ldm_type][i].m_core_bind = true;
+      m_threads[thread_type][inx].m_bind_no = next_cpu_id;
+      m_threads[thread_type][inx].m_bind_type = T_Thread::B_CPU_BIND;
+      m_threads[thread_type][inx].m_core_bind = true;
 
       Uint32 core_cpu_ids[MAX_NUM_CPUS];
       Uint32 num_core_cpus = 0;
@@ -925,102 +691,83 @@ THRConfig::do_parse(unsigned realtime,
                         num_core_cpus);
       if (num_core_cpus >= 2)
       {
-        Uint32 neighbour_cpu = core_cpu_ids[0];
-        if (neighbour_cpu == next_cpu_id)
-        {
-          neighbour_cpu = core_cpu_ids[1];
-        }
-        m_threads[thread_ldm_type][i].m_shared_cpu_id = neighbour_cpu;
+        /* First CPU in core list is always our own CPU id */
+        Uint32 neighbour_cpu = core_cpu_ids[1];
+        m_threads[thread_type][inx].m_shared_cpu_id = neighbour_cpu;
       }
       next_cpu_id = Ndb_GetNextCPUInMap(next_cpu_id);
     }
-    for (Uint32 i = 0; i < num_database_threads; i++)
+    /**
+     * This code is used to discover where we have the shared
+     * instance (if one exists).
+     *
+     * The shared instance is used as the second option after
+     * selecting the LQH block.
+     */
+    Uint32 thread_type = T_LDM;
+    Uint32 num_ldm_threads = ldm_threads;
+    if (num_ldm_threads == 0)
     {
-      Uint32 my_cpu_id = m_threads[thread_ldm_type][i].m_bind_no;
-      for (Uint32 j = i; j < ldm_threads; j++)
-      {
-        if (m_threads[thread_ldm_type][i].m_shared_cpu_id != Uint32(~0) &&
-            m_threads[thread_ldm_type][i].m_shared_cpu_id == my_cpu_id)
-        {
-          m_threads[thread_ldm_type][i].m_shared_instance = j + 1;
-          m_threads[thread_ldm_type][j].m_shared_instance = i + 1;
-        }
-      }
+      thread_type = T_RECV;
+      num_ldm_threads = recv_threads;
     }
-
-    Uint32 tc_count = 0;
-    Uint32 main_count = 0;
-    Uint32 send_count = 0;
-    Uint32 rep_count = 0;
-    Uint32 recv_count = 0;
-
-    Uint32 max_threads = 0;
-    max_threads = MAX(max_threads, tc_threads);
-    max_threads = MAX(max_threads, main_threads);
-    max_threads = MAX(max_threads, send_threads);
-    max_threads = MAX(max_threads, rep_threads);
-    max_threads = MAX(max_threads, recv_threads);
-    for (Uint32 i = 0; i < max_threads; i++)
+    for (Uint32 i = 0; i < num_ldm_threads; i++)
     {
-      require(next_cpu_id != Uint32(RNIL));
-      if (tc_count < tc_threads)
+      if (m_threads[thread_type][i].m_shared_cpu_id != Uint32(~0))
       {
-        m_threads[T_TC][i].m_bind_no = next_cpu_id;
-        m_threads[T_TC][i].m_bind_type = T_Thread::B_CPU_BIND;
-        m_threads[T_TC][i].m_core_bind = true;
-        next_cpu_id = Ndb_GetNextCPUInMap(next_cpu_id);
-      }
-      if (main_count < main_threads)
-      {
-        main_count++;
-        require(next_cpu_id != Uint32(RNIL));
-        m_threads[T_MAIN][i].m_bind_no = next_cpu_id;
-        m_threads[T_MAIN][i].m_bind_type = T_Thread::B_CPU_BIND;
-        m_threads[T_MAIN][i].m_core_bind = true;
-        next_cpu_id = Ndb_GetNextCPUInMap(next_cpu_id);
-      }
-      if (send_count < send_threads)
-      {
-        send_count++;
-        require(next_cpu_id != Uint32(RNIL));
-        m_threads[T_SEND][i].m_bind_no = next_cpu_id;
-        m_threads[T_SEND][i].m_bind_type = T_Thread::B_CPU_BIND;
-        m_threads[T_SEND][i].m_core_bind = true;
-        next_cpu_id = Ndb_GetNextCPUInMap(next_cpu_id);
-      }
-      if (rep_count < rep_threads)
-      {
-        rep_count++;
-        require(next_cpu_id != Uint32(RNIL));
-        m_threads[T_REP][i].m_bind_no = next_cpu_id;
-        m_threads[T_REP][i].m_bind_type = T_Thread::B_CPU_BIND;
-        m_threads[T_REP][i].m_core_bind = true;
-        next_cpu_id = Ndb_GetNextCPUInMap(next_cpu_id);
-      }
-      if (recv_count < recv_threads)
-      {
-        recv_count++;
-        require(next_cpu_id != Uint32(RNIL));
-        m_threads[T_RECV][i].m_bind_no = next_cpu_id;
-        m_threads[T_RECV][i].m_bind_type = T_Thread::B_CPU_BIND;
-        m_threads[T_RECV][i].m_core_bind = true;
-        next_cpu_id = Ndb_GetNextCPUInMap(next_cpu_id);
+        Uint32 shared_cpu_id = m_threads[thread_type][i].m_shared_cpu_id;
+        Uint32 inx = 0;
+        for (Uint32 j = 0; j < ldm_threads; j++, inx++)
+        {
+          if (m_threads[T_LDM][j].m_bind_no == shared_cpu_id)
+          {
+            m_threads[thread_type][i].m_shared_instance = inx;
+          }
+        }
+        for (Uint32 j = 0; j < tc_threads; j++, inx++)
+        {
+          if (m_threads[T_TC][j].m_bind_no == shared_cpu_id)
+          {
+            m_threads[thread_type][i].m_shared_instance = inx;
+          }
+        }
+        for (Uint32 j = 0; j < recv_threads; j++, inx++)
+        {
+          if (m_threads[T_RECV][j].m_bind_no == shared_cpu_id)
+          {
+            m_threads[thread_type][i].m_shared_instance = inx;
+          }
+        }
+        for (Uint32 j = 0; j < main_threads; j++, inx++)
+        {
+          if (m_threads[T_MAIN][j].m_bind_no == shared_cpu_id)
+          {
+            m_threads[thread_type][i].m_shared_instance = inx;
+          }
+        }
+        for (Uint32 j = 0; j < rep_threads; j++, inx++)
+        {
+          if (m_threads[T_REP][j].m_bind_no == shared_cpu_id)
+          {
+            m_threads[thread_type][i].m_shared_instance = inx;
+          }
+        }
       }
     }
   }
   else
   {
-    num_rr_groups = Ndb_GetRRGroups(ldm_threads);
+    num_rr_groups = Ndb_GetRRGroups(num_query_instances);
   }
   return 0;
 }
 
 int
-THRConfig::do_parse(unsigned MaxNoOfExecutionThreads,
-                    unsigned __ndbmt_lqh_threads,
-                    unsigned __ndbmt_classic,
-                    unsigned realtime,
-                    unsigned spintime)
+THRConfig::do_parse_classic(unsigned MaxNoOfExecutionThreads,
+                            unsigned __ndbmt_lqh_threads,
+                            unsigned __ndbmt_classic,
+                            unsigned realtime,
+                            unsigned spintime)
 {
   /**
    * This is old ndbd.cpp : get_multithreaded_config
@@ -1681,7 +1428,6 @@ int THRConfig::handle_spec(const char* str,
         !(type == T_LDM ||
           type == T_TC ||
           type == T_RECV ||
-          type == T_QUERY ||
           type == T_MAIN ||
           type == T_REP))
     {
@@ -1819,9 +1565,9 @@ THRConfig::do_validate_thread_counts()
 }
 
 int
-THRConfig::do_parse(const char * ThreadConfig,
-                    unsigned realtime,
-                    unsigned spintime)
+THRConfig::do_parse_thrconfig(const char * ThreadConfig,
+                              unsigned realtime,
+                              unsigned spintime)
 {
   int ret = handle_spec(ThreadConfig, realtime, spintime);
   if (ret != 0)
@@ -1917,7 +1663,7 @@ TAPTEST(thr_config)
   ndb_init();
   {
     THRConfig tmp;
-    OK(tmp.do_parse(8, 0, 0, 0, 0) == 0);
+    OK(tmp.do_parse_classic(8, 0, 0, 0, 0) == 0);
   }
 
   /**
@@ -2005,8 +1751,8 @@ TAPTEST(thr_config)
     for (Uint32 i = 0; ok[i]; i++)
     {
       THRConfig tmp;
-      int res = tmp.do_parse(ok[i], 0, 0);
-      printf("do_parse(%s) => %s - %s\n", ok[i],
+      int res = tmp.do_parse_thrconfig(ok[i], 0, 0);
+      printf("do_parse_thrconfig(%s) => %s - %s\n", ok[i],
              res == 0 ? "OK" : "FAIL",
              res == 0 ? tmp.getConfigString() :
              tmp.getErrorMessage());
@@ -2014,7 +1760,7 @@ TAPTEST(thr_config)
       {
         BaseString out(tmp.getConfigString());
         THRConfig check;
-        OK(check.do_parse(out.c_str(), 0, 0) == 0);
+        OK(check.do_parse_thrconfig(out.c_str(), 0, 0) == 0);
         OK(strcmp(out.c_str(), check.getConfigString()) == 0);
       }
     }
@@ -2022,8 +1768,8 @@ TAPTEST(thr_config)
     for (Uint32 i = 0; fail[i]; i++)
     {
       THRConfig tmp;
-      int res = tmp.do_parse(fail[i], 0, 0);
-      printf("do_parse(%s) => %s - %s\n", fail[i],
+      int res = tmp.do_parse_thrconfig(fail[i], 0, 0);
+      printf("do_parse_thrconfig(%s) => %s - %s\n", fail[i],
              res == 0 ? "OK" : "FAIL",
              res == 0 ? "" : tmp.getErrorMessage());
       OK(res != 0);
@@ -2188,7 +1934,7 @@ TAPTEST(thr_config)
     {
       THRConfig tmp;
       tmp.setLockExecuteThreadToCPU(t[i+0]);
-      const int _res = tmp.do_parse(t[i+1], 0, 0);
+      const int _res = tmp.do_parse_thrconfig(t[i+1], 0, 0);
       const int expect_res = strcmp(t[i+2], "OK") == 0 ? 0 : -1;
       const int res = _res == expect_res ? 0 : -1;
       int ok = expect_res == 0 ?

--- a/storage/ndb/src/common/portlib/NdbHW.cpp
+++ b/storage/ndb/src/common/portlib/NdbHW.cpp
@@ -58,6 +58,7 @@ static Uint32 *g_first_virt_l3_cache = nullptr;
 static Uint32 *g_num_l3_cpus = nullptr;
 static Uint32 *g_num_l3_cpus_online = nullptr;
 static Uint32 *g_num_virt_l3_cpus = nullptr;
+static Uint32 *g_create_cpu_map = nullptr;
 
 /**
  * initialize list of cpu
@@ -182,6 +183,43 @@ void NdbHW_End()
 }
 
 void
+Ndb_InitRRGroups(Uint32 *rr_group,
+                 Uint32 num_rr_groups,
+                 Uint32 num_query_instances,
+                 Uint32 max_threads)
+{
+  require(num_query_instances <= max_threads);
+  require(num_rr_groups > 0);
+  for (Uint32 i = 0; i < max_threads; i++)
+  {
+    rr_group[i] = 0xFFFFFFFF; //Ensure group not valid as init value
+  }
+  if (g_create_cpu_map)
+  {
+    memcpy(rr_group,
+           g_create_cpu_map,
+           sizeof(Uint32) * num_query_instances);
+    for (Uint32 i = 0; i < num_query_instances; i++)
+    {
+      require(rr_group[i] < num_rr_groups);
+    }
+  }
+  else
+  {
+    Uint32 rr_group_id = 0;
+    for (Uint32 i = 0; i < num_query_instances; i++)
+    {
+      rr_group[i] = rr_group_id;
+      rr_group_id++;
+      if (rr_group_id == num_rr_groups)
+      {
+        rr_group_id = 0;
+      }
+    }
+  }
+}
+
+void
 Ndb_GetCoreCPUIds(Uint32 cpu_id, Uint32 *cpu_ids, Uint32 &num_cpus)
 {
   struct ndb_hwinfo *hwinfo = g_ndb_hwinfo;
@@ -200,11 +238,13 @@ Ndb_GetCoreCPUIds(Uint32 cpu_id, Uint32 *cpu_ids, Uint32 &num_cpus)
   }
   Uint32 index = 1;
   Uint32 core_id = hwinfo->cpu_info[cpu_id].core_id;
+  Uint32 package_id = hwinfo->cpu_info[cpu_id].package_id;
   cpu_ids[0] = cpu_id;
   for (Uint32 i = 0; i < hwinfo->cpu_cnt_max; i++)
   {
     if ((hwinfo->cpu_info[i].online == 1) &&
         (hwinfo->cpu_info[i].core_id == core_id) &&
+        (hwinfo->cpu_info[i].package_id == package_id) &&
         (i != cpu_id))
     {
       cpu_ids[index] = i;
@@ -216,9 +256,9 @@ Ndb_GetCoreCPUIds(Uint32 cpu_id, Uint32 *cpu_ids, Uint32 &num_cpus)
 }
 
 Uint32
-Ndb_GetRRGroups(Uint32 ldm_threads)
+Ndb_GetRRGroups(Uint32 num_query_instances)
 {
-  return (ldm_threads + MAX_RR_GROUP_SIZE) / MAX_RR_GROUP_SIZE;
+  return (num_query_instances + MAX_RR_GROUP_SIZE) / MAX_RR_GROUP_SIZE;
 }
 
 Uint32
@@ -257,27 +297,36 @@ create_prev_list(struct ndb_hwinfo *hwinfo)
 
 static void
 create_cpu_list(struct ndb_hwinfo *hwinfo,
-                Uint32 num_cpus_per_ldm_group,
                 Uint32 num_rr_groups,
-                Uint32 num_ldm_instances)
+                Uint32 num_query_instances)
 {
-  Uint32 found_ldm_groups = 0;
   Uint32 prev_cpu = RNIL;
   Uint32 next_cpu = RNIL;
   Uint32 all_groups = hwinfo->num_virt_l3_caches;
-  Uint32 current_groups = num_rr_groups > 0 ? num_rr_groups : all_groups;
   bool found = false;
+  Uint32 found_query = 0;
   Uint32 first_virt_l3_cache[MAX_NUM_CPUS];
-  for (Uint32 i = 0; i < hwinfo->num_virt_l3_caches; i++)
+  for (Uint32 i = 0; i < all_groups; i++)
   {
     first_virt_l3_cache[i] = g_first_virt_l3_cache[i];
   }
+  /**
+   * Create a CPU list with 2 CPUs at a time from each virtual
+   * L3 cache. This means that we can assign one LDM and one
+   * other block thread that contains a Query instance.
+   *
+   * This code is highly dependant of the code in do_parse
+   * in thread_config.cpp for Automatic Thread Config where
+   * we make use of all CPUs available.
+   */
+  Uint32 num_groups = num_rr_groups;
+  Uint32 inx = 0;
   do
   {
     found = false;
-    for (Uint32 i = 0; i < current_groups; i++)
+    for (Uint32 i = 0; i < num_groups; i++)
     {
-      for (Uint32 j = 0; j < num_cpus_per_ldm_group; j++)
+      for (Uint32 j = 0; j < 2; j++)
       {
         next_cpu = first_virt_l3_cache[i];
         if (next_cpu == RNIL)
@@ -297,26 +346,17 @@ create_cpu_list(struct ndb_hwinfo *hwinfo,
         first_virt_l3_cache[i] =
           hwinfo->cpu_info[next_cpu].next_virt_l3_cpu_map;
         hwinfo->cpu_info[next_cpu].next_cpu_map = RNIL;
-      }
-      if (next_cpu == RNIL)
-      {
-        require(found_ldm_groups >= num_ldm_instances);
-      }
-      else
-      {
-        found_ldm_groups++;
-        if (found_ldm_groups == num_ldm_instances)
-        {
-          /**
-           * We have setup all LDM and Query instances, now we can process the
-           * remainder without the same level of checks and looping through all
-           * groups.
-           */
-          current_groups = all_groups;
-        }
+        g_create_cpu_map[inx++] = i;
+        found_query++;
       }
     }
+    if (!found && num_groups < all_groups)
+    {
+      num_groups = all_groups;
+      found = true;
+    }
   } while (found);
+  require(found_query >= num_query_instances);
   return;
 }
 
@@ -363,6 +403,16 @@ sort_virt_l3_caches(struct ndb_hwinfo *hwinfo)
       }
     }
   }
+#ifdef VM_TRACE
+  for (Uint32 i = 0; i < hwinfo->num_virt_l3_caches; i++)
+  {
+    Uint32 num_cpus_in_group = g_num_virt_l3_cpus[i];
+    (void)num_cpus_in_group;
+    DEBUG_HW((stderr,
+              "num_cpus %u in group %u\n",
+              num_cpus_in_group, i));
+  }
+#endif
 }
 
 static void create_init_virt_l3_cache_list(struct ndb_hwinfo *hwinfo)
@@ -571,102 +621,101 @@ create_l3_cache_list(struct ndb_hwinfo *hwinfo)
 }
 
 static bool
-check_if_virt_l3_cache_will_be_ok(struct ndb_hwinfo *hwinfo,
-                                  Uint32 group_size,
-                                  Uint32 num_groups,
-                                  Uint32 num_ldm_instances,
-                                  Uint32 ldm_group_size)
+check_if_virt_l3_cache_is_ok(struct ndb_hwinfo *hwinfo,
+                             Uint32 group_size,
+                             Uint32 num_groups,
+                             Uint32 num_query_instances,
+                             Uint32 min_group_size,
+                             bool will_be_ok)
 {
+  Uint32 count_non_fit_groups = 0;
+  Uint32 count_non_fit_group_cpus = 0;
+  Uint32 count_extra_cpus = 0;
   Uint32 count_full_groups_found = 0;
   Uint32 count_non_full_groups_found = 0;
-  Uint32 full_group_size = group_size * ldm_group_size;
-  Uint32 non_full_group_size = (group_size - 1) * ldm_group_size;
+  Uint32 full_group_size = group_size;
+  Uint32 non_full_group_size = group_size > 2 ? group_size - 2 : 1;
+  if (non_full_group_size < min_group_size)
+    non_full_group_size = min_group_size;
+
   DEBUG_HW((stderr,
             "full group size: %u, non full group size: %u"
-            ", ldm group size: %u\n",
+            ", num_groups: %u, will_be_ok: %u\n",
             full_group_size,
             non_full_group_size,
-            ldm_group_size));
+            num_groups,
+            will_be_ok));
   for (Uint32 i = 0; i < hwinfo->num_virt_l3_caches; i++)
   {
     Uint32 num_cpus_in_group = g_num_virt_l3_cpus[i];
     DEBUG_HW((stderr,
               "num_cpus %u in group %u\n",
               num_cpus_in_group, i));
+    bool found_full_group = false;
     while (num_cpus_in_group >= full_group_size)
     {
+      found_full_group = true;
       num_cpus_in_group -= full_group_size;
       count_full_groups_found++;
+      if (!will_be_ok)
+        break;
     }
-    if (num_cpus_in_group >= non_full_group_size)
+    if (!found_full_group && num_cpus_in_group >= non_full_group_size)
     {
       count_non_full_groups_found++;
     }
+    else if (!found_full_group)
+    {
+      count_non_fit_groups++;
+      count_non_fit_group_cpus += num_cpus_in_group;
+    }
+    else
+    {
+      count_extra_cpus += num_cpus_in_group;
+      continue;
+    }
+    if (num_cpus_in_group > non_full_group_size)
+    {
+      count_extra_cpus += (num_cpus_in_group - min_group_size);
+    }
   }
   DEBUG_HW((stderr,
-            "Full groups: %u, Non-full groups: %u\n",
+            "Full groups: %u, Non-full groups: %u"
+            ", extra_cpus: %u, non-fit_groups: %u"
+            ", non-fit group cpus: %u\n",
             count_full_groups_found,
-            count_non_full_groups_found));
+            count_non_full_groups_found,
+            count_extra_cpus,
+            count_non_fit_groups,
+            count_non_fit_group_cpus));
   /* Only count non full groups up until the searched number of groups */
   count_non_full_groups_found = MIN(count_non_full_groups_found,
                                     (num_groups - count_full_groups_found));
-  Uint32 tot_ldm_groups_found =
+  Uint32 tot_query_found =
     count_full_groups_found * group_size +
-    count_non_full_groups_found * (group_size - 1);
-  DEBUG_HW((stderr,
-            "Total LDM groups found: %u\n", tot_ldm_groups_found));
-  return (tot_ldm_groups_found >= num_ldm_instances);
-}
+    count_non_full_groups_found * non_full_group_size;
 
-static bool
-check_if_virt_l3_cache_is_ok(struct ndb_hwinfo *hwinfo,
-                             Uint32 group_size,
-                             Uint32 num_groups,
-                             Uint32 num_ldm_instances,
-                             Uint32 ldm_group_size)
-{
-  Uint32 count_full_groups_found = 0;
-  Uint32 count_non_full_groups_found = 0;
-  Uint32 full_group_size = group_size * ldm_group_size;
-  Uint32 non_full_group_size = (group_size - 1) * ldm_group_size;
-  for (Uint32 i = 0; i < hwinfo->num_virt_l3_caches; i++)
-  {
-    Uint32 num_cpus_in_group = g_num_virt_l3_cpus[i];
-    if (num_cpus_in_group >= full_group_size)
-    {
-      count_full_groups_found++;
-    }
-    else if (num_cpus_in_group >= non_full_group_size)
-    {
-      count_non_full_groups_found++;
-    }
-  }
-  count_non_full_groups_found = MIN(count_non_full_groups_found,
-                                    (num_groups - count_full_groups_found));
-  Uint32 tot_ldm_groups_found =
-    count_full_groups_found * group_size +
-    count_non_full_groups_found * (group_size - 1);
-  DEBUG_HW((stderr,
-            "Total LDM groups found: %u\n", tot_ldm_groups_found));
-  return (tot_ldm_groups_found >= num_ldm_instances);
-}
+  if (count_extra_cpus == 0 && count_non_fit_groups == 1)
+    tot_query_found += count_non_fit_group_cpus;
 
+  DEBUG_HW((stderr,
+            "Total Query instances found: %u\n", tot_query_found));
+  return (tot_query_found >= num_query_instances);
+}
 
 static void
 merge_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
                          Uint32 largest_list,
                          Uint32 second_largest_list,
-                         Uint32 min_group_size,
-                         Uint32 ldm_group_size)
+                         Uint32 min_group_size)
 {
   DEBUG_HW((stderr,
             "merge_virt_l3_cache_list, "
             " into group %u from group %u, "
-            " min_group_size: %u, ldm_group_size: %u\n",
+            " min_group_size: %u\n",
             largest_list,
             second_largest_list,
-            min_group_size,
-            ldm_group_size));
+            min_group_size));
   /**
    * Merge first list at end of second list. Make second list as long
    * as the minimum group size, but not larger than that to avoid
@@ -676,7 +725,7 @@ merge_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
    * Move last entry into removed entry if not removed entry was the
    * last entry.
    */
-  Uint32 group_size = ldm_group_size * min_group_size;
+  Uint32 group_size = min_group_size;
   Uint32 num_cpus_in_first_list = g_num_virt_l3_cpus[largest_list];
   Uint32 first_cpu_next = g_first_virt_l3_cache[largest_list];
   Uint32 last_cpu_first;
@@ -744,6 +793,11 @@ split_group(struct ndb_hwinfo *hwinfo,
    * position with the first group_size CPUs removed to the new list.
    * Increment number of virtual L3 caches.
    */
+  DEBUG_HW((stderr,
+            "Split L3 group %u, current size: %u, group_size: %u\n",
+            split_group_id,
+            g_num_virt_l3_cpus[split_group_id],
+            check_group_size));
   g_num_virt_l3_cpus[hwinfo->num_virt_l3_caches] =
     g_num_virt_l3_cpus[split_group_id] - check_group_size;
   g_num_virt_l3_cpus[split_group_id] = check_group_size;
@@ -762,44 +816,13 @@ split_group(struct ndb_hwinfo *hwinfo,
   hwinfo->num_virt_l3_caches++;
 }
 
-static void
-adjust_rr_group_sizes(struct ndb_hwinfo *hwinfo,
-                      Uint32 num_rr_groups,
-                      Uint32 ldm_group_size,
-                      Uint32 num_ldm_instances)
-{
-  if(num_rr_groups == 0)
-    return;
-  Uint32 group_size =
-    (num_ldm_instances + (num_rr_groups - 1)) / num_rr_groups;
-  Uint32 non_full_groups =
-    (group_size * num_rr_groups) - num_ldm_instances;
-  Uint32 full_groups = num_rr_groups - non_full_groups;
-  require(full_groups > 0);
-  for (Uint32 i = 0; i < num_rr_groups; i++)
-  {
-    Uint32 check_group_size = group_size * ldm_group_size;
-    if (i >= full_groups)
-    {
-      check_group_size = (group_size - 1) * ldm_group_size;
-    }
-    if (g_num_virt_l3_cpus[i] > check_group_size)
-    {
-      split_group(hwinfo,
-                  i,
-                  check_group_size);
-    }
-  }
-}
-
 static bool
 split_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
-                         Uint32 group_size,
-                         Uint32 ldm_group_size)
+                         Uint32 group_size)
 {
   DEBUG_HW((stderr,
             "split_virt_l3_cache_list\n"));
-  Uint32 check_group_size = group_size * ldm_group_size;
+  Uint32 check_group_size = group_size;
   Uint32 largest_group_size = 0;
   Uint32 largest_group_id = RNIL;
   for (Uint32 i = 0; i < hwinfo->num_virt_l3_caches; i++)
@@ -826,8 +849,7 @@ split_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
 
 static bool
 create_min_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
-                              Uint32 min_group_size,
-                              Uint32 ldm_group_size)
+                              Uint32 min_group_size)
 {
   if (hwinfo->num_virt_l3_caches == 1)
   {
@@ -835,7 +857,7 @@ create_min_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
   }
   Uint32 largest_group_id = RNIL;
   Uint32 largest_group_size = 0;
-  Uint32 group_size = ldm_group_size * min_group_size;
+  Uint32 group_size = min_group_size;
   DEBUG_HW((stderr,
             "create_min_virt_l3_cache_list\n"));
   DEBUG_HW((stderr,
@@ -876,12 +898,16 @@ create_min_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
              largest_group_size,
              sec_largest_group_id,
              sec_largest_group_size));
+  if (sec_largest_group_id == RNIL)
+  {
+    return true;
+  }
   require(sec_largest_group_id != RNIL);
+  require(largest_group_id != RNIL);
   merge_virt_l3_cache_list(hwinfo,
                            largest_group_id,
                            sec_largest_group_id,
-                           min_group_size,
-                           ldm_group_size);
+                           min_group_size);
   return true;
 }
 
@@ -900,11 +926,10 @@ create_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
                           Uint32 optimal_group_size,
                           Uint32 min_group_size,
                           Uint32 max_num_groups,
-                          Uint32 ldm_group_size,
-                          Uint32 num_ldm_instances)
+                          Uint32 num_query_instances)
 {
   create_init_virt_l3_cache_list(hwinfo);
-  if(num_ldm_instances == 0 && max_num_groups == 0)
+  if(num_query_instances == 0 && max_num_groups == 0)
     return 0;
 
   /**
@@ -929,23 +954,38 @@ create_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
    * and is thus the last step when nothing else works to create a
    * set of minimally sized groups.
    */
+  if (min_group_size < MIN_RR_GROUP_SIZE)
+  {
+    /* In this case use group size = 1 */
+    if (min_group_size >= 2)
+    {
+      min_group_size = 2;
+      optimal_group_size = 2;
+    }
+    else
+    {
+      min_group_size = 1;
+      optimal_group_size = 1;
+    }
+  }
   bool found_group_size = false;
   Uint32 used_group_size = min_group_size;
   Uint32 used_num_groups = max_num_groups;
   for (Uint32 check_group_size = optimal_group_size;
        check_group_size >= min_group_size;
-       check_group_size--)
+       check_group_size -= 2)
   {
     Uint32 num_groups =
-      (num_ldm_instances + (check_group_size - 1)) /
+      (num_query_instances + (check_group_size - 1)) /
         check_group_size;
-    if (num_groups * (check_group_size - 1) < num_ldm_instances)
+    if (num_groups * check_group_size >= num_query_instances)
     {
-      if (check_if_virt_l3_cache_will_be_ok(hwinfo,
-                                            check_group_size,
-                                            num_groups,
-                                            num_ldm_instances,
-                                            ldm_group_size))
+      if (check_if_virt_l3_cache_is_ok(hwinfo,
+                                       check_group_size,
+                                       num_groups,
+                                       num_query_instances,
+                                       min_group_size,
+                                       true))
       {
         DEBUG_HW((stderr,
                   "Virtual L3 cache will be ok with group size %u\n",
@@ -963,15 +1003,15 @@ create_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
     if (check_if_virt_l3_cache_is_ok(hwinfo,
                                      used_group_size,
                                      used_num_groups,
-                                     num_ldm_instances,
-                                     ldm_group_size))
+                                     num_query_instances,
+                                     min_group_size,
+                                     false))
     {
       return used_num_groups;
     }
     DEBUG_HW((stderr, "Split virtual L3 cache list\n"));
     if (!split_virt_l3_cache_list(hwinfo,
-                                  used_group_size,
-                                  ldm_group_size))
+                                  used_group_size))
     {
       break;
     }
@@ -993,14 +1033,21 @@ create_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
    * L3 cache groups to be able to form groups of at least the minimum
    * group size.
    */
+  DEBUG_HW((stderr,
+            "Start merge loop, min_group_size: %u, max_num_groups: %u, "
+            "num_query_instances: %u\n",
+            min_group_size,
+            max_num_groups,
+            num_query_instances));
   loop_count = 0;
   do
   {
     if (check_if_virt_l3_cache_is_ok(hwinfo,
                                      min_group_size,
                                      max_num_groups,
-                                     num_ldm_instances,
-                                     ldm_group_size))
+                                     num_query_instances,
+                                     min_group_size,
+                                     false))
     {
       return max_num_groups;
     }
@@ -1009,8 +1056,7 @@ create_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
               ", minimum group size is %u\n",
               min_group_size));
     if (!create_min_virt_l3_cache_list(hwinfo,
-                                       min_group_size,
-                                       ldm_group_size))
+                                       min_group_size))
     {
       break;
     }
@@ -1022,8 +1068,7 @@ create_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
 }
 
 Uint32
-Ndb_CreateCPUMap(Uint32 num_ldm_instances,
-                 Uint32 num_query_threads_per_ldm)
+Ndb_CreateCPUMap(Uint32 num_query_instances, Uint32 max_threads)
 {
   struct ndb_hwinfo *hwinfo = g_ndb_hwinfo;
   /**
@@ -1039,48 +1084,52 @@ Ndb_CreateCPUMap(Uint32 num_ldm_instances,
    * this list will be ok even if we set number of LDM instances to 0
    * here.
    */
-  num_ldm_instances = (num_ldm_instances == 0) ? 1 : num_ldm_instances;
-  Uint32 num_cpus_per_ldm_group = 1 + num_query_threads_per_ldm;
-  Uint32 optimal_num_ldm_groups =
-    (num_ldm_instances + (MAX_RR_GROUP_SIZE - 1)) /
-    MAX_RR_GROUP_SIZE;
-  Uint32 optimal_group_size = (num_ldm_instances > 0) ?
-    (num_ldm_instances + (optimal_num_ldm_groups - 1)) /
-    optimal_num_ldm_groups : 0;
-  Uint32 max_num_groups = num_ldm_instances < MAX_RR_GROUP_SIZE ? 1 :
-    num_ldm_instances / MIN_RR_GROUP_SIZE;
-  max_num_groups = (num_ldm_instances > 0) ? max_num_groups : 0;
-  Uint32 min_group_size = (max_num_groups > 0) ?
-      (num_ldm_instances + (max_num_groups - 1)) / max_num_groups : 0;
+  g_create_cpu_map = (Uint32*)malloc(sizeof(Uint32) * max_threads);
+  num_query_instances = (num_query_instances == 0) ? 1 : num_query_instances;
+  Uint32 optimal_group_size = MAX_RR_GROUP_SIZE;
+  Uint32 min_group_size = MIN(MIN_RR_GROUP_SIZE, num_query_instances);
+  Uint32 max_num_groups =
+    (num_query_instances + (min_group_size - 1)) / min_group_size;
 
-  hwinfo->num_cpus_per_group = num_cpus_per_ldm_group;
   DEBUG_HW((stderr,
             "Call create_virt_l3_cache_list: "
-            " %u opt groups, size: %u ::"
-            " %u min groups, size: %u ::"
-            " num ldms: %u CPUs per group: %u\n",
-            optimal_num_ldm_groups,
+            " opt group size: %u\n"
+            " max_num_groups: %u min_group_size: %u\n"
+            " num query instances: %u\n",
             optimal_group_size,
             max_num_groups,
             min_group_size,
-            num_ldm_instances,
-            num_cpus_per_ldm_group));
+            num_query_instances));
   Uint32 num_rr_groups = create_virt_l3_cache_list(hwinfo,
                                                    optimal_group_size,
                                                    min_group_size,
                                                    max_num_groups,
-                                                   num_cpus_per_ldm_group,
-                                                   num_ldm_instances);
+                                                   num_query_instances);
   sort_virt_l3_caches(hwinfo);
-  adjust_rr_group_sizes(hwinfo,
-                     num_rr_groups,
-                     num_cpus_per_ldm_group,
-                     num_ldm_instances);
   create_prev_list(hwinfo);
+
+  /**
+   * Check if we need to bring along the last group with too
+   * few CPUs, but still required to fill the number of
+   * instances we seek.
+   */
+  Uint32 found_instances = 0;
+  for (Uint32 i = 0; i < num_rr_groups; i++)
+  {
+    found_instances += g_num_virt_l3_cpus[i];
+  }
+  if (found_instances < num_query_instances)
+  {
+    require(num_rr_groups < hwinfo->num_virt_l3_caches);
+    found_instances += g_num_virt_l3_cpus[num_rr_groups];
+    require(found_instances >= num_query_instances);
+    num_rr_groups++;
+  }
+
   create_cpu_list(hwinfo,
-                  num_cpus_per_ldm_group,
                   num_rr_groups,
-                  num_ldm_instances);
+                  num_query_instances);
+  require(found_instances >= num_query_instances);
   return num_rr_groups;
 }
 
@@ -1128,6 +1177,9 @@ static struct ndb_hwinfo *Ndb_SetHWInfo()
   res->cpu_data = (ndb_cpudata*)p_cpudata;
   res->cpu_cnt_max = ncpu;
   res->cpu_cnt = ncpu;
+#if 0
+  fprintf(stderr, "Found %u CPUs on the machine\n", ncpu);
+#endif
   res->total_cpu_capacity = ncpu * 100;
 
   for (Uint32 i = 0; i < ncpu; i++)
@@ -1654,6 +1706,9 @@ static int Ndb_ReloadHWInfo(struct ndb_hwinfo * hwinfo)
     goto error_exit;
 
   hwinfo->cpu_cnt = active_cpu;
+#if 0
+  fprintf(stderr, "Found %u active CPUs on the machine\n", active_cpu);
+#endif
   hwinfo->num_cpu_cores = cpu_cores;
   hwinfo->num_cpu_sockets = cpu_sockets;
   hwinfo->hw_memory_size = (Uint64)memory_size;
@@ -1748,6 +1803,9 @@ static int Ndb_ReloadHWInfo(struct ndb_hwinfo * hwinfo)
     hwinfo->cpu_info[i].online = true;
   }
   hwinfo->cpu_cnt = active_cpu;
+#if 0
+  fprintf(stderr, "Found %u active CPUs on the machine\n", active_cpu);
+#endif
   check_cpu_online(hwinfo);
   hwinfo->num_cpu_cores = 0;
   hwinfo->num_cpu_sockets = 0;
@@ -2582,6 +2640,9 @@ static int Ndb_ReloadHWInfo(struct ndb_hwinfo * hwinfo)
   {
     /* Linux ARM needs information from other sources */
     hwinfo->cpu_cnt = cpu_online_count;
+#if 0
+    fprintf(stderr, "Found %u active CPUs on the machine\n", cpu_online_count);
+#endif
     DEBUG_HW((stderr,
               "Found %u CPUs online, no core info in /proc/cpuinfo\n",
               cpu_online_count));
@@ -2649,6 +2710,9 @@ static int Ndb_ReloadHWInfo(struct ndb_hwinfo * hwinfo)
               num_cpu_per_core));
   }
   hwinfo->cpu_cnt = cpu_online_count;
+#if 0
+  fprintf(stderr, "Found %u active CPUs on the machine\n", cpu_online_count);
+#endif
   DEBUG_HW((stderr,
             "There are %u CPUs online before checking\n",
             cpu_online_count));
@@ -2717,6 +2781,9 @@ static int init_hwinfo(struct ndb_hwinfo *)
 static int Ndb_ReloadHWInfo(struct ndb_hwinfo * hwinfo)
 {
   hwinfo->cpu_cnt_max = ncpu;
+#if 0
+  fprintf(stderr, "Found %u active CPUs on the machine\n", ncpu);
+#endif
   hwinfo->cpu_cnt = ncpu;
   check_cpu_online(hwinfo);
   return 0;
@@ -2762,164 +2829,151 @@ static int Ndb_ReloadCPUData(struct ndb_hwinfo *)
 struct test_cpumap_data
 {
   Uint32 num_l3_caches;
+  Uint32 num_cpus_per_l3_cache;
   Uint32 num_cpus_in_l3_cache[MAX_NUM_L3_CACHES];
-  Uint32 num_query_threads_per_ldm;
-  Uint32 num_ldm_instances;
-  Uint32 cores_per_package;
+  Uint32 num_query_instances;
+  Uint32 num_cpus_per_package;
+  Uint32 num_p_cpus_per_core;
+  Uint32 num_p_cpus_per_package;
+  Uint32 num_e_cpus_per_package;
+  Uint32 num_e_cpus_per_core;
   bool exact_core;
-  bool intel_core;
 };
 
 static void test_1(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 1;
+  map->num_cpus_per_l3_cache = 4;
   map->num_cpus_in_l3_cache[0] = 4;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 2;
-  map->cores_per_package = 4;
+  map->num_query_instances = 4;
+  map->num_cpus_per_package = 4;
   map->exact_core = true;
-  map->intel_core = false;
-  printf("Run test 1 with 1 L3 group with 4 CPUs, 2 LDMs\n");
+  printf("Run test 1 with 1 L3 group with 4 CPUs, 4 Query\n");
 }
 
 static void test_2(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 1;
+  map->num_cpus_per_l3_cache = 16;
   map->num_cpus_in_l3_cache[0] = 16;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 6;
-  map->cores_per_package = 16;
+  map->num_query_instances = 14;
+  map->num_cpus_per_package = 16;
   map->exact_core = true;
-  map->intel_core = false;
-  printf("Run test 2 with 1 L3 group with 16 CPUs, 6 LDMs\n");
+  printf("Run test 2 with 1 L3 group with 16 CPUs, 14 Query\n");
 }
 
 static void test_3(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 2;
+  map->num_cpus_per_l3_cache = 8;
   map->num_cpus_in_l3_cache[0] = 8;
   map->num_cpus_in_l3_cache[1] = 8;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 8;
-  map->cores_per_package = 8;
+  map->num_query_instances = 16;
+  map->num_cpus_per_package = 8;
   map->exact_core = true;
-  map->intel_core = false;
-  printf("Run test 3 with 2 L3 group with 8,8 CPUs, 8 LDMs\n");
+  printf("Run test 3 with 2 L3 group with 8,8 CPUs, 16 Query\n");
 }
 
 static void test_4(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 4;
+  map->num_cpus_per_l3_cache = 8;
   map->num_cpus_in_l3_cache[0] = 4;
   map->num_cpus_in_l3_cache[1] = 8;
   map->num_cpus_in_l3_cache[2] = 2;
   map->num_cpus_in_l3_cache[3] = 6;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 8;
-  map->cores_per_package = 32;
-  map->exact_core = true;
-  map->intel_core = false;
-  printf("Run test 4 with 4 L3 group with 4,8,2,6 CPUs, 8 LDMs\n");
+  map->num_query_instances = 19;
+  map->num_cpus_per_package = 32;
+  printf("Run test 4 with 4 L3 group with 4,8,2,6 CPUs, 19 Query\n");
 }
 
 static void test_5(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 4;
+  map->num_cpus_per_l3_cache = 8;
   map->num_cpus_in_l3_cache[0] = 4;
   map->num_cpus_in_l3_cache[1] = 8;
   map->num_cpus_in_l3_cache[2] = 2;
   map->num_cpus_in_l3_cache[3] = 4;
-  map->cores_per_package = 16;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 8;
-  map->exact_core = true;
-  map->intel_core = false;
-  printf("Run test 5 with 4 L3 group with 4,8,2,4 CPUs, 8 LDMs\n");
+  map->num_cpus_per_package = 8;
+  map->num_query_instances = 18;
+  printf("Run test 5 with 4 L3 group with 4,8,2,4 CPUs, 18 Query\n");
 }
 
 static void test_6(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 2;
+  map->num_cpus_per_l3_cache = 30;
   map->num_cpus_in_l3_cache[0] = 30;
   map->num_cpus_in_l3_cache[1] = 30;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 16;
-  map->cores_per_package = 15;
+  map->num_query_instances = 50;
+  map->num_cpus_per_package = 30;
   map->exact_core = true;
-  map->intel_core = false;
-  printf("Run test 6 with 2 L3 group with 30,30 CPUs, 16 LDMs\n");
+  printf("Run test 6 with 2 L3 group with 30,30 CPUs, 50 Query\n");
 }
 
 static void test_7(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 2;
+  map->num_cpus_per_l3_cache = 30;
   map->num_cpus_in_l3_cache[0] = 30;
   map->num_cpus_in_l3_cache[1] = 30;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 18;
-  map->cores_per_package = 15;
+  map->num_query_instances = 55;
+  map->num_cpus_per_package = 60;
   map->exact_core = true;
-  map->intel_core = false;
-  printf("Run test 7 with 2 L3 group with 30,30 CPUs, 18 LDMs\n");
+  printf("Run test 7 with 2 L3 group with 30,30 CPUs, 55 Query\n");
 }
 
 static void test_8(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 3;
+  map->num_cpus_per_l3_cache = 24;
   map->num_cpus_in_l3_cache[0] = 23;
   map->num_cpus_in_l3_cache[1] = 11;
   map->num_cpus_in_l3_cache[2] = 8;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 20;
-  map->cores_per_package = 12;
-  map->exact_core = false;
-  map->intel_core = true;
-  printf("Run test 8 with 3 L3 group with 23,11,8 CPUs, 20 LDMs\n");
+  map->num_query_instances = 42;
+  map->num_cpus_per_package = 24;
+  printf("Run test 8 with 3 L3 group with 23,11,8 CPUs, 42 Query\n");
 }
 
 static void test_9(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 2;
+  map->num_cpus_per_l3_cache = 36;
   map->num_cpus_in_l3_cache[0] = 33;
   map->num_cpus_in_l3_cache[1] = 11;
-  map->num_query_threads_per_ldm = 2;
-  map->num_ldm_instances = 14;
-  map->cores_per_package = 12;
-  map->exact_core = false;
-  map->intel_core = true;
-  printf("Run test 9 with 2 L3 group with 33,11 CPUs, 14(2) LDMs\n");
+  map->num_query_instances = 42;
+  map->num_cpus_per_package = 36;
+  printf("Run test 9 with 2 L3 group with 33,11 CPUs, 42 Query\n");
 }
 
 static void test_10(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 2;
+  map->num_cpus_per_l3_cache = 16;
   map->num_cpus_in_l3_cache[0] = 15;
   map->num_cpus_in_l3_cache[1] = 12;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 13;
-  map->cores_per_package = 8;
-  map->exact_core = false;
-  map->intel_core = true;
-  printf("Run test 10 with 2 L3 group with 15,12 CPUs, 13 LDMs\n");
+  map->num_query_instances = 26;
+  map->num_cpus_per_package = 16;
+  printf("Run test 10 with 2 L3 group with 15,12 CPUs, 26 Query\n");
 }
 
 static void test_11(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 3;
+  map->num_cpus_per_l3_cache = 16;
   map->num_cpus_in_l3_cache[0] = 15;
   map->num_cpus_in_l3_cache[1] = 13;
   map->num_cpus_in_l3_cache[2] = 13;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 19;
-  map->cores_per_package = 8;
-  map->exact_core = false;
-  map->intel_core = true;
-  printf("Run test 11 with 3 L3 group with 15,13,13 CPUs, 19 LDMs\n");
+  map->num_query_instances = 40;
+  map->num_cpus_per_package = 16;
+  printf("Run test 11 with 3 L3 group with 15,13,13 CPUs, 40 Query\n");
 }
 
 static void test_12(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 8;
+  map->num_cpus_per_l3_cache = 16;
   map->num_cpus_in_l3_cache[0] = 11;
   map->num_cpus_in_l3_cache[1] = 13;
   map->num_cpus_in_l3_cache[2] = 13;
@@ -2928,17 +2982,15 @@ static void test_12(struct test_cpumap_data *map)
   map->num_cpus_in_l3_cache[5] = 13;
   map->num_cpus_in_l3_cache[6] = 13;
   map->num_cpus_in_l3_cache[7] = 13;
-  map->num_query_threads_per_ldm = 3;
-  map->num_ldm_instances = 24;
-  map->cores_per_package = 4;
-  map->exact_core = false;
-  map->intel_core = true;
-  printf("Run test 12 with 8 L3 group with 11,13,,,,13 CPUs, 24 LDMs\n");
+  map->num_query_instances = 100;
+  map->num_cpus_per_package = 32;
+  printf("Run test 12 with 8 L3 group with 11,13,,,,13 CPUs, 100 Query\n");
 }
 
 static void test_13(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 8;
+  map->num_cpus_per_l3_cache = 16;
   map->num_cpus_in_l3_cache[0] = 16;
   map->num_cpus_in_l3_cache[1] = 16;
   map->num_cpus_in_l3_cache[2] = 16;
@@ -2947,17 +2999,15 @@ static void test_13(struct test_cpumap_data *map)
   map->num_cpus_in_l3_cache[5] = 16;
   map->num_cpus_in_l3_cache[6] = 8;
   map->num_cpus_in_l3_cache[7] = 8;
-  map->num_query_threads_per_ldm = 3;
-  map->num_ldm_instances = 24;
-  map->cores_per_package = 4;
-  map->exact_core = false;
-  map->intel_core = true;
-  printf("Run test 13 with 8 L3 group with 16,,,16,8,8 CPUs, 24 LDMs\n");
+  map->num_query_instances = 110;
+  map->num_cpus_per_package = 64;
+  printf("Run test 13 with 8 L3 group with 16,,,16,8,8 CPUs, 110 Query\n");
 }
 
 static void test_14(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 16;
+  map->num_cpus_per_l3_cache = 2;
   map->num_cpus_in_l3_cache[0] = 1;
   map->num_cpus_in_l3_cache[1] = 1;
   map->num_cpus_in_l3_cache[2] = 1;
@@ -2974,17 +3024,15 @@ static void test_14(struct test_cpumap_data *map)
   map->num_cpus_in_l3_cache[13] = 1;
   map->num_cpus_in_l3_cache[14] = 1;
   map->num_cpus_in_l3_cache[15] = 1;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 6;
-  map->cores_per_package = 4;
-  map->exact_core = false;
-  map->intel_core = true;
-  printf("Run test 14 with 16 L3 group with 1 CPU, 6 LDMs\n");
+  map->num_query_instances = 16;
+  map->num_cpus_per_package = 2;
+  printf("Run test 14 with 16 L3 group with 1 CPU, 16 Query\n");
 }
 
 static void test_15(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 16;
+  map->num_cpus_per_l3_cache = 16;
   map->num_cpus_in_l3_cache[0] = 1;
   map->num_cpus_in_l3_cache[1] = 2;
   map->num_cpus_in_l3_cache[2] = 4;
@@ -3001,111 +3049,139 @@ static void test_15(struct test_cpumap_data *map)
   map->num_cpus_in_l3_cache[13] = 2;
   map->num_cpus_in_l3_cache[14] = 4;
   map->num_cpus_in_l3_cache[15] = 2;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 24;
-  map->cores_per_package = 4;
-  map->exact_core = false;
-  map->intel_core = true;
-  printf("Run test 15 with 16 L3 group with 0/1 CPU, 4 LDMs\n");
+  map->num_query_instances = 50;
+  map->num_cpus_per_package = 32;
+  printf("Run test 15 with 16 L3 group with 0/1 CPU, 50 Query\n");
 }
 
 static void test_16(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 1;
+  map->num_cpus_per_l3_cache = 2;
   map->num_cpus_in_l3_cache[0] = 2;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 0;
-  map->cores_per_package = 1;
+  map->num_query_instances = 1;
+  map->num_cpus_per_package = 2;
   map->exact_core = true;
-  map->intel_core = true;
-  printf("Run test 16 with 1 L3 group with 2 CPU, 0 LDMs\n");
+  printf("Run test 16 with 1 L3 group with 2 CPU, 1 Query\n");
 }
 
 static void test_17(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 1;
+  map->num_cpus_per_l3_cache = 2;
   map->num_cpus_in_l3_cache[0] = 2;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 0;
-  map->cores_per_package = 1;
-  map->exact_core = false;
-  map->intel_core = true;
-  printf("Run test 17 with 1 L3 group with 2 CPU, 0 LDMs\n");
+  map->num_query_instances = 2;
+  map->num_cpus_per_package = 1;
+  printf("Run test 17 with 1 L3 group with 2 CPU, 2 Query\n");
 }
 
 static void test_18(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 1;
+  map->num_cpus_per_l3_cache = 2;
   map->num_cpus_in_l3_cache[0] = 2;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 0;
-  map->cores_per_package = 1;
+  map->num_query_instances = 1;
+  map->num_cpus_per_package = 2;
   map->exact_core = true;
-  map->intel_core = false;
-  printf("Run test 18 with 1 L3 group with 2 CPU, 0 LDMs\n");
+  printf("Run test 18 with 1 L3 group with 2 CPU, 1 Query\n");
 }
 
 static void test_19(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 1;
+  map->num_cpus_per_l3_cache = 2;
   map->num_cpus_in_l3_cache[0] = 2;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 0;
-  map->cores_per_package = 1;
-  map->exact_core = false;
-  map->intel_core = false;
-  printf("Run test 19 with 1 L3 group with 2 CPU, 0 LDMs\n");
+  map->num_query_instances = 2;
+  map->num_cpus_per_package = 1;
+  printf("Run test 19 with 1 L3 group with 2 CPU, 2 Query\n");
 }
 
 static void test_20(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 2;
+  map->num_cpus_per_l3_cache = 2;
   map->num_cpus_in_l3_cache[0] = 2;
   map->num_cpus_in_l3_cache[1] = 1;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 0;
-  map->cores_per_package = 1;
-  map->exact_core = false;
-  map->intel_core = true;
-  printf("Run test 20 with 2 L3 group with 1 CPU, 0 LDMs\n");
+  map->num_query_instances = 3;
+  map->num_cpus_per_package = 2;
+  printf("Run test 20 with 2 L3 group with 1 CPU, 3 Query\n");
 }
 
 static void test_21(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 3;
+  map->num_cpus_per_l3_cache = 2;
   map->num_cpus_in_l3_cache[0] = 1;
   map->num_cpus_in_l3_cache[1] = 1;
   map->num_cpus_in_l3_cache[2] = 1;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 0;
-  map->cores_per_package = 1;
-  map->exact_core = false;
-  map->intel_core = true;
-  printf("Run test 21 with 3 L3 group with 1 CPU, 0 LDMs\n");
+  map->num_query_instances = 3;
+  map->num_cpus_per_package = 2;
+  printf("Run test 21 with 3 L3 group with 1 CPU, 3 Query\n");
 }
 
 static void test_22(struct test_cpumap_data *map)
 {
   map->num_l3_caches = 2;
+  map->num_cpus_per_l3_cache = 2;
   map->num_cpus_in_l3_cache[0] = 1;
   map->num_cpus_in_l3_cache[1] = 1;
-  map->num_query_threads_per_ldm = 1;
-  map->num_ldm_instances = 0;
-  map->cores_per_package = 2;
-  map->exact_core = true;
-  map->intel_core = true;
-  printf("Run test 22 with 2 L3 group with 1 CPU, 0 LDMs\n");
+  map->num_query_instances = 2;
+  map->num_cpus_per_package = 2;
+  printf("Run test 22 with 2 L3 group with 1 CPU, 2 Query\n");
+}
+
+static void test_23(struct test_cpumap_data *map)
+{
+  map->num_l3_caches = 2;
+  map->num_cpus_per_l3_cache = 6;
+  map->num_cpus_in_l3_cache[0] = 6;
+  map->num_cpus_in_l3_cache[1] = 6;
+  map->num_query_instances = 11;
+  map->num_cpus_per_package = 12;
+  printf("Run test 23 with 2 L3 group with 6 CPU, 11 Query\n");
+}
+
+static void test_24(struct test_cpumap_data *map)
+{
+  map->num_l3_caches = 2;
+  map->num_cpus_per_l3_cache = 10;
+  map->num_cpus_in_l3_cache[0] = 10;
+  map->num_cpus_in_l3_cache[1] = 10;
+  map->num_query_instances = 19;
+  map->num_cpus_per_package = 20;
+  printf("Run test 24 with 2 L3 group with 10 CPUs, 19 Query\n");
+}
+
+static void test_25(struct test_cpumap_data *map)
+{
+  map->num_l3_caches = 1;
+  map->num_cpus_per_l3_cache = 32;
+  map->num_cpus_in_l3_cache[0] = 32;
+  map->num_p_cpus_per_package = 16;
+  map->num_e_cpus_per_package = 16;
+  map->num_query_instances = 30;
+  map->num_cpus_per_package = 32;
+  printf("Run test 25 with 1 L3 group with 32 CPUs, 30 Query, Intel Rapid Lake\n");
+}
+
+static void test_26(struct test_cpumap_data *map)
+{
+  map->num_l3_caches = 2;
+  map->num_cpus_per_l3_cache = 28;
+  map->num_cpus_in_l3_cache[0] = 28;
+  map->num_cpus_in_l3_cache[1] = 28;
+  map->num_p_cpus_per_package = 12;
+  map->num_e_cpus_per_package = 16;
+  map->num_query_instances = 54;
+  map->num_cpus_per_package = 28;
+  printf("Run test 26 with 2 L3 group with 28 CPUs, 54 Query, Intel Rapid Lake\n");
 }
 
 static void
 create_hwinfo_test_cpu_map(struct test_cpumap_data *map)
 {
-  Uint32 num_cpus = 0;
+  Uint32 num_cpus = map->num_cpus_per_l3_cache * map->num_l3_caches;
   g_ndb_hwinfo = (struct ndb_hwinfo*)malloc(sizeof(struct ndb_hwinfo));
-  for (Uint32 i = 0; i < map->num_l3_caches; i++)
-  {
-    num_cpus += map->num_cpus_in_l3_cache[i];
-  }
   void *ptr = malloc(sizeof(struct ndb_cpuinfo_data) * num_cpus);
   g_ndb_hwinfo->cpu_info = (struct ndb_cpuinfo_data*)ptr;
   g_ndb_hwinfo->cpu_cnt_max = num_cpus;
@@ -3116,32 +3192,60 @@ create_hwinfo_test_cpu_map(struct test_cpumap_data *map)
   Uint32 cpu_id = 0;
   struct ndb_hwinfo *hwinfo = g_ndb_hwinfo;
   Uint32 core_id = 0;
+  Uint32 package_id = 0;
+  Uint32 core_cpu_count = 0;
+  Uint32 num_cpus_per_core = map->num_p_cpus_per_core;
+  ncpu = 0;
+  Uint32 package_cpu_id = 0;
   for (Uint32 l3_cache_id = 0; l3_cache_id < map->num_l3_caches; l3_cache_id++)
   {
-    for (Uint32 i = 0; i < map->num_cpus_in_l3_cache[l3_cache_id]; i++)
+    require(map->num_cpus_per_l3_cache >=
+            map->num_cpus_in_l3_cache[l3_cache_id]);
+    for (Uint32 i = 0; i < map->num_cpus_per_l3_cache; i++)
     {
-      hwinfo->cpu_info[cpu_id].l3_cache_id = l3_cache_id;
-      hwinfo->cpu_info[cpu_id].cpu_no = cpu_id;
-      if (map->intel_core)
+      if (i < map->num_cpus_in_l3_cache[l3_cache_id])
       {
+        /* Online CPU */
+        hwinfo->cpu_info[cpu_id].l3_cache_id = l3_cache_id;
+        hwinfo->cpu_info[cpu_id].cpu_no = cpu_id;
         hwinfo->cpu_info[cpu_id].core_id = core_id;
-        core_id++;
-        if (core_id == map->cores_per_package)
-        {
-          core_id = 0;
-        }
+        hwinfo->cpu_info[cpu_id].socket_id = package_id;
+        hwinfo->cpu_info[cpu_id].package_id = package_id;
+        hwinfo->cpu_info[cpu_id].online = 1;
       }
       else
       {
-        hwinfo->cpu_info[cpu_id].core_id = cpu_id / 2;
+        hwinfo->cpu_info[cpu_id].l3_cache_id = l3_cache_id;
+        hwinfo->cpu_info[cpu_id].socket_id = package_id;
+        hwinfo->cpu_info[cpu_id].package_id = package_id;
+        hwinfo->cpu_info[cpu_id].online = 0;
+        hwinfo->cpu_info[cpu_id].core_id = core_id;
       }
-      hwinfo->cpu_info[cpu_id].socket_id = 0;
-      hwinfo->cpu_info[cpu_id].package_id = 0;
-      hwinfo->cpu_info[cpu_id].online = 1;
+      ncpu++;
       cpu_id++;
+      package_cpu_id++;
+      core_cpu_count++;
+      if (core_cpu_count == num_cpus_per_core)
+      {
+        core_id++;
+        core_cpu_count = 0;
+      }
+      if (package_cpu_id == map->num_p_cpus_per_package)
+      {
+        num_cpus_per_core = map->num_e_cpus_per_core;
+        core_cpu_count = 0;
+      }
+      if (package_cpu_id == map->num_cpus_per_package)
+      {
+        package_id++;
+        core_id = 0;
+        package_cpu_id = 0;
+        num_cpus_per_core = map->num_p_cpus_per_core;
+        core_cpu_count = 0;
+      }
     }
   }
-  create_l3_cache_list(g_ndb_hwinfo);
+  create_l3_cache_list(hwinfo);
 }
 
 static void
@@ -3155,9 +3259,10 @@ cleanup_test()
     Uint32 next_cpu = g_first_virt_l3_cache[i];
     do
     {
-      printf("    CPU %u, core: %u, l3_cache_id: %u\n",
+      printf("    CPU %u, core: %u, package_id: %u, l3_cache_id: %u\n",
              next_cpu,
              hwinfo->cpu_info[next_cpu].core_id,
+             hwinfo->cpu_info[next_cpu].package_id,
              hwinfo->cpu_info[next_cpu].l3_cache_id);
       next_cpu = hwinfo->cpu_info[next_cpu].next_virt_l3_cpu_map;
     } while (next_cpu != RNIL);
@@ -3166,9 +3271,10 @@ cleanup_test()
   Uint32 next_cpu = hwinfo->first_cpu_map;
   do
   {
-    printf("    CPU %u, core: %u, l3_cache_id: %u\n",
+    printf("    CPU %u, core: %u, package_id: %u, l3_cache_id: %u\n",
            next_cpu,
            hwinfo->cpu_info[next_cpu].core_id,
+           hwinfo->cpu_info[next_cpu].package_id,
            hwinfo->cpu_info[next_cpu].l3_cache_id);
     next_cpu = hwinfo->cpu_info[next_cpu].next_cpu_map;
   } while (next_cpu != RNIL);
@@ -3191,6 +3297,12 @@ cleanup_test()
 static void
 test_create(struct test_cpumap_data *map, Uint32 test_case)
 {
+  /* Set default values */
+  map->exact_core = false;
+  map->num_p_cpus_per_core = 2;
+  map->num_e_cpus_per_core = 1;
+  map->num_p_cpus_per_package = 0;
+  map->num_e_cpus_per_package = 0;
   switch (test_case)
   {
     case 0:
@@ -3303,16 +3415,41 @@ test_create(struct test_cpumap_data *map, Uint32 test_case)
       test_22(map);
       break;
     }
+    case 22:
+    {
+      test_23(map);
+      break;
+    }
+    case 23:
+    {
+      test_24(map);
+      break;
+    }
+    case 24:
+    {
+      test_25(map);
+      break;
+    }
+    case 25:
+    {
+      test_26(map);
+      break;
+    }
     default:
     {
       require(false);
       break;
     }
   }
+  if (map->num_p_cpus_per_package == 0)
+    map->num_p_cpus_per_package = map->num_cpus_per_package;
+  require(map->num_cpus_per_package ==
+          (map->num_p_cpus_per_package +
+           map->num_e_cpus_per_package));
   return;
 }
 
-#define NUM_TESTS 22
+#define NUM_TESTS 26
 static void
 test_create_cpumap()
 {
@@ -3320,25 +3457,29 @@ test_create_cpumap()
   expected_res[0] = 1;
   expected_res[1] = 1;
   expected_res[2] = 2;
-  expected_res[3] = 2;
-  expected_res[4] = 2;
-  expected_res[5] = 2;
-  expected_res[6] = 3;
-  expected_res[7] = 5;
-  expected_res[8] = 3;
+  expected_res[3] = 5;
+  expected_res[4] = 5;
+  expected_res[5] = 4;
+  expected_res[6] = 4;
+  expected_res[7] = 11;
+  expected_res[8] = 11;
   expected_res[9] = 2;
-  expected_res[10] = 3;
-  expected_res[11] = 6;
-  expected_res[12] = 6;
-  expected_res[13] = 1;
-  expected_res[14] = 6;
+  expected_res[10] = 10;
+  expected_res[11] = 25;
+  expected_res[12] = 14;
+  expected_res[13] = 4;
+  expected_res[14] = 13;
   expected_res[15] = 1;
   expected_res[16] = 1;
   expected_res[17] = 1;
   expected_res[18] = 1;
-  expected_res[19] = 1;
-  expected_res[20] = 1;
+  expected_res[19] = 2;
+  expected_res[20] = 2;
   expected_res[21] = 1;
+  expected_res[22] = 2;
+  expected_res[23] = 2;
+  expected_res[24] = 2;
+  expected_res[25] = 4;
   struct test_cpumap_data test_map;
   for (Uint32 i = 0; i < NUM_TESTS; i++)
   {
@@ -3348,27 +3489,33 @@ test_create_cpumap()
     create_hwinfo_test_cpu_map(&test_map);
     printf("Create CPUMap for test %u\n", i + 1);
     Uint32 num_rr_groups =
-      Ndb_CreateCPUMap(test_map.num_ldm_instances,
-                       test_map.num_query_threads_per_ldm);
+      Ndb_CreateCPUMap(test_map.num_query_instances, 1024);
     for (Uint32 id = 0; id < g_ndb_hwinfo->cpu_cnt_max; id++)
     {
-      Uint32 cpu_ids[8];
+      Uint32 cpu_ids[MAX_USED_NUM_CPUS];
       Uint32 num_cpus;
-      Ndb_GetCoreCPUIds(id, &cpu_ids[0], num_cpus);
-      printf("Ndb_GetCoreCPUIds: id: %u, num_cpus: %u\n",
-             id,
-             num_cpus);
-      if (test_map.exact_core)
+      if (g_ndb_hwinfo->cpu_info[id].online)
       {
-        OK(num_cpus == (test_map.num_query_threads_per_ldm + 1));
-      }
-      else
-      {
-        OK(num_cpus <= (test_map.num_query_threads_per_ldm + 1));
+        Ndb_GetCoreCPUIds(id, &cpu_ids[0], num_cpus);
+        printf("Ndb_GetCoreCPUIds: id: %u, num_cpus: %u\n",
+               id,
+               num_cpus);
+        if (test_map.exact_core)
+        {
+          OK(num_cpus == (test_map.num_p_cpus_per_core));
+        }
+        else
+        {
+          OK(num_cpus <= (test_map.num_p_cpus_per_core));
+        }
       }
     }
-    OK(num_rr_groups == expected_res[i]);
     cleanup_test();
+    printf("Test %u num_rr_groups: %u, expected: %u\n",
+           i + 1,
+           num_rr_groups,
+           expected_res[i]);
+    OK(num_rr_groups == expected_res[i]);
   }
   printf("test_create_cpumap passed\n");
 }

--- a/storage/ndb/src/kernel/blocks/backup/Backup.hpp
+++ b/storage/ndb/src/kernel/blocks/backup/Backup.hpp
@@ -819,7 +819,8 @@ private:
     Uint32 masterRef;
     NdbNodeBitmask nodes;
 
-    Bitmask<(Uint32)(MAX_NDBMT_LQH_THREADS/sizeof(Uint32))> fragWorkers[MAX_NDB_NODES];
+    Bitmask<(Uint32)(MAX_NDBMT_LQH_WORKERS/sizeof(Uint32))>
+      fragWorkers[MAX_NDB_NODES];
     Uint32 idleFragWorkerCount;
 
     /**

--- a/storage/ndb/src/kernel/blocks/dbacc/Dbacc.hpp
+++ b/storage/ndb/src/kernel/blocks/dbacc/Dbacc.hpp
@@ -1332,7 +1332,7 @@ public:
                                Uint32 & inx)
   {
     inx = 0;
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
     {
       LHBits32 hashVal = getElementHash(opPtr);
       inx = hashVal.get_bits(NUM_ACC_FRAGMENT_MUTEXES - 1);
@@ -1353,7 +1353,7 @@ public:
   void release_frag_mutex_hash(Fragmentrec *fragPtrP,
                                Uint32 inx)
   {
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
     {
 #if defined(VM_TRACE) || defined(ERROR_INSERT)
       jam();
@@ -1365,15 +1365,11 @@ public:
       jamDebug();
       jamLine(inx);
     }
-    else
-    {
-      ndbassert(inx == 0);
-    }
   }
   void acquire_frag_mutex_bucket(Fragmentrec *fragPtrP,
                                  Uint32 bucket)
   {
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
     {
       Uint32 inx = bucket & (NUM_ACC_FRAGMENT_MUTEXES - 1);
 #if defined(VM_TRACE) || defined(ERROR_INSERT)
@@ -1386,7 +1382,7 @@ public:
   }
   void release_frag_mutex_bucket(Fragmentrec *fragPtrP, Uint32 bucket)
   {
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
     {
       Uint32 inx = bucket & (NUM_ACC_FRAGMENT_MUTEXES - 1);
 #if defined(VM_TRACE) || defined(ERROR_INSERT)

--- a/storage/ndb/src/kernel/blocks/dbacc/DbaccMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbacc/DbaccMain.cpp
@@ -6755,9 +6755,7 @@ Dbacc::get_lock_information(Dbacc **acc_block, Dblqh** lqh_block)
   {
     (*acc_block) = this;
     (*lqh_block) = c_lqh;
-    if (!c_lqh->is_restore_phase_done() &&
-        (globalData.ndbMtRecoverThreads +
-         globalData.ndbMtQueryWorkers) > 0)
+    if (!c_lqh->is_restore_phase_done())
     {
       lock_flag = true;
     }

--- a/storage/ndb/src/kernel/blocks/dbacc/Dbqacc.cpp
+++ b/storage/ndb/src/kernel/blocks/dbacc/Dbqacc.cpp
@@ -39,8 +39,7 @@ Dbqacc::Dbqacc(Block_context& ctx,
 Uint64 Dbqacc::getTransactionMemoryNeed()
 {
   Uint32 query_instance_count =
-    globalData.ndbMtQueryWorkers +
-    globalData.ndbMtRecoverThreads;
+    globalData.ndbMtQueryWorkers;
   Uint32 acc_scan_recs = 1;
   Uint32 acc_op_recs = 1;
 

--- a/storage/ndb/src/kernel/blocks/dbdict/Dbdict.hpp
+++ b/storage/ndb/src/kernel/blocks/dbdict/Dbdict.hpp
@@ -1567,7 +1567,7 @@ private:
     static const uint MaxInternalReqs =
                   MAX_NDB_NODES +                   /* restartCreateObj() forward to Master */
                   1 +                               /* SUMA SUB_CREATE_REQ */
-                  (2 * MAX_NDBMT_LQH_THREADS) +     /* Backup - 1 LCP + 1 Backup per LDM instance */
+                  (2 * MAX_NDBMT_LQH_WORKERS) +     /* Backup - 1 LCP + 1 Backup per LDM instance */
                   1;                                /* Trix Index stat */
 
     /**

--- a/storage/ndb/src/kernel/blocks/dbdih/Dbdih.hpp
+++ b/storage/ndb/src/kernel/blocks/dbdih/Dbdih.hpp
@@ -2149,7 +2149,7 @@ private:
   void emptyverificbuffer(Signal *, Uint32 q, bool aContintueB);
   void emptyverificbuffer_check(Signal*, Uint32, Uint32);
 
-  DIVERIFY_queue c_diverify_queue[MAX_NDBMT_TC_THREADS];
+  DIVERIFY_queue c_diverify_queue[MAX_NDBMT_TC_WORKERS];
   Uint32 c_diverify_queue_cnt;
 
   /*------------------------------------------------------------------------*/

--- a/storage/ndb/src/kernel/blocks/dbdih/DbdihMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbdih/DbdihMain.cpp
@@ -10084,31 +10084,8 @@ void Dbdih::execNODE_FAILREP(Signal* signal)
   sendSignal(DBSPJ_REF, GSN_NODE_FAILREP, signal,
              NodeFailRep::SignalLength, JBB, lsptr, 1);
 
-  if ((globalData.ndbMtQueryWorkers +
-       globalData.ndbMtRecoverThreads) > 0)
-  {
-    sendSignal(DBQLQH_REF, GSN_NODE_FAILREP, signal,
-               NodeFailRep::SignalLength, JBB, lsptr, 1);
-  }
-  else
-  {
-    /* No query threads, report complete already here */
-    for (i = 0; i < noOfFailedNodes; i++)
-    {
-      jam();
-      NodeRecordPtr TNodePtr;
-      TNodePtr.i = failedNodes[i];
-      ptrCheckGuard(TNodePtr, MAX_NDB_NODES, nodeRecord);
-      /* ----------------------------------------------------------------- */
-      // Report the event that DBQLQH completed node failure handling.
-      /* ----------------------------------------------------------------- */
-      signal->theData[0] = NDB_LE_NodeFailCompleted;
-      signal->theData[1] = DBQLQH;
-      signal->theData[2] = TNodePtr.i;
-      sendSignal(CMVMI_REF, GSN_EVENT_REP, signal, 3, JBB);
-    }
-  }
-
+  sendSignal(DBQLQH_REF, GSN_NODE_FAILREP, signal,
+             NodeFailRep::SignalLength, JBB, lsptr, 1);
 
   if (ERROR_INSERTED(7179) || ERROR_INSERTED(7217))
   {
@@ -10492,17 +10469,8 @@ void Dbdih::failedNodeSynchHandling(Signal* signal,
   failedNodePtr.p->dbtcFailCompleted = ZFALSE;
   failedNodePtr.p->dbdihFailCompleted = ZFALSE;
   failedNodePtr.p->dblqhFailCompleted = ZFALSE;
-  if ((globalData.ndbMtQueryWorkers +
-       globalData.ndbMtRecoverThreads) > 0)
-  {
-    jam();
-    failedNodePtr.p->dbqlqhFailCompleted = ZFALSE;
-  }
-  else
-  {
-    jam();
-    failedNodePtr.p->dbqlqhFailCompleted = ZTRUE;
-  }
+  jam();
+  failedNodePtr.p->dbqlqhFailCompleted = ZFALSE;
   
   failedNodePtr.p->m_NF_COMPLETE_REP.clearWaitingFor();
 

--- a/storage/ndb/src/kernel/blocks/dbinfo/Dbinfo.cpp
+++ b/storage/ndb/src/kernel/blocks/dbinfo/Dbinfo.cpp
@@ -102,7 +102,7 @@ void Dbinfo::execREAD_CONFIG_REQ(Signal *signal)
   const THRConfigApplier & thr_cf =
     globalEmulatorData.theConfiguration->m_thr_config;
   counts.threads.send = globalData.ndbMtSendThreads;
-  counts.threads.db = thr_cf.getThreadCount() + globalData.ndbMtRecoverThreads;
+  counts.threads.db = thr_cf.getThreadCount();
   counts.threads.ldm = thr_cf.getThreadCount(THRConfig::T_LDM);
   counts.cpus = Ndb_GetHWInfo(false)->cpu_cnt;
 

--- a/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
@@ -521,7 +521,7 @@ public:
     Uint32 prevList;
   };
   typedef Ptr<CopyFragRecord> CopyFragRecordPtr;
-#define ZCOPYFRAGREC_FILE_SIZE MAX_NDBMT_LQH_THREADS
+#define ZCOPYFRAGREC_FILE_SIZE MAX_NDBMT_LQH_WORKERS
   typedef ArrayPool<CopyFragRecord> CopyFragRecord_pool;
   typedef DLFifoList<CopyFragRecord_pool> CopyFragRecord_fifo;
 
@@ -1302,10 +1302,10 @@ public:
   typedef Ptr<GcpRecord> GcpRecordPtr;
 
   struct HostRecord {
-    Bitmask<(MAX_NDBMT_LQH_THREADS+1+31)/32> lqh_pack_mask;
-    Bitmask<(MAX_NDBMT_TC_THREADS+1+31)/32> tc_pack_mask;
-    struct PackedWordsContainer lqh_pack[MAX_NDBMT_LQH_THREADS+1];
-    struct PackedWordsContainer tc_pack[MAX_NDBMT_TC_THREADS+1];
+    Bitmask<(MAX_NDBMT_LQH_WORKERS+1+31)/32> lqh_pack_mask;
+    Bitmask<(MAX_NDBMT_TC_WORKERS+1+31)/32> tc_pack_mask;
+    struct PackedWordsContainer lqh_pack[MAX_NDBMT_LQH_WORKERS+1];
+    struct PackedWordsContainer tc_pack[MAX_NDBMT_TC_WORKERS+1];
     Uint8 inPackedList;
     Uint8 nodestatus;
   };
@@ -5202,31 +5202,23 @@ public:
 #endif
   void lock_alloc_operation()
   {
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-    {
-      NdbMutex_Lock(&alloc_operation_mutex);
-    }
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
+    NdbMutex_Lock(&alloc_operation_mutex);
   }
   void unlock_alloc_operation()
   {
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-    {
-      NdbMutex_Unlock(&alloc_operation_mutex);
-    }
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
+    NdbMutex_Unlock(&alloc_operation_mutex);
   }
   void lock_take_over_hash()
   {
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-    {
-      NdbMutex_Lock(&c_scanTakeOverMutex);
-    }
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
+    NdbMutex_Lock(&c_scanTakeOverMutex);
   }
   void unlock_take_over_hash()
   {
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-    {
-      NdbMutex_Unlock(&c_scanTakeOverMutex);
-    }
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
+    NdbMutex_Unlock(&c_scanTakeOverMutex);
   }
   Uint32 m_first_qt_thr_no;
   Uint32 m_num_qt_our_rr_group;
@@ -5621,68 +5613,57 @@ Dblqh::is_exclusive_condition_ready(Fragrecord *fragPtrP)
 inline void
 Dblqh::upgrade_to_write_key_frag_access()
 {
-  if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-  {
-    jamDebug();
-    handle_upgrade_to_write_key_frag_access(fragptr.p);
-  }
+  jamDebug();
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
+  handle_upgrade_to_write_key_frag_access(fragptr.p);
 }
 
 inline void
 Dblqh::upgrade_to_exclusive_frag_access_no_return()
 {
-  if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-  {
-    jamDebug();
-    handle_upgrade_to_exclusive_frag_access(fragptr.p);
-    m_old_fragment_lock_status = FRAGMENT_UNLOCKED;
-  }
+  jamDebug();
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
+  handle_upgrade_to_exclusive_frag_access(fragptr.p);
+  m_old_fragment_lock_status = FRAGMENT_UNLOCKED;
 }
 
 inline void
 Dblqh::upgrade_to_exclusive_frag_access()
 {
-  if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-  {
-    jamDebug();
-    handle_upgrade_to_exclusive_frag_access(fragptr.p);
-  }
+  jamDebug();
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
+  handle_upgrade_to_exclusive_frag_access(fragptr.p);
 }
 
 inline void
 Dblqh::upgrade_to_exclusive_frag_access(Fragrecord *fragPtrP)
 {
-  if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-  {
-    jamDebug();
-    handle_upgrade_to_exclusive_frag_access(fragPtrP);
-  }
+  jamDebug();
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
+  handle_upgrade_to_exclusive_frag_access(fragPtrP);
 }
 
 inline void
 Dblqh::downgrade_from_exclusive_frag_access()
 {
-  if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-  {
-    jamDebug();
-    handle_downgrade_from_exclusive_frag_access(fragptr.p);
-  }
+  jamDebug();
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
+  handle_downgrade_from_exclusive_frag_access(fragptr.p);
 }
 
 inline void
 Dblqh::downgrade_from_exclusive_frag_access(Fragrecord *fragPtrP)
 {
-  if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-  {
-    jamDebug();
-    handle_downgrade_from_exclusive_frag_access(fragPtrP);
-  }
+  jamDebug();
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
+  handle_downgrade_from_exclusive_frag_access(fragPtrP);
 }
 
 inline void
 Dblqh::acquire_frag_commit_access_write_key()
 {
-  if (qt_likely(globalData.ndbMtQueryWorkers > 0))
+  jamDebug();
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
   {
     Fragrecord *fragPtrP = fragptr.p;
     if (m_fragment_lock_status == FRAGMENT_UNLOCKED)
@@ -5717,7 +5698,8 @@ Dblqh::acquire_frag_commit_access_write_key()
 inline void
 Dblqh::acquire_frag_commit_access_exclusive()
 {
-  if (qt_likely(globalData.ndbMtQueryWorkers > 0))
+  jamDebug();
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
   {
     jamDebug();
     Fragrecord *fragPtrP = fragptr.p;
@@ -5736,17 +5718,16 @@ inline void
 Dblqh::acquire_frag_abort_access(Fragrecord *fragPtrP,
                                   TcConnectionrec *regTcPtr)
 {
-  if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-  {
-    jamDebug();
-    handle_acquire_frag_abort_access(fragPtrP, regTcPtr);
-  }
+  jamDebug();
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
+  handle_acquire_frag_abort_access(fragPtrP, regTcPtr);
 }
 
 inline void
 Dblqh::acquire_frag_prepare_key_access(Fragrecord *fragPtrP,
                                        TcConnectionrec *regTcPtr)
 {
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
   if (is_write_key_frag_access(regTcPtr))
   {
     /**
@@ -5777,6 +5758,7 @@ Dblqh::acquire_frag_prepare_key_access(Fragrecord *fragPtrP,
   }
   else
   {
+    jamDebug();
     handle_acquire_read_key_frag_access(fragPtrP, false, true);
     m_fragment_lock_status = FRAGMENT_LOCKED_IN_READ_KEY_MODE;
   }
@@ -5786,7 +5768,7 @@ inline void
 Dblqh::acquire_frag_scan_access(Fragrecord *fragPtrP,
                                        TcConnectionrec *regTcPtr)
 {
-  if (qt_likely(globalData.ndbMtQueryWorkers > 0))
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
   {
     if (m_fragment_lock_status == FRAGMENT_UNLOCKED)
     {
@@ -5803,11 +5785,9 @@ inline void
 Dblqh::acquire_frag_scan_access_new(Fragrecord *fragPtrP,
                                     TcConnectionrec *regTcPtr)
 {
-  if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-  {
-    jamDebug();
-    handle_acquire_scan_frag_access(fragPtrP);
-  }
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
+  jamDebug();
+  handle_acquire_scan_frag_access(fragPtrP);
 }
 
 inline void

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhInit.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhInit.cpp
@@ -476,14 +476,8 @@ void Dblqh::initRecords(const ndb_mgm_configuration_iterator* mgm_cfg,
      */
     Uint32 reserveTcConnRecsShared = reserveTcConnRecs;
     reserveTcConnRecs /= 10;
-    if (globalData.ndbMtQueryWorkers > 0)
-    {
-      reserveTcConnRecs *= 4;
-    }
-    else
-    {
-      reserveTcConnRecs = reserveTcConnRecsShared;
-    }
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
+    reserveTcConnRecs *= 4;
     ctcConnectReserved = reserveTcConnRecs;
     ctcConnectReservedShared = reserveTcConnRecsShared;
     ctcNumFree = reserveTcConnRecs;
@@ -925,14 +919,10 @@ Dblqh::~Dblqh()
     NdbMutex_Destroy(m_lock_acc_page_mutex);
     if (!isNdbMtLqh() || instance() == 1)
     {
-      if ((globalData.ndbMtRecoverThreads +
-           globalData.ndbMtQueryWorkers) > 0)
-      {
-        NdbMutex_Destroy(m_restore_mutex);
-      }
+      NdbMutex_Destroy(m_restore_mutex);
       m_restore_mutex = 0;
       ndbd_free((void*)m_num_recover_active,
-                sizeof(Uint32) * (MAX_NDBMT_QUERY_THREADS + 1));
+                sizeof(Uint32) * (MAX_NDBMT_QUERY_WORKERS + 1));
       m_num_recover_active = 0;
     }
     {

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
@@ -1411,23 +1411,21 @@ Dblqh::sttor_startphase1(Signal *signal)
     m_lock_tup_page_mutex = NdbMutex_Create();
   }
   if (instance() == 1 &&
-      !m_is_query_block &&
-      (globalData.ndbMtRecoverThreads +
-       globalData.ndbMtQueryWorkers) > 0)
+      !m_is_query_block)
   {
     jam();
     m_restore_mutex = NdbMutex_Create();
     ndbrequire(m_restore_mutex != 0);
     m_num_recover_active = (Uint32*) ndbd_malloc(sizeof(Uint32) *
-                                       (MAX_NDBMT_QUERY_THREADS + 1));
+                                       (MAX_NDBMT_QUERY_WORKERS + 1));
     memset(m_num_recover_active,
            0,
-           sizeof(Uint32) * (MAX_NDBMT_QUERY_THREADS + 1));
+           sizeof(Uint32) * (MAX_NDBMT_QUERY_WORKERS + 1));
     m_instance_recover_active = (Uint32*) ndbd_malloc(sizeof(Uint32) *
-                                       (MAX_NDBMT_LQH_THREADS + 1));
+                                       (MAX_NDBMT_LQH_WORKERS + 1));
     memset(m_instance_recover_active,
            0,
-           sizeof(Uint32) * (MAX_NDBMT_LQH_THREADS + 1));
+           sizeof(Uint32) * (MAX_NDBMT_LQH_WORKERS + 1));
     /**
      * The number of active instances is tracked when we are using query
      * threads and recover threads. The reason is that we want to enable
@@ -1449,10 +1447,10 @@ Dblqh::sttor_startphase1(Signal *signal)
   if (!m_is_query_block)
   {
     jam();
-    Uint32 num_restore_threads = 1 + (
-      (globalData.ndbMtRecoverThreads +
+    Uint32 num_restore_threads =
+      (globalData.ndbMtQueryWorkers +
        (globalData.ndbMtLqhWorkers - 1)) /
-      globalData.ndbMtLqhWorkers);
+      globalData.ndbMtLqhWorkers;
     m_num_restore_threads = num_restore_threads;
   }
 
@@ -6385,7 +6383,7 @@ void Dblqh::sendCommitLqh(Signal* signal,
   ndbassert(refToMain(alqhBlockref) == getDBLQH());
 
 #ifndef UNPACKED_COMMIT_SIGNALS
-  if (unlikely(instanceKey > MAX_NDBMT_LQH_THREADS))
+  if (unlikely(instanceKey > MAX_NDBMT_LQH_WORKERS))
 #endif
   {
     /* No send packed support in these cases */
@@ -6440,7 +6438,7 @@ void Dblqh::sendCompleteLqh(Signal* signal,
   ndbassert(refToMain(alqhBlockref) == getDBLQH());
 
 #ifndef UNPACKED_COMMIT_SIGNALS
-  if (unlikely(instanceKey > MAX_NDBMT_LQH_THREADS))
+  if (unlikely(instanceKey > MAX_NDBMT_LQH_WORKERS))
 #endif
   {
     /* No send packed support in these cases */
@@ -6490,7 +6488,7 @@ void Dblqh::sendCommittedTc(Signal* signal,
   Uint32 instanceKey = refToInstance(atcBlockref);
 
   ndbassert(refToMain(atcBlockref) == DBTC);
-  if (instanceKey > MAX_NDBMT_TC_THREADS)
+  if (instanceKey > MAX_NDBMT_TC_WORKERS)
   {
     /* No send packed support in these cases */
     jam();
@@ -6538,7 +6536,7 @@ void Dblqh::sendCompletedTc(Signal* signal,
   Uint32 instanceKey = refToInstance(atcBlockref);
 
   ndbassert(refToMain(atcBlockref) == DBTC);
-  if (instanceKey > MAX_NDBMT_TC_THREADS)
+  if (instanceKey > MAX_NDBMT_TC_WORKERS)
   {
     /* No handling of send packed in those cases */
     jam();
@@ -6598,7 +6596,7 @@ void Dblqh::sendLqhkeyconfTc(Signal* signal,
   }
   if (block == getDBLQH())
   {
-    if (instanceKey <= MAX_NDBMT_LQH_THREADS)
+    if (instanceKey <= MAX_NDBMT_LQH_WORKERS)
     {
       container = &Thostptr.p->lqh_pack[instanceKey];
     }
@@ -6609,7 +6607,7 @@ void Dblqh::sendLqhkeyconfTc(Signal* signal,
   }
   else if (block == DBTC)
   {
-    if (instanceKey <= MAX_NDBMT_TC_THREADS)
+    if (instanceKey <= MAX_NDBMT_TC_WORKERS)
     {
       container = &Thostptr.p->tc_pack[instanceKey];
     }
@@ -6648,12 +6646,12 @@ void Dblqh::sendLqhkeyconfTc(Signal* signal,
 
     if (block == getDBLQH())
     {
-      if (instanceKey <= MAX_NDBMT_LQH_THREADS)
+      if (instanceKey <= MAX_NDBMT_LQH_WORKERS)
         Thostptr.p->lqh_pack_mask.set(instanceKey);
     }
     else if (block == DBTC)
     {
-      if (instanceKey <= MAX_NDBMT_TC_THREADS)
+      if (instanceKey <= MAX_NDBMT_TC_WORKERS)
         Thostptr.p->tc_pack_mask.set(instanceKey);
     }
   }
@@ -10010,8 +10008,7 @@ void Dblqh::execLQHKEYREQ(Signal* signal)
       0;
   }//if
   ndbassert(regTcPtr->totReclenAi == regTcPtr->currReclenAi);
-  if (qt_likely((globalData.ndbMtQueryWorkers > 0) &&
-      refToMain(regTcPtr->clientBlockref) != getRESTORE()))
+  if (refToMain(regTcPtr->clientBlockref) != getRESTORE())
   {
     acquire_frag_prepare_key_access(fragptr.p, regTcPtr);
   }
@@ -13392,7 +13389,7 @@ Dblqh::sendFireTrigConfTc(Signal* signal,
   Uint32 instanceKey = refToInstance(atcBlockref);
 
   ndbassert(refToMain(atcBlockref) == DBTC);
-  if (instanceKey > MAX_NDBMT_TC_THREADS)
+  if (instanceKey > MAX_NDBMT_TC_WORKERS)
   {
     jam();
     memcpy(signal->theData, Tdata, 4 * FireTrigConf::SignalLength);
@@ -16804,7 +16801,7 @@ void Dblqh::setup_key_pointers(Uint32 tcIndex, bool acquire_lock)
   ndbrequire(Magic::check_ptr(tcConnectptr.p));
   ndbrequire(Magic::check_ptr(tcConnectptr.p->tupConnectPtrP));
   ndbrequire(Magic::check_ptr(tcConnectptr.p->accConnectPtrP));
-  if (qt_likely((globalData.ndbMtQueryWorkers > 0) && acquire_lock))
+  if (acquire_lock)
   {
     acquire_frag_prepare_key_access(fragPtr.p, tcConnectptr.p);
   }
@@ -20820,6 +20817,7 @@ void Dblqh::send_next_NEXT_SCANREQ(Signal* signal,
           prim_tab_fragptr.p->m_cond_write_key_waiters == 0 &&
           prim_tab_fragptr.p->m_cond_exclusive_waiters == 0)
       {
+        jamDebug();
         scan_direct_count = 1;
         m_tot_scan_direct_count = tot_scan_direct_count;
         /**
@@ -20839,6 +20837,7 @@ void Dblqh::send_next_NEXT_SCANREQ(Signal* signal,
            * Insert scan into TUX index node to ensure we get back to correct
            * position after real-time break.
            */
+          jamDebug();
           c_tux->relinkScan(__LINE__);
         }
         /* Early release to ensure waiters can quickly get started */
@@ -29185,7 +29184,8 @@ Dblqh::get_recover_thread_instance()
    * we return 0, otherwise we return the instance number of the recover
    * thread we can use (instance number 0 is the proxy instance).
    */
-  Uint32 num_recover_threads = globalData.ndbMtRecoverThreads;
+  Uint32 num_recover_threads =
+    (globalData.ndbMtQueryWorkers - globalData.ndbMtLqhWorkers);
   if (num_recover_threads == 0)
   {
     return 0;
@@ -29212,9 +29212,11 @@ Dblqh::completed_restore(Uint32 instance)
    * A restore of a fragment has completed, we release the recover thread
    * for someone else to use.
    */
+  Uint32 num_recover_threads =
+    (globalData.ndbMtQueryWorkers - globalData.ndbMtLqhWorkers);
   ndbrequire(instance > globalData.ndbMtLqhWorkers);
   instance -= globalData.ndbMtLqhWorkers;
-  ndbrequire(instance <= globalData.ndbMtRecoverThreads);
+  ndbrequire(instance <= num_recover_threads);
   Uint32 *num_recover_active = c_restore_mutex_lqh->m_num_recover_active;
   NdbMutex_Lock(c_restore_mutex_lqh->m_restore_mutex);
   ndbrequire(num_recover_active[instance] == 1);
@@ -29233,7 +29235,8 @@ Dblqh::instance_completed_restore(Uint32 instance)
    * false. This is used to send a signal to the recover threads to
    * log output about its restore operations.
    */
-  Uint32 num_recover_threads = globalData.ndbMtRecoverThreads;
+  Uint32 num_recover_threads =
+    (globalData.ndbMtQueryWorkers - globalData.ndbMtLqhWorkers);
   if (num_recover_threads == 0)
   {
     jam();
@@ -40626,7 +40629,8 @@ Dblqh::mark_end_of_lcp_restore(Signal* signal)
      * All LDM threads are done. Now time to also report
      * restore rates performed by Recover threads.
      */
-    Uint32 num_recover_threads = globalData.ndbMtRecoverThreads;
+    Uint32 num_recover_threads =
+      (globalData.ndbMtQueryWorkers - globalData.ndbMtLqhWorkers);
     for (Uint32 i = 1; i <= num_recover_threads; i++)
     {
       Uint32 instance = globalData.ndbMtLqhWorkers + i;
@@ -40868,7 +40872,7 @@ Dblqh::check_abort_signal_executed(Uint32 recv_thr_no,
    * path as the first ABORT signal. Thus we only check the query threads
    * here.
    */
-  ndbrequire(globalData.ndbMtQueryWorkers > 0);
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
   for (Uint32 i = 0; i < m_num_qt_our_rr_group; i++)
   {
     jam();
@@ -40899,14 +40903,8 @@ Dblqh::check_abort_signal_executed(Uint32 recv_thr_no,
 void
 Dblqh::set_up_qt_our_rr_group()
 {
-  if (globalData.ndbMtQueryWorkers == 0)
-  {
-    /* Not used in this case. */
-    return;
-  }
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
   /* Round Robin group information is static variables in SimulatedBlock */
-  ndbrequire(globalData.ndbMtQueryThreads == 0);
-  ndbrequire(globalData.ndbMtLqhWorkers == globalData.ndbMtQueryWorkers);
   Uint32 first_qt_thr_no = getFirstQueryThreadId();
   m_num_qt_our_rr_group = 0;
   Uint32 our_rr_group = m_rr_group[instance() - 1];

--- a/storage/ndb/src/kernel/blocks/dblqh/Dbqlqh.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/Dbqlqh.cpp
@@ -39,8 +39,7 @@ Dbqlqh::Dbqlqh(Block_context& ctx,
 Uint64 Dbqlqh::getTransactionMemoryNeed()
 {
   Uint32 query_instance_count =
-    globalData.ndbMtQueryWorkers +
-    globalData.ndbMtRecoverThreads;
+    globalData.ndbMtQueryWorkers;
   Uint32 lqh_scan_recs = 1;
   Uint32 lqh_op_recs = 1;
   Uint64 scan_byte_count = 0;

--- a/storage/ndb/src/kernel/blocks/dbspj/DbspjMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbspj/DbspjMain.cpp
@@ -8239,7 +8239,7 @@ Dbspj::scanFrag_send(Signal* signal,
       {
         if (nodeId == getOwnNodeId())
         {
-          if (globalData.ndbMtQueryWorkers > 0)
+          ndbassert(globalData.ndbMtQueryWorkers > 0);
           {
             /**
              * ReadCommittedFlag is always set in DBSPJ when Query threads are
@@ -8275,22 +8275,6 @@ Dbspj::scanFrag_send(Signal* signal,
             jam();
             ref = get_scan_fragreq_ref(&c_tc->m_distribution_handle,
                                        instance_no);
-            fragPtr.p->m_next_ref = ref;
-          }
-          else
-          {
-            jam();
-            /**
-             * We are not using query threads in this node, we can set
-             * m_next_ref immediately, we can also set m_ref to the proper
-             * DBLQH location since there is no flexible scheduling without
-             * query threads.
-             *
-             * There is no need to set the query thread flag here since we
-             * already know the location where SCAN_FRAGREQ is executed.
-             */
-            ref = numberToRef(DBLQH, instance_no, nodeId);
-            fragPtr.p->m_ref = ref;
             fragPtr.p->m_next_ref = ref;
           }
         }

--- a/storage/ndb/src/kernel/blocks/dbtc/Dbtc.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/Dbtc.hpp
@@ -1624,8 +1624,8 @@ public:
   /* SYSTEM                                               */
   /********************************************************/
   struct HostRecord {
-    Bitmask<(MAX_NDBMT_LQH_THREADS+1+31)/32> lqh_pack_mask;
-    struct PackedWordsContainer lqh_pack[MAX_NDBMT_LQH_THREADS+1];
+    Bitmask<(MAX_NDBMT_LQH_WORKERS+1+31)/32> lqh_pack_mask;
+    struct PackedWordsContainer lqh_pack[MAX_NDBMT_LQH_WORKERS+1];
     struct PackedWordsContainer packTCKEYCONF;
     HostState hostStatus;
     LqhTransState lqhTransStatus;

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
@@ -5814,7 +5814,7 @@ void Dbtc::sendlqhkeyreq(Signal* signal,
       if (nodeId == getOwnNodeId())
       {
         Uint32 instance_no = refToInstance(TBRef);
-        ndbrequire(globalData.ndbMtQueryWorkers > 0);
+        ndbassert(globalData.ndbMtQueryWorkers > 0);
         jam();
         TBRef = get_lqhkeyreq_ref(&m_distribution_handle, instance_no);
       }
@@ -6331,7 +6331,7 @@ bool
 Dbtc::CommitAckMarker::insert_in_commit_ack_marker_all(Dbtc *tc,
                                                        NodeId node_id)
 {
-  for (Uint32 ikey = 1; ikey <= MAX_NDBMT_LQH_THREADS; ikey++)
+  for (Uint32 ikey = 1; ikey <= MAX_NDBMT_LQH_WORKERS; ikey++)
   {
     if (!insert_in_commit_ack_marker(tc, ikey, node_id))
       return false;
@@ -7733,7 +7733,7 @@ Dbtc::sendCommitLqh(Signal* signal,
   Uint32 len = 5;
   Uint32 instanceNo = getInstanceNo(Tnode, instanceKey);
 #ifndef UNPACKED_COMMIT_SIGNALS
-  if (unlikely(instanceNo > MAX_NDBMT_LQH_THREADS))
+  if (unlikely(instanceNo > MAX_NDBMT_LQH_WORKERS))
 #endif
   {
     memcpy(&signal->theData[0], &Tdata[0], len << 2);
@@ -8266,7 +8266,7 @@ Dbtc::sendCompleteLqh(Signal* signal,
 
   Uint32 instanceNo = getInstanceNo(Tnode, instanceKey);
 #ifndef UNPACKED_COMMIT_SIGNALS
-  if (unlikely(instanceNo > MAX_NDBMT_LQH_THREADS))
+  if (unlikely(instanceNo > MAX_NDBMT_LQH_WORKERS))
 #endif
   {
     memcpy(&signal->theData[0], &Tdata[0], len << 2);
@@ -8495,7 +8495,7 @@ Dbtc::sendFireTrigReqLqh(Signal* signal,
   req->pass = pass;
   Uint32 len = FireTrigReq::SignalLength;
   Uint32 instanceNo = getInstanceNo(Tnode, instanceKey);
-  if (instanceNo > MAX_NDBMT_LQH_THREADS) {
+  if (instanceNo > MAX_NDBMT_LQH_WORKERS) {
     memcpy(signal->theData, Tdata, len << 2);
     BlockReference lqhRef = numberToRef(DBLQH, instanceNo, Tnode);
     sendSignal(lqhRef, GSN_FIRE_TRIG_REQ, signal, len, JBB);
@@ -8768,7 +8768,7 @@ Dbtc::sendRemoveMarker(Signal* signal,
   Tdata[2] = transid2;
   Uint32 len = 3;
   Uint32 instanceNo = getInstanceNo(nodeId, instanceKey);
-  if (instanceNo > MAX_NDBMT_LQH_THREADS) {
+  if (instanceNo > MAX_NDBMT_LQH_WORKERS) {
     jam();
     // first word omitted
     memcpy(&signal->theData[0], &Tdata[1], (len - 1) << 2);
@@ -18547,7 +18547,7 @@ bool Dbtc::sendScanFragReq(Signal* signal,
         if (nodeId == getOwnNodeId())
         {
           jam();
-          ndbrequire(globalData.ndbMtQueryWorkers > 0);
+          ndbassert(globalData.ndbMtQueryWorkers > 0);
           ref = get_scan_fragreq_ref(&m_distribution_handle, instance_no);
           check_blockref(ref);
           scanFragP.p->lqhBlockref = ref;

--- a/storage/ndb/src/kernel/blocks/dbtup/Dbqtup.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/Dbqtup.cpp
@@ -39,8 +39,7 @@ Dbqtup::Dbqtup(Block_context& ctx,
 Uint64 Dbqtup::getTransactionMemoryNeed()
 {
   Uint32 query_instance_count =
-    globalData.ndbMtQueryWorkers +
-    globalData.ndbMtRecoverThreads;
+    globalData.ndbMtQueryWorkers;
   Uint32 tup_scan_recs = 1;
   Uint32 tup_op_recs = 1;
   Uint32 tup_sp_recs = 1;

--- a/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
@@ -854,21 +854,17 @@ struct Fragrecord {
   void acquire_frag_page_map_mutex(Fragrecord *fragPtrP,
                                    EmulatedJamBuffer *jamBuf)
   {
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-    {
-      thrjam(jamBuf);
-      ndbrequire(!m_is_in_query_thread);
-      NdbMutex_Lock(&fragPtrP->tup_frag_page_map_mutex);
-    }
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
+    thrjam(jamBuf);
+    ndbrequire(!m_is_in_query_thread);
+    NdbMutex_Lock(&fragPtrP->tup_frag_page_map_mutex);
   }
   void release_frag_page_map_mutex(Fragrecord *fragPtrP,
                                    EmulatedJamBuffer *jamBuf)
   {
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
-    {
-      NdbMutex_Unlock(&fragPtrP->tup_frag_page_map_mutex);
-      thrjam(jamBuf);
-    }
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
+    NdbMutex_Unlock(&fragPtrP->tup_frag_page_map_mutex);
+    thrjam(jamBuf);
   }
   void acquire_frag_page_map_mutex_read(EmulatedJamBuffer *jamBuf)
   {
@@ -900,7 +896,7 @@ struct Fragrecord {
                           Uint32 logicalPageId,
                           EmulatedJamBuffer *jamBuf)
   {
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
     {
       ndbrequire(!m_is_in_query_thread);
       Uint32 hash = logicalPageId & (NUM_TUP_FRAGMENT_MUTEXES - 1);
@@ -913,12 +909,12 @@ struct Fragrecord {
                           Uint32 logicalPageId,
                           EmulatedJamBuffer *jamBuf)
   {
-    if (qt_likely(globalData.ndbMtQueryWorkers > 0))
+    ndbassert(globalData.ndbMtQueryWorkers > 0);
     {
       Uint32 hash = logicalPageId & (NUM_TUP_FRAGMENT_MUTEXES - 1);
       NdbMutex_Unlock(&fragPtrP->tup_frag_mutex[hash]);
       thrjamDebug(jamBuf);
-      thrjamLine(jamBuf, hash);
+      thrjamLineDebug(jamBuf, hash);
     }
   }
   void acquire_frag_mutex_read(Fragrecord *fragPtrP,

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupPagMan.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupPagMan.cpp
@@ -223,9 +223,7 @@ Dbtup::update_pages_allocated(int retNo)
   {
     lqh_block = c_lqh;
     tup_block = this;
-    if (!c_lqh->is_restore_phase_done() &&
-        (globalData.ndbMtRecoverThreads +
-         globalData.ndbMtQueryThreads) > 0)
+    if (!c_lqh->is_restore_phase_done())
     {
       lock_flag = true;
     }

--- a/storage/ndb/src/kernel/blocks/dbtux/Dbqtux.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/Dbqtux.cpp
@@ -39,8 +39,7 @@ Dbqtux::Dbqtux(Block_context& ctx,
 Uint64 Dbqtux::getTransactionMemoryNeed()
 {
   Uint32 query_instance_count =
-    globalData.ndbMtQueryWorkers +
-    globalData.ndbMtRecoverThreads;
+    globalData.ndbMtQueryWorkers;
   Uint64 scan_op_byte_count = 1;
   Uint32 tux_scan_recs = 1;
   Uint32 tux_scan_lock_recs = 1;

--- a/storage/ndb/src/kernel/blocks/dbtux/DbtuxScan.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/DbtuxScan.cpp
@@ -1561,10 +1561,6 @@ Dbtux::checkScanInstance(Uint32 scanInstance)
   const bool scanInstance_is_tux =
     (get_block_from_scan_instance(scanInstance) == DBTUX);
 
-  /* Basic sanity */
-  ndbrequire((i_am_tux && scanInstance_is_tux) ||
-             (globalData.ndbMtQueryWorkers > 0));
-
   if (i_am_tux)
   {
     /* TUX */
@@ -1604,7 +1600,6 @@ Dbtux::relinkScan(ScanOp& scan,
                   bool need_lock,
                   Uint32 line)
 {
-  ndbrequire(checkScanInstance(scanInstance));
   /**
    * This is called at the end of a real-time break. We do
    * two actions here. At first we move the linked scan record
@@ -1629,7 +1624,7 @@ Dbtux::relinkScan(ScanOp& scan,
    * done by writers and these have already acquired exclusive access to
    * the index (and the whole table for that matter).
    */
-  ndbassert(checkScanInstance(scanInstance));
+  ndbrequire(checkScanInstance(scanInstance));
   if (scan.m_scanLinkedPos == scan.m_scanPos.m_loc)
   {
     jamDebug();
@@ -1637,10 +1632,6 @@ Dbtux::relinkScan(ScanOp& scan,
                scan.m_scanLinkedPos == NullTupLoc);
     scan.m_scanLinkedPos = NullTupLoc;
     return;
-  }
-  if (qt_unlikely(globalData.ndbMtQueryWorkers == 0))
-  {
-    need_lock = false;
   }
   NodeHandle old_node(frag);
   NodeHandle new_node(frag);

--- a/storage/ndb/src/kernel/blocks/ndbcntr/Ndbcntr.hpp
+++ b/storage/ndb/src/kernel/blocks/ndbcntr/Ndbcntr.hpp
@@ -562,7 +562,7 @@ private:
   Uint32 m_local_lcp_id;
   RedoStateRep::RedoAlertState m_global_redo_alert_state;
   RedoStateRep::RedoAlertState m_node_redo_alert_state;
-  RedoStateRep::RedoAlertState m_redo_alert_state[MAX_NDBMT_LQH_THREADS];
+  RedoStateRep::RedoAlertState m_redo_alert_state[MAX_NDBMT_LQH_WORKERS];
 
   RedoStateRep::RedoAlertState get_node_redo_alert_state();
   Uint32 send_to_all_lqh(Signal*, Uint32 gsn, Uint32 sig_len);

--- a/storage/ndb/src/kernel/blocks/ndbcntr/NdbcntrInit.cpp
+++ b/storage/ndb/src/kernel/blocks/ndbcntr/NdbcntrInit.cpp
@@ -80,7 +80,7 @@ void Ndbcntr::initData()
   m_local_lcp_id = 0;
   m_global_redo_alert_state = RedoStateRep::NO_REDO_ALERT;
   m_node_redo_alert_state = RedoStateRep::NO_REDO_ALERT;
-  for (Uint32 i = 0; i < MAX_NDBMT_LQH_THREADS; i++)
+  for (Uint32 i = 0; i < MAX_NDBMT_LQH_WORKERS; i++)
     m_redo_alert_state[i] = RedoStateRep::NO_REDO_ALERT;
 }//Ndbcntr::initData()
 

--- a/storage/ndb/src/kernel/blocks/ndbcntr/NdbcntrMain.cpp
+++ b/storage/ndb/src/kernel/blocks/ndbcntr/NdbcntrMain.cpp
@@ -7003,7 +7003,7 @@ RedoStateRep::RedoAlertState
 Ndbcntr::get_node_redo_alert_state()
 {
   RedoStateRep::RedoAlertState redo_alert_state = RedoStateRep::NO_REDO_ALERT;
-  for (Uint32 i = 0; i < MAX_NDBMT_LQH_THREADS; i++)
+  for (Uint32 i = 0; i < MAX_NDBMT_LQH_WORKERS; i++)
   {
     if (m_redo_alert_state[i] > redo_alert_state)
     {

--- a/storage/ndb/src/kernel/blocks/thrman.hpp
+++ b/storage/ndb/src/kernel/blocks/thrman.hpp
@@ -83,9 +83,9 @@ private:
   bool m_tc_thread;
   bool m_ldm_thread;
 
-  const char *m_thread_name;
+  char m_thread_name[32];
+  char m_thread_description[32];
   const char *m_send_thread_name;
-  const char *m_thread_description;
   const char *m_send_thread_description;
 
   struct ndb_rusage m_last_50ms_rusage;
@@ -438,6 +438,7 @@ private:
   void update_query_distribution(Signal*);
   void initial_query_distribution(Signal*);
   void send_query_distribution(Uint32*, Signal*);
+  void adjust_weights(Uint32*);
 
   struct ThrLoad
   {

--- a/storage/ndb/src/kernel/blocks/trpman.cpp
+++ b/storage/ndb/src/kernel/blocks/trpman.cpp
@@ -1029,7 +1029,7 @@ Trpman::distribute_signal(SignalHeader * const header,
 {
   DistributionHandler *handle = &m_distribution_handle;
   Uint32 gsn = header->theVerId_signalNumber;
-  ndbrequire(globalData.ndbMtQueryWorkers > 0);
+  ndbassert(globalData.ndbMtQueryWorkers > 0);
   ndbrequire(m_distribution_handler_inited);
   if (unlikely(gsn == GSN_ABORT))
   {

--- a/storage/ndb/src/kernel/blocks/tsman.cpp
+++ b/storage/ndb/src/kernel/blocks/tsman.cpp
@@ -99,7 +99,7 @@ Tsman::Tsman(Block_context& ctx) :
   if (isNdbMtLqh())
   {
     jam();
-    for (Uint32 i = 0; i < MAX_NDBMT_LQH_THREADS + 1; i++)
+    for (Uint32 i = 0; i < MAX_NDBMT_LQH_WORKERS + 1; i++)
     {
       m_client_mutex[i] = NdbMutex_Create();
       ndbrequire(m_client_mutex[i] != 0);
@@ -147,7 +147,7 @@ Tsman::~Tsman()
 {
   if (isNdbMtLqh())
   {
-    for (Uint32 i = 0; i < MAX_NDBMT_LQH_THREADS + 1; i++)
+    for (Uint32 i = 0; i < MAX_NDBMT_LQH_WORKERS + 1; i++)
     {
       NdbMutex_Destroy(m_client_mutex[i]);
       m_client_mutex[i] = 0;
@@ -3457,7 +3457,7 @@ Tsman::client_lock() const
 {
   if (isNdbMtLqh())
   {
-    for (Uint32 i = 0; i < MAX_NDBMT_LQH_THREADS + 1; i++)
+    for (Uint32 i = 0; i < MAX_NDBMT_LQH_WORKERS + 1; i++)
     {
       int ret = NdbMutex_Lock(m_client_mutex[i]);
       ndbrequire(ret == 0);
@@ -3470,7 +3470,7 @@ Tsman::client_unlock() const
 {
   if (isNdbMtLqh())
   {
-    for (Uint32 i = 0; i < MAX_NDBMT_LQH_THREADS + 1; i++)
+    for (Uint32 i = 0; i < MAX_NDBMT_LQH_WORKERS + 1; i++)
     {
       int ret = NdbMutex_Unlock(m_client_mutex[i]);
       ndbrequire(ret == 0);

--- a/storage/ndb/src/kernel/blocks/tsman.hpp
+++ b/storage/ndb/src/kernel/blocks/tsman.hpp
@@ -241,7 +241,7 @@ private:
   Lgman * m_lgman;
   SimulatedBlock * m_tup;
 
-  mutable NdbMutex *m_client_mutex[MAX_NDBMT_LQH_THREADS + 1];
+  mutable NdbMutex *m_client_mutex[MAX_NDBMT_LQH_WORKERS + 1];
   NdbMutex *m_alloc_extent_mutex;
   void client_lock() const;
   void client_unlock() const;

--- a/storage/ndb/src/kernel/ndbd.cpp
+++ b/storage/ndb/src/kernel/ndbd.cpp
@@ -363,8 +363,8 @@ init_global_memory_manager(EmulatorData &ed, Uint32 *watchCounter)
     /**
      * Disk page buffer memory
      */
-    Uint32 recoverInstances = globalData.ndbMtRecoverThreads +
-                              globalData.ndbMtQueryThreads;
+    Uint32 recoverInstances = 
+      (globalData.ndbMtQueryWorkers - globalData.ndbMtLqhWorkers);
     Uint64 page_buffer = globalData.theDiskPageBufferMemory;
 
     Uint32 pages = 0;
@@ -594,13 +594,13 @@ get_multithreaded_config(EmulatorData& ed)
   if (!globalData.isNdbMtLqh)
     return 0;
 
-  g_eventLogger->info("NDBMT: ldm_workers=%u ldm_threads=%u"
-                      " query_workers=%u query_threads=%u\n"
+  g_eventLogger->info("NDBMT: ldm_threads=%u ldm_workers=%u"
+                      " query_workers=%u\n"
                       " tc_threads=%u tc_workers=%u"
                       " send=%u receive=%u main_threads=%u",
-                      globalData.ndbMtLqhWorkers, globalData.ndbMtLqhThreads,
-                      globalData.ndbMtQueryWorkers, globalData.ndbMtQueryThreads,
-                      globalData.ndbMtTcWorkers, globalData.ndbMtTcThreads,
+                      globalData.ndbMtLqhThreads, globalData.ndbMtLqhWorkers,
+                      globalData.ndbMtQueryWorkers,
+                      globalData.ndbMtTcThreads, globalData.ndbMtTcWorkers,
                       globalData.ndbMtSendThreads, globalData.ndbMtReceiveThreads,
                       globalData.ndbMtMainThreads);
 

--- a/storage/ndb/src/kernel/vm/Configuration.cpp
+++ b/storage/ndb/src/kernel/vm/Configuration.cpp
@@ -987,8 +987,6 @@ Configuration::get_send_buffer(const ndb_mgm_configuration_iterator *p)
   else
   {
     Uint32 num_threads = get_num_threads();
-    Uint32 num_extra_threads = globalData.ndbMtRecoverThreads;
-    num_threads += num_extra_threads;
     mem = globalTransporterRegistry.get_total_max_send_buffer();
     mem += (Uint64(2) * MBYTE64 * num_threads);
   }
@@ -1045,7 +1043,7 @@ Configuration::compute_os_overhead(
     os_cpu_overhead = Uint64(100) * MBYTE64;
   }
   Uint64 reserved_part = total_memory / Uint64(100);
-  Uint32 num_threads = get_num_threads() + globalData.ndbMtRecoverThreads;
+  Uint32 num_threads = get_num_threads();
   os_cpu_overhead *= Uint64(num_threads);
   return os_static_overhead + os_cpu_overhead + reserved_part;
 }
@@ -1287,10 +1285,8 @@ Configuration::assign_default_memory_sizes(
 Uint64
 Configuration::compute_restore_memory()
 {
-  Uint32 num_ldm_threads = globalData.ndbMtLqhWorkers;
-  Uint32 num_restore_threads = globalData.ndbMtRecoverThreads;
-  num_ldm_threads += num_restore_threads;
-  Uint64 restore_memory = Uint64(4) * MBYTE64 * Uint64(num_ldm_threads);
+  Uint32 num_restore_threads = globalData.ndbMtQueryWorkers;
+  Uint64 restore_memory = Uint64(4) * MBYTE64 * Uint64(num_restore_threads);
   return restore_memory;
 }
 
@@ -1303,11 +1299,10 @@ Configuration::compute_static_overhead()
    */
   Uint64 static_overhead = Uint64(208) * MBYTE64;
   Uint32 num_threads = get_num_threads();
-  Uint32 num_extra_threads = globalData.ndbMtRecoverThreads;
   static_overhead += // Small memory allocations
-    ((num_threads + num_extra_threads) * MBYTE64);
+    ((num_threads) * MBYTE64);
   Uint32 num_send_threads = globalData.ndbMtSendThreads;
-  Uint64 num_all_threads = num_threads + num_extra_threads + num_send_threads;
+  Uint64 num_all_threads = num_threads + num_send_threads;
   static_overhead += (num_all_threads * 2 * MBYTE64); // Stack memory
   return static_overhead;
 }
@@ -1677,7 +1672,7 @@ Configuration::setupConfiguration()
   if (auto_thread_config == 0 &&
       thrconfigstring != nullptr && thrconfigstring[0] != 0)
   {
-    int res = m_thr_config.do_parse(
+    int res = m_thr_config.do_parse_thrconfig(
         thrconfigstring, _realtimeScheduler, _schedulerSpinTimer);
     if (res != 0)
     {
@@ -1693,10 +1688,17 @@ Configuration::setupConfiguration()
       Uint32 num_cpus = 0;
       iter.get(CFG_DB_NUM_CPUS, &num_cpus);
       g_eventLogger->info("Use automatic thread configuration");
-      m_thr_config.do_parse(_realtimeScheduler,
-                            _schedulerSpinTimer,
-                            num_cpus,
-                            globalData.ndbRRGroups);
+      Uint32 use_tc_threads = 1;
+      iter.get(CFG_DB_USE_TC_THREADS, &use_tc_threads);
+      Uint32 use_ldm_threads = 1;
+      iter.get(CFG_DB_USE_LDM_THREADS, &use_ldm_threads);
+      m_thr_config.do_parse_auto(_realtimeScheduler,
+                                 _schedulerSpinTimer,
+                                 num_cpus,
+                                 globalData.ndbRRGroups,
+                                 MAX_DISTR_THREADS,
+                                 use_tc_threads,
+                                 use_ldm_threads);
     }
     else
     {
@@ -1712,11 +1714,11 @@ Configuration::setupConfiguration()
 #endif
       Uint32 lqhthreads = 0;
       iter.get(CFG_NDBMT_LQH_THREADS, &lqhthreads);
-      int res = m_thr_config.do_parse(mtthreads,
-                                      lqhthreads,
-                                      classic,
-                                      _realtimeScheduler,
-                                      _schedulerSpinTimer);
+      int res = m_thr_config.do_parse_classic(mtthreads,
+                                              lqhthreads,
+                                              classic,
+                                              _realtimeScheduler,
+                                              _schedulerSpinTimer);
       if (res != 0)
       {
         ERROR_SET(fatal, NDBD_EXIT_INVALID_CONFIG,
@@ -1766,19 +1768,6 @@ Configuration::setupConfiguration()
       m_thr_config.getThreadCount(THRConfig::T_RECV);
     globalData.ndbMtSendThreads =
       m_thr_config.getThreadCount(THRConfig::T_SEND);
-    globalData.ndbMtQueryThreads =
-      m_thr_config.getThreadCount(THRConfig::T_QUERY);
-    if (globalData.ndbMtQueryThreads > 0)
-    {
-      ERROR_SET(fatal, NDBD_EXIT_INVALID_CONFIG,
-               "Invalid configuration fetched. ",
-               " Query threads are no longer supported"
-               ", instead Query blocks are part of LDM threads,"
-               " thus move the query thread instances to LDM threads"
-               " and also the CPU bindings should be moved");
-    }
-    globalData.ndbMtRecoverThreads =
-      m_thr_config.getThreadCount(THRConfig::T_RECOVER);
     globalData.ndbMtTcThreads = m_thr_config.getThreadCount(THRConfig::T_TC);
     if (globalData.ndbMtTcThreads == 0)
     {
@@ -1839,7 +1828,15 @@ Configuration::setupConfiguration()
 
     globalData.ndbMtLqhWorkers = ldm_workers;
     globalData.ndbMtLqhThreads = ldm_threads;
-    globalData.ndbMtQueryWorkers = ldm_workers;
+    /**
+     * Each block thread will have one Query worker, thus no more
+     * any need for recover threads.
+     */
+    globalData.ndbMtQueryWorkers = ldm_threads +
+                                   globalData.ndbMtTcThreads +
+                                   globalData.ndbMtMainThreads +
+                                   globalData.ndbMtReceiveThreads;
+
     if (ldm_threads == 0)
     {
       /**
@@ -1852,54 +1849,37 @@ Configuration::setupConfiguration()
        * With 1 receive thread we will allow for a maximum of 1 main
        * thread.
        */
-      if ((globalData.ndbMtTcThreads > 0) ||
-          (globalData.ndbMtRecoverThreads > 0))
+      if (globalData.ndbMtTcThreads > 0)
       {
         ERROR_SET(fatal, NDBD_EXIT_INVALID_CONFIG,
                   "Invalid configuration fetched. ",
                   "Setting number of ldm threads to 0 must be combined"
-                  " with 0 tc and recover threads");
+                  " with 0 tc threads");
       }
-      if (globalData.ndbMtReceiveThreads > 1)
+      if (globalData.ndbMtReceiveThreads == 1 &&
+          globalData.ndbMtMainThreads > 1)
       {
-        /**
-         * In the case of 1 receive thread and no LDM threads we will not
-         * assign any Query workers. But with more than 1 receive thread
-         * and no LDM thread we will use 1 LDM worker and 1 Query worker in
-         * each receive thread in addition to a TC worker.
-         *
-         * This ensures that the receive thread can take care of the entire
-         * query for Committed Read queries, a sort of parallel ndbd setup.
-         */
-        globalData.ndbMtQueryWorkers = globalData.ndbMtReceiveThreads;
+        ERROR_SET(fatal, NDBD_EXIT_INVALID_CONFIG,
+                  "Invalid configuration fetched. ",
+                  "No LDM threads with 1 receive thread allows for"
+                  " 1 main thread, but no more");
       }
-      else
-      {
-        globalData.ndbMtQueryWorkers = 0;
-        if (globalData.ndbMtMainThreads > 1)
-        {
-          ERROR_SET(fatal, NDBD_EXIT_INVALID_CONFIG,
-                    "Invalid configuration fetched. ",
-                    "No LDM threads with 1 receive thread allows for"
-                    " 1 main thread, but no more");
-        }
-      }
-    }
-    globalData.QueryThreadsPerLdm = 0;
-    if (globalData.ndbMtQueryWorkers > 0)
-    {
-      globalData.QueryThreadsPerLdm = 1;
     }
 
-    if ((globalData.ndbMtRecoverThreads + globalData.ndbMtQueryWorkers) >
-         MAX_NDBMT_QUERY_THREADS)
+    if ((globalData.ndbMtQueryWorkers) > MAX_NDBMT_QUERY_WORKERS)
     {
       ERROR_SET(fatal, NDBD_EXIT_INVALID_CONFIG,
                 "Invalid configuration fetched. ",
-                "Sum of recover threads and query threads can be max 127");
+                "Query workers can be max 127");
     }
-    require(globalData.ndbMtQueryWorkers == globalData.ndbMtLqhThreads ||
-            globalData.ndbMtQueryWorkers == globalData.ndbMtReceiveThreads);
+    if (globalData.ndbRRGroups == 0)
+    {
+      /**
+       * ndbRRGroups haven't been set yet, means we didn't use
+       * do_parse_auto. Calculate it here.
+       */
+      globalData.ndbRRGroups = Ndb_GetRRGroups(globalData.ndbMtQueryWorkers);
+    }
   } while (0);
 
   calcSizeAlt(cf);

--- a/storage/ndb/src/kernel/vm/GlobalData.hpp
+++ b/storage/ndb/src/kernel/vm/GlobalData.hpp
@@ -96,16 +96,13 @@ struct GlobalData {
   Uint32     ndbMtLqhThreads;
   Uint32     ndbMtTcWorkers;
   Uint32     ndbMtTcThreads;
-  Uint32     ndbMtQueryThreads;
   Uint32     ndbMtQueryWorkers;
-  Uint32     ndbMtRecoverThreads;
   Uint32     ndbMtSendThreads;
   Uint32     ndbMtReceiveThreads;
   Uint32     ndbMtMainThreads;
   Uint32     ndbLogParts;
   Uint32     ndbRRGroups;
   Uint32     num_io_laggers; // Protected by theIO_lag_mutex
-  Uint32     QueryThreadsPerLdm;
   
   Uint64     theMicrosSleep;
   Uint64     theBufferFullMicrosSleep;
@@ -153,16 +150,13 @@ struct GlobalData {
     ndbMtLqhThreads = 0;
     ndbMtTcWorkers = 0;
     ndbMtTcThreads = 0;
-    ndbMtQueryThreads = 0;
     ndbMtQueryWorkers = 0;
-    ndbMtRecoverThreads = 0;
     ndbMtSendThreads = 0;
     ndbMtReceiveThreads = 0;
     ndbMtMainThreads = 0;
     ndbLogParts = 0;
-    ndbRRGroups = 1;
+    ndbRRGroups = 0;
     num_io_laggers = 0;
-    QueryThreadsPerLdm = 0;
     theMicrosSleep = 0;
     theBufferFullMicrosSleep = 0;
     theMicrosSend = 0;
@@ -208,8 +202,8 @@ struct GlobalData {
 
   Uint32 getBlockThreads() const {
     return ndbMtLqhThreads +
-           ndbMtQueryThreads +
            ndbMtTcThreads +
+           ndbMtMainThreads +
            ndbMtReceiveThreads;
   }
 

--- a/storage/ndb/src/kernel/vm/TransporterCallback.cpp
+++ b/storage/ndb/src/kernel/vm/TransporterCallback.cpp
@@ -411,18 +411,6 @@ TransporterReceiveHandleKernel::deliver_signal(SignalHeader * const header,
        * and to query threads.
        */
       require(prio == JBB);
-      if (unlikely(globalData.ndbMtQueryWorkers == 0))
-      {
-        /**
-         * Older versions of RonDB (before 21.04.9) could potentially
-         * send a request to V_QUERY even when we don't have any query
-         * threads. In this case we simply change to use the DBLQH
-         * block.
-         */
-        header->theReceiversBlockNumber = DBLQH;
-        sendlocal(m_thr_no, header, theData, secPtrI);
-        return false;
-      }
       Uint32 data[25];
       Uint32 *out_data = theData;
       Uint32 *buf_ptr = &data[0];

--- a/storage/ndb/src/kernel/vm/mt.hpp
+++ b/storage/ndb/src/kernel/vm/mt.hpp
@@ -48,10 +48,7 @@
   messages directed to other nodes and contains no blocks and
   executes thus no signals.
 */
-#define MAX_BLOCK_THREADS (MAX_MAIN_THREADS +       \
-                           MAX_NDBMT_LQH_THREADS +  \
-                           MAX_NDBMT_TC_THREADS +   \
-                           MAX_NDBMT_RECEIVE_THREADS)
+#define MAX_BLOCK_THREADS (NDBMT_MAX_BLOCK_INSTANCES)
 
 /**
  * The worst case is the single thread instance running the receive thread,
@@ -108,7 +105,6 @@ void mt_setConfMinSendDelay(Uint32 min_send_delay);
 void mt_setMaxSendDelay(Uint32 max_send_delay);
 void mt_setMinSendDelay(Uint32 min_send_delay);
 void mt_setMaxSendBufferSizeDelay(Uint32 max_send_buffer_size_delay);
-bool mt_is_recover_thread(Uint32 thr_no);
 void mt_setOverloadStatus(Uint32 self,
                          OverloadStatus new_status);
 void mt_setNodeOverloadStatus(Uint32 self,
@@ -125,8 +121,8 @@ void mt_setSpintime(Uint32 self, Uint32 new_spintime);
 Uint32 mt_getWakeupLatency(void);
 void mt_setWakeupLatency(Uint32);
 
-const char *mt_getThreadName(Uint32 self);
-const char *mt_getThreadDescription(Uint32 self);
+void mt_getThreadName(Uint32 self, char *name);
+void mt_getThreadDescription(Uint32 self, char *desc);
 void mt_getSendPerformanceTimers(Uint32 send_instance,
                                  Uint64 & exec_time,
                                  Uint64 & sleep_time,
@@ -146,6 +142,7 @@ bool mt_is_recv_thread_for_new_trp(Uint32 self,
                                    NodeId node_id,
                                    TrpId trp_id);
 Uint32 mt_getMainThrmanInstance();
+Uint32 mt_getRepThrmanInstance();
 
 SendStatus mt_send_remote(Uint32 self, const SignalHeader *sh, Uint8 prio,
                           const Uint32 *data, NodeId nodeId,

--- a/storage/ndb/src/kernel/vm/ndbd_malloc_impl.cpp
+++ b/storage/ndb/src/kernel/vm/ndbd_malloc_impl.cpp
@@ -2092,7 +2092,6 @@ Ndbd_mem_manager::init_memory_pools()
   glob_mem_manager = this;
   unsigned int num_threads =
     globalData.ndbMtLqhThreads +
-    globalData.ndbMtQueryThreads +
     globalData.ndbMtReceiveThreads + 
     globalData.ndbMtMainThreads +
     globalData.ndbMtTcThreads;


### PR DESCRIPTION
This patch changes the workings of query threads. To start with query threads were a physical thread, next step they were integrated with LDM threads to ensure higher throughput in writes.

In this step we extend such that all block threads, thus also recv, main, rep and TC threads can also act as query workers.

The reasoning behind this change is that e.g. a TC thread that isn't busy can assist the LDM thread by handling read queries, similarly for recv, main and rep threads.

We still want to maintain the possibility to run a thread pipeline that gives more efficient execution, but at the same time we want to use the CPUs fully since specialised threads gives some CPU usage not used since it is impossible to get a perfect balance between LDM, TC and recv thread.

Thus block threads can now both assist on sending as well as on read queries.

As part of this patch we have removed the recover threads. Since all query workers can be used for recovery the only CPUs not being used is the CPU by the send thread and this is not enough to motivate keeping recover threads.

The patch introduces two new configuration parameters: UseLdmThreads and UseTcThreads.

Setting UseLdmThreads to false means that we will run with only receive threads.

Setting UseTcThreads to false and UseLdmThreads means that we will have LDM threads and recv threads and main threads, no TC threads. This parameter is used in conjunction with AutomaticThreadConfig=1 which is the default setting.

The patch also does a major effort to improve the portability layer for RonDB. This includes handling CPUs like Intel Rapid Lake that have a mix of efficient and power CPUs. It fixes a number of bugs in the portability layer as well and extends the unit tests for this part.

Previously LDM threads was not sharing L3 cache groups with TC and recv threads. With this patch we have changed this such that also other block threads are part of L3 cache groups and thus read assistance is only provided to LDMs that are part of the same Round Robin Group (thus sharing L3 cache).

This patch removes the possibility to run RonDB without query workers. This feature has not been used in RonDB for several years. Thus it is just as well to cut away this possibility.

Some updates of the query distribution was made. A constant was introduced making it possible to schedule a bit less on TC and recv threads.

Also fixing a few bugs related to query scheduling where scans were not given enough weight and it was possible to end up in an eternal loop. Some extra protection against this possibility was added.

Also since we want to make use other than LDM threads we go directly to the round robin scheduler in some cases.

The concept of Query threads per LDM was removed. In situations with hyperthreading CPUs we still make a bit of work to schedule work on the same CPU core as the LDM thread resides on.

Updated the configuration of automatic thread configuration based on experiments performed in developing this feature.