### PR TITLE
RONDB-663: The mutex handling in DBLQH is improved

### DIFF
--- a/storage/ndb/rest-server/rest-api-server/Makefile
+++ b/storage/ndb/rest-server/rest-api-server/Makefile
@@ -49,7 +49,8 @@ COVERAGE_HTML_OUTPUT_FILE?=./coverage.html
 COVERAGE_FUNC_OUTPUT_FILE?=/dev/stdout
 
 #CGO_LDFLAGS
-MY_CGO_LDFLAGS?="-g -O3 -L${RDRS_LIB_DIR}/ -Wl,--allow-multiple-definition,-rpath,../lib -Wl,-rpath,${RDRS_LIB_DIR}  -lrdrclient"
+MY_CGO_LDFLAGS?="-g -O3 -L${RDRS_LIB_DIR}/ -Wl,-rpath,../lib -Wl,-rpath,${RDRS_LIB_DIR}  -lrdrclient"
+#MY_CGO_LDFLAGS?="-g -O3 -L${RDRS_LIB_DIR}/ -Wl,--allow-multiple-definition,-rpath,../lib -Wl,-rpath,${RDRS_LIB_DIR}  -lrdrclient"
 
 all: rdrs
 

--- a/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
@@ -747,8 +747,8 @@ public:
 //#define DEBUG_FRAGMENT_LOCK 1
 #define LOCK_LINE_MASK 2047
 //#define LOCK_LINE_MASK 511
-#define LOCK_READ_SPIN_TIME 30
-#define LOCK_WRITE_SPIN_TIME 40
+#define LOCK_READ_SPIN_TIME 60
+#define LOCK_WRITE_SPIN_TIME 60
 #ifdef DEBUG_FRAGMENT_LOCK
 #define DEB_FRAGMENT_LOCK(frag) debug_fragment_lock(frag, __LINE__)
 #else
@@ -4875,24 +4875,28 @@ public:
   Uint32 m_scan_frag_access_cond_waits;
   Uint64 m_scan_frag_access_spinloops;
   Uint64 m_scan_frag_access_spintime;
+  Uint64 m_scan_frag_access_waittime;
 
   Uint32 m_read_key_frag_access;
   Uint32 m_read_key_frag_access_contended;
   Uint32 m_read_key_frag_access_cond_waits;
   Uint64 m_read_key_frag_access_spinloops;
   Uint64 m_read_key_frag_access_spintime;
+  Uint64 m_read_key_frag_access_waittime;
 
   Uint32 m_write_key_frag_access;
   Uint32 m_write_key_frag_access_contended;
   Uint32 m_write_key_frag_access_cond_waits;
   Uint64 m_write_key_frag_access_spinloops;
   Uint64 m_write_key_frag_access_spintime;
+  Uint64 m_write_key_frag_access_waittime;
 
   Uint32 m_exclusive_frag_access;
   Uint32 m_exclusive_frag_access_contended;
   Uint32 m_exclusive_frag_access_cond_waits;
   Uint64 m_exclusive_frag_access_spinloops;
   Uint64 m_exclusive_frag_access_spintime;
+  Uint64 m_exclusive_frag_access_waittime;
 
   Uint32 m_upgrade_frag_access;
 


### PR DESCRIPTION
When entering the mode of conditional wait and waking up again after sleep, the thread would simply wake up and quickly go to sleep again without spinning. A better solution is to spin for a while before going to sleep again.

Also minor optimisation and improved debugging of the functionality, spin time was increased.