### PR TITLE
[FSTORE-1405] Add detail status option to rest api feature store endpoints 

### DIFF
--- a/storage/ndb/rest-server/rest-api-server/internal/handlers/batchfeaturestore/handler.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/handlers/batchfeaturestore/handler.go
@@ -113,6 +113,10 @@ func (h *Handler) Execute(request interface{}, response interface{}) (int, error
 		return err.GetStatus(), err.GetError()
 	}
 	var featureStatus = make([]api.FeatureStatus, len(*fsReq.Entries))
+	var detailedStatus [][]*api.DetailedStatus
+	if fsReq.GetOptions().IncludeDetailedStatus {
+		detailedStatus = make([][]*api.DetailedStatus, len(*fsReq.Entries))
+	}
 	var numPassed = checkFeatureStatus(fsReq, metadata, &featureStatus)
 	var readParams = getBatchPkReadParamsMutipleEntries(metadata, fsReq.Entries, &featureStatus)
 	fsResp := response.(*api.BatchFeatureStoreResponse)
@@ -135,7 +139,7 @@ func (h *Handler) Execute(request interface{}, response interface{}) (int, error
 			var fsError = fshandler.TranslateRonDbError(code, ronDbErr.Error())
 			return fsError.GetStatus(), fsError.GetError()
 		}
-		features, err = getFeatureValuesMultipleEntries(dbResponseIntf, fsReq.Entries, metadata, &featureStatus)
+		features, err = getFeatureValuesMultipleEntries(dbResponseIntf, fsReq.Entries, metadata, &featureStatus, &detailedStatus, fsReq.GetOptions().IncludeDetailedStatus)
 		if err != nil {
 			return err.GetStatus(), err.GetError()
 		}
@@ -152,10 +156,13 @@ func (h *Handler) Execute(request interface{}, response interface{}) (int, error
 	if fsReq.MetadataRequest != nil {
 		fsResp.Metadata = *fshandler.GetFeatureMetadata(metadata, fsReq.MetadataRequest)
 	}
+	if fsReq.GetOptions().IncludeDetailedStatus {
+		fsResp.DetailedStatus = detailedStatus
+	}
 	return http.StatusOK, nil
 }
 
-func getFeatureValuesMultipleEntries(batchResponse *api.BatchOpResponse, entries *[]*map[string]*json.RawMessage, featureView *feature_store.FeatureViewMetadata, batchStatus *[]api.FeatureStatus) (*[][]interface{}, *feature_store.RestErrorCode) {
+func getFeatureValuesMultipleEntries(batchResponse *api.BatchOpResponse, entries *[]*map[string]*json.RawMessage, featureView *feature_store.FeatureViewMetadata, batchStatus *[]api.FeatureStatus, detailedStatus *[][]*api.DetailedStatus, includeDetailedStatus bool) (*[][]interface{}, *feature_store.RestErrorCode) {
 	rondbResp := (*batchResponse).(*api.BatchResponseJSON)
 	ronDbBatchResult := make([][]*api.PKReadResponseWithCodeJSON, len(*batchStatus))
 	batchResult := make([][]interface{}, len(*batchStatus))
@@ -170,9 +177,12 @@ func getFeatureValuesMultipleEntries(batchResponse *api.BatchOpResponse, entries
 	}
 	for i, ronDbResult := range ronDbBatchResult {
 		if len(ronDbResult) != 0 {
-			result, status, _ := fshandler.GetFeatureValues(&ronDbResult, (*entries)[i], featureView)
+			result, status, perEntryDetailedStatus, _ := fshandler.GetFeatureValues(&ronDbResult, (*entries)[i], featureView, includeDetailedStatus)
 			batchResult[i] = *result
 			(*batchStatus)[i] = status
+			if includeDetailedStatus {
+				(*detailedStatus)[i] = perEntryDetailedStatus
+			}
 		}
 	}
 	return &batchResult, nil

--- a/storage/ndb/rest-server/rest-api-server/internal/handlers/feature_store/handler.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/handlers/feature_store/handler.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"hopsworks.ai/rdrs/internal/common"
@@ -222,9 +223,12 @@ func (h *Handler) Execute(request interface{}, response interface{}) (int, error
 	if fsError != nil {
 		return fsError.GetStatus(), fsError.GetError()
 	}
-	features, status, fsError := GetFeatureValues(rondbResp.Result, fsReq.Entries, metadata)
+	features, status, detailedStatus, fsError := GetFeatureValues(rondbResp.Result, fsReq.Entries, metadata, fsReq.GetOptions().IncludeDetailedStatus)
 	if fsError != nil {
 		return fsError.GetStatus(), fsError.GetError()
+	}
+	if log.IsDebug() {
+		log.Debugf("Detailed Status : %s", detailedStatus)
 	}
 	fsResp := response.(*api.FeatureStoreResponse)
 	fsResp.Status = status
@@ -232,6 +236,9 @@ func (h *Handler) Execute(request interface{}, response interface{}) (int, error
 	fsResp.Features = *features
 	if fsReq.MetadataRequest != nil {
 		fsResp.Metadata = *GetFeatureMetadata(metadata, fsReq.MetadataRequest)
+	}
+	if fsReq.GetOptions().IncludeDetailedStatus {
+		fsResp.DetailedStatus = detailedStatus
 	}
 	return http.StatusOK, nil
 }
@@ -296,11 +303,23 @@ func TranslateRonDbError(code int, err string) *feature_store.RestErrorCode {
 	return fsError
 }
 
-func GetFeatureValues(ronDbResult *[]*api.PKReadResponseWithCodeJSON, entries *map[string]*json.RawMessage, featureView *feature_store.FeatureViewMetadata) (*[]interface{}, api.FeatureStatus, *feature_store.RestErrorCode) {
+func GetFeatureValues(ronDbResult *[]*api.PKReadResponseWithCodeJSON, entries *map[string]*json.RawMessage, featureView *feature_store.FeatureViewMetadata, includeDetailedStatus bool) (*[]interface{}, api.FeatureStatus, []*api.DetailedStatus, *feature_store.RestErrorCode) {
 	featureValues := make([]interface{}, featureView.NumOfFeatures)
 	var status = api.FEATURE_STATUS_COMPLETE
+	var arrDetailedStatus = make([]*api.DetailedStatus, 0, len(*ronDbResult))
 	var err *feature_store.RestErrorCode
 	for _, response := range *ronDbResult {
+		if includeDetailedStatus {
+			fgInt, err := strconv.Atoi(strings.Split(*response.Body.OperationID, "|")[1])
+			if err != nil {
+				log.Errorf("Failed to convert feature group id to int: %s", *response.Body.OperationID)
+				fgInt = -1
+			}
+			arrDetailedStatus = append(arrDetailedStatus, &api.DetailedStatus{
+				FeatureGroupId: fgInt,
+				HttpStatus:     *response.Code,
+			})
+		}
 		if *response.Code == http.StatusNotFound {
 			status = api.FEATURE_STATUS_MISSING
 		} else if *response.Code == http.StatusBadRequest {
@@ -331,7 +350,7 @@ func GetFeatureValues(ronDbResult *[]*api.PKReadResponseWithCodeJSON, entries *m
 		}
 	}
 	// Fill in primary key value from request into the vector
-	// If multiple matched entries are found, the priority of the entry follows the order in `GetBatchPkReadParams` 
+	// If multiple matched entries are found, the priority of the entry follows the order in `GetBatchPkReadParams`
 	// i.e required entry > entry with prefix > entry without prefix
 	// Reason why it has to loop all entries for each `*JoinKeyMap` is to make sure the value are filled in according to the priority.
 	// Otherwise the lower priority one can overwrite the previous assigned entry if the later entry exists only in the lower priority map.
@@ -365,7 +384,7 @@ func GetFeatureValues(ronDbResult *[]*api.PKReadResponseWithCodeJSON, entries *m
 			FillPrimaryKey(featureView, &featureValues, joinKeysRequired, value)
 		}
 	}
-	return &featureValues, status, err
+	return &featureValues, status, arrDetailedStatus, err
 }
 
 func FillPrimaryKey(featureView *feature_store.FeatureViewMetadata, featureValues *[]interface{}, joinKeys []string, value *json.RawMessage) {
@@ -425,13 +444,13 @@ func GetBatchPkReadParams(metadata *feature_store.FeatureViewMetadata, entries *
 						log.Debugf("Add to filter: %s", pkCol)
 					}
 				}
-			} else if (*entries)[servingKey.Prefix + servingKey.FeatureName] != nil {
+			} else if (*entries)[servingKey.Prefix+servingKey.FeatureName] != nil {
 				// Also Fallback and use feature name with prefix.
-				var filter = api.Filter{Column: &pkCol, Value: (*entries)[servingKey.Prefix + servingKey.FeatureName]}
+				var filter = api.Filter{Column: &pkCol, Value: (*entries)[servingKey.Prefix+servingKey.FeatureName]}
 				filters = append(filters, filter)
 				if log.IsDebug() {
 					var entryValue interface{}
-					err := json.Unmarshal(*(*entries)[servingKey.Prefix + servingKey.FeatureName], &entryValue)
+					err := json.Unmarshal(*(*entries)[servingKey.Prefix+servingKey.FeatureName], &entryValue)
 					if err == nil {
 						log.Debugf("Add to filter: %s=%v", pkCol, entryValue)
 					} else {

--- a/storage/ndb/rest-server/rest-api-server/internal/integrationtests/batchfeaturestore/handler_test.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/integrationtests/batchfeaturestore/handler_test.go
@@ -1232,7 +1232,6 @@ func Test_GetFeatureVector_IncompletePrimaryKey_Join_IncludePk(t *testing.T) {
 		nil,
 	)
 	for _, row := range rows {
-
 		// Only features from right fg are not null because primary key of the right fg is provided
 		for j := range row {
 			if j < 4 {
@@ -2222,4 +2221,165 @@ func Test_PassedFeatures_LabelShouldFail_NoValidation(t *testing.T) {
 	fsReq.OptionsRequest = &api.OptionsRequest{ValidatePassedFeatures: &validatePassedFeatures}
 	var fsResp = GetFeatureStoreResponseWithDetail(t, fsReq, "", http.StatusOK)
 	ValidateResponseWithDataExcludeCols(t, &rows, &cols, &exCols, fsResp)
+}
+
+func Test_IncludeDetailedStatus_SingleTable(t *testing.T) {
+	rows, pks, cols, err := fshelper.GetNSampleData(testdbs.FSDB001, "sample_1_1", 5)
+	if err != nil {
+		t.Fatalf("Cannot get sample data with error %s ", err)
+	}
+	var fsReq = CreateFeatureStoreRequest(
+		testdbs.FSDB001,
+		"sample_1",
+		1,
+		pks,
+		*GetPkValues(&rows, &pks, &cols),
+		nil,
+		nil,
+	)
+	includeDetailedStatus := true
+	fsReq.OptionsRequest = &api.OptionsRequest{IncludeDetailedStatus: &includeDetailedStatus}
+	fsResp := GetFeatureStoreResponse(t, fsReq)
+
+	ValidateResponseWithData(t, &rows, &cols, fsResp)
+	if fsResp.DetailedStatus == nil {
+		t.Fatalf("Detailed status has been explicitly requested but not returned")
+	}
+	for _, list_ds := range fsResp.DetailedStatus {
+		if len(list_ds) != 1 {
+			t.Fatalf("Detailed status should have only one entry")
+		}
+		if list_ds[0].HttpStatus != http.StatusOK {
+			t.Fatalf("Detailed status should have http status %d", http.StatusOK)
+		}
+		if list_ds[0].FeatureGroupId == -1 {
+			t.Fatalf("FeatureGroupId should have been parsed correctly from operationId")
+		}
+	}
+}
+
+func Test_IncludeDetailedStatus_JoinedTable(t *testing.T) {
+	rows, pks, cols, err := fshelper.GetSampleDataWithJoin(testdbs.FSDB001, "sample_1_1", testdbs.FSDB001, "sample_2_1", "fg2_")
+	if err != nil {
+		t.Fatalf("Cannot get sample data with error %s ", err)
+	}
+	var fsReq = CreateFeatureStoreRequest(
+		testdbs.FSDB001,
+		"sample_1n2",
+		1,
+		pks,
+		*GetPkValues(&rows, &pks, &cols),
+		nil,
+		nil,
+	)
+	includeDetailedStatus := true
+	fsReq.OptionsRequest = &api.OptionsRequest{IncludeDetailedStatus: &includeDetailedStatus}
+	fsResp := GetFeatureStoreResponse(t, fsReq)
+
+	ValidateResponseWithData(t, &rows, &cols, fsResp)
+	if fsResp.DetailedStatus == nil {
+		t.Fatalf("Detailed status has been explicitly requested but not returned")
+	}
+	for _, list_ds := range fsResp.DetailedStatus {
+		if len(list_ds) != 2 {
+			t.Fatalf("Detailed status should have only two entry")
+		}
+		if list_ds[0].HttpStatus != http.StatusOK {
+			t.Fatalf("Detailed status should have http status %d", http.StatusOK)
+		}
+		if list_ds[0].FeatureGroupId == -1 {
+			t.Fatalf("FeatureGroupId should have been parsed correctly from operationId")
+		}
+	}
+}
+
+func Test_IncludeDetailedStatus_JoinedTablePartialKey(t *testing.T) {
+	rows, _, cols, err := fshelper.GetSampleDataWithJoin(testdbs.FSDB001, "sample_1_1", testdbs.FSDB001, "sample_1_1", "fg1_")
+	if err != nil {
+		t.Fatalf("Cannot get sample data with error %s ", err)
+	}
+	var pkValues = make([][]interface{}, 0)
+	for _, row := range rows {
+		// Primary key of right fg
+		pkValues = append(pkValues, []interface{}{row[4]})
+	}
+
+	var fsReq = CreateFeatureStoreRequest(
+		testdbs.FSDB001,
+		"sample_1n1_self",
+		1,
+		[]string{"fg1_id1"},
+		pkValues,
+		nil,
+		nil,
+	)
+	for _, row := range rows {
+		// Only features from right fg are not null because primary key of the right fg is provided
+		for j := range row {
+			if j < 4 {
+				row[j] = nil
+			}
+		}
+	}
+	includeDetailedStatus := true
+	fsReq.OptionsRequest = &api.OptionsRequest{IncludeDetailedStatus: &includeDetailedStatus}
+	fsResp := GetFeatureStoreResponse(t, fsReq)
+
+	ValidateResponseWithData(t, &rows, &cols, fsResp)
+	if fsResp.DetailedStatus == nil {
+		t.Fatalf("Detailed status has been explicitly requested but not returned")
+	}
+	for _, list_ds := range fsResp.DetailedStatus {
+		if len(list_ds) != 2 {
+			t.Fatalf("Detailed status should have two entries")
+		}
+		for idx, ds := range list_ds {
+			if idx == 1 && ds.HttpStatus != http.StatusOK {
+				t.Fatalf("Detailed status should have http status %d", http.StatusOK)
+			}
+			if idx == 0 && ds.HttpStatus != http.StatusBadRequest {
+				t.Fatalf("Detailed status should have http status %d", http.StatusBadRequest)
+			}
+			if ds.FeatureGroupId == -1 {
+				t.Fatalf("FeatureGroupId should have been parsed correctly from operationId")
+			}
+		}
+
+	}
+}
+
+func Test_IncludeDetailedStatus_JoinedTablePartialKeyAndMissingRow(t *testing.T) {
+	var fsReq = CreateFeatureStoreRequest(
+		testdbs.FSDB001,
+		"sample_1n3",
+		1,
+		[]string{"id1"},
+		[][]interface{}{{[]byte(`"99999"`)}, {[]byte(`"9999"`)}},
+		nil,
+		nil,
+	)
+	includeDetailedStatus := true
+	fsReq.OptionsRequest = &api.OptionsRequest{IncludeDetailedStatus: &includeDetailedStatus}
+	fsResp := GetFeatureStoreResponse(t, fsReq)
+	if fsResp.DetailedStatus == nil {
+		t.Fatalf("Detailed status has been explicitly requested but not returned")
+	}
+	for _, list_ds := range fsResp.DetailedStatus {
+		if len(list_ds) != 2 {
+			t.Fatalf("Detailed status should have two entries")
+		}
+		for idx, ds := range list_ds {
+			if idx == 0 && ds.HttpStatus != http.StatusNotFound {
+				t.Fatalf("Detailed status should have http status %d", http.StatusNotFound)
+			}
+			if idx == 1 && ds.HttpStatus != http.StatusBadRequest {
+				t.Fatalf("Detailed status should have http status %d", http.StatusBadRequest)
+			}
+			if ds.FeatureGroupId == -1 {
+				t.Fatalf("FeatureGroupId should have been parsed correctly from operationId")
+			}
+		}
+
+	}
+
 }


### PR DESCRIPTION
…r (batch) feature store endpoints (#464)

* Add detailedStatus field to response and in request options

* Fix batch and prevent nil includeDetailedStatus

* Working with nil is always bad

* Remove message and operationId fields from detailed status + add unit tests

* fix test

---------