### PR TITLE
RONDB-693: API Key cache rewrite

### DIFF
--- a/mysql-test/suite/ronsql/include/ronsql_compare.inc
+++ b/mysql-test/suite/ronsql/include/ronsql_compare.inc
@@ -1,5 +1,6 @@
 # This include-file, or subroutine, executes a query with both mysql client and
 # ronsql_cli, then compares the results.
+--source include/have_util_sed.inc
 --echo == Query ==
 if ($QUERY!='')
 {
@@ -18,7 +19,8 @@ if ($QUERY=='')
 --let $QUERY_PARAMS = -D test $QUERY_PARAMS
 --exec $MYSQL $QUERY_PARAMS > $MYSQL_TMP_DIR/mysql.out
 if ($canonicalization_script) {
---exec sed -ri '$canonicalization_script' $MYSQL_TMP_DIR/mysql.out
+--exec sed -r '$canonicalization_script' $MYSQL_TMP_DIR/mysql.out > $MYSQL_TMP_DIR/mysql.out.canon
+--move_file $MYSQL_TMP_DIR/mysql.out.canon $MYSQL_TMP_DIR/mysql.out
 }
 --exec (head -n 1 $MYSQL_TMP_DIR/mysql.out && tail -n +2 $MYSQL_TMP_DIR/mysql.out | sort) > $MYSQL_TMP_DIR/mysql.out.sorted
 if ($show_all_results) {
@@ -28,7 +30,8 @@ if ($show_all_results) {
 }
 --exec $RONSQL_CLI_EXE --connect-string $NDB_CONNECTSTRING $QUERY_PARAMS > $MYSQL_TMP_DIR/ronsql.out
 if ($canonicalization_script) {
---exec sed -ri '$canonicalization_script' $MYSQL_TMP_DIR/ronsql.out
+--exec sed -r '$canonicalization_script' $MYSQL_TMP_DIR/ronsql.out > $MYSQL_TMP_DIR/ronsql.out.canon
+--move_file $MYSQL_TMP_DIR/ronsql.out.canon $MYSQL_TMP_DIR/ronsql.out
 }
 --exec (head -n 1 $MYSQL_TMP_DIR/ronsql.out && tail -n +2 $MYSQL_TMP_DIR/ronsql.out | sort) > $MYSQL_TMP_DIR/ronsql.out.sorted
 if ($explain_ronsql) {

--- a/storage/ndb/rest-server/data-access-rondb/src/rdrs_rondb_connection_pool.cpp
+++ b/storage/ndb/rest-server/data-access-rondb/src/rdrs_rondb_connection_pool.cpp
@@ -33,7 +33,6 @@ RDRSRonDBConnectionPool::~RDRSRonDBConnectionPool() {
   dataConnection     = nullptr;
   metadataConnection = nullptr;
   is_shutdown = true;
-  ndb_end(1);  // sometimes causes seg faults when called repeatedly from unit tests
 }
 
 RS_Status RDRSRonDBConnectionPool::Check() {
@@ -44,11 +43,6 @@ RS_Status RDRSRonDBConnectionPool::Check() {
 }
 
 RS_Status RDRSRonDBConnectionPool::Init() {
-  int retCode = 0;
-  retCode     = ndb_init();
-  if (retCode != 0) {
-    return RS_SERVER_ERROR(ERROR_001 + std::string(" RetCode: ") + std::to_string(retCode));
-  }
   return RS_OK;
 }
 

--- a/storage/ndb/rest-server2/extra/CMakeLists.txt
+++ b/storage/ndb/rest-server2/extra/CMakeLists.txt
@@ -13,5 +13,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_subdirectory(drogon)
 add_subdirectory(simdjson)

--- a/storage/ndb/rest-server2/server/src/CMakeLists.txt
+++ b/storage/ndb/rest-server2/server/src/CMakeLists.txt
@@ -9,7 +9,7 @@ file(GLOB_RECURSE SRC
 	*.cpp
 	*.h
 )
-NDB_ADD_EXECUTABLE(${PROJECT_NAME} ${SRC})
+NDB_ADD_EXECUTABLE(${PROJECT_NAME} ${SRC} STATIC_NDBCLIENT)
 add_dependencies(${PROJECT_NAME} DROGON_IS_BUILD SIMDJSON_IS_BUILD)
 
 set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${RDRS_DROGON_CMAKE_MODULES_DIR})
@@ -81,7 +81,7 @@ INCLUDE_DIRECTORIES(${RDRS_SIMDJSON_INCLUDE_DIR})
 LINK_DIRECTORIES(${RDRS_DROGON_LIB_DIR})
 INCLUDE_DIRECTORIES(${AVROCPP_INCLUDE_DIR})
 
-target_link_libraries(${PROJECT_NAME}
+TARGET_LINK_LIBRARIES(${PROJECT_NAME}
                       base64
                       ${AVROCPP_LIBRARIES}
                       Jsoncpp_lib
@@ -90,9 +90,9 @@ target_link_libraries(${PROJECT_NAME}
                       simdjson::simdjson
                       ${RDRS_OPENSSL_LIBRARY}
                       ${RDRS_CRYPTO_LIBRARY}
-                      ndbclient_so
                       ndbgeneral
                       rdrs_string
+                      mysqlclient
                       ronsql)
 
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME} 
@@ -111,13 +111,12 @@ target_include_directories(rdrs2_lib PUBLIC
   ${CMAKE_SOURCE_DIR}/storage/ndb/include/util
   ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(rdrs2_lib PUBLIC ${RDRS_DROGON_INCLUDE_DIR})
-#target_include_directories(rdrs2_lib PUBLIC ${RDRS_SIMDJSON_DIR})
 target_include_directories(rdrs2_lib PUBLIC ${RDRS_SIMDJSON_INCLUDE_DIR})
 target_include_directories(rdrs2_lib PUBLIC ${RDRS_AVRO_INCLUDE_DIR})
 target_link_directories(rdrs2_lib PUBLIC ${RDRS_DROGON_LIB_DIR})
 
 # todo-ronsql is ronsql needed for rdrs2_lib? It's used in ../test/api_key_test
-target_link_libraries(rdrs2_lib
+TARGET_LINK_LIBRARIES(rdrs2_lib
                       base64
                       ${AVROCPP_LIBRARIES}
                       Jsoncpp_lib

--- a/storage/ndb/rest-server2/server/src/api_key.cpp
+++ b/storage/ndb/rest-server2/server/src/api_key.cpp
@@ -26,19 +26,101 @@
 #include <iostream>
 #include <memory>
 #include <openssl/evp.h>
-#include <pthread.h>
 #include <thread>
 #include <unordered_map>
 #include <functional>
 #include <algorithm>
+#include <NdbThread.h>
+#include <util/require.h>
+#include <EventLogger.hpp>
 
-std::shared_ptr<APIKeyCache> apiKeyCache;
+//#define DEBUG_AUTH 1
+//#define DEBUG_AUTH_THREAD 1
+//#define DEBUG_AUTH_TIME 1
+//#define DEBUG_AUTH_DBS 1
+
+#ifdef DEBUG_AUTH
+#define DEB_AUTH(arglist) do { g_eventLogger->info arglist ; } while (0)
+#else
+#define DEB_AUTH(arglist) do { } while (0)
+#endif
+
+#ifdef DEBUG_AUTH_THREAD
+#define DEB_AUTH_THREAD(arglist) do { g_eventLogger->info arglist ; } while (0)
+#else
+#define DEB_AUTH_THREAD(arglist) do { } while (0)
+#endif
+
+#ifdef DEBUG_AUTH_TIME
+#define DEB_AUTH_TIME(arglist) do { g_eventLogger->info arglist ; } while (0)
+#else
+#define DEB_AUTH_TIME(arglist) do { } while (0)
+#endif
+
+#ifdef DEBUG_AUTH_DBS
+#define DEB_AUTH_DBS(arglist) do { g_eventLogger->info arglist ; } while (0)
+#else
+#define DEB_AUTH_DBS(arglist) do { } while (0)
+#endif
+
+#ifndef DEBUG_AUTH_THREAD
+#define CLEANUP_SLEEP_TIME 10
+#else
+#define CLEANUP_SLEEP_TIME 1000
+#endif
+extern EventLogger *g_eventLogger;
+
+APIKeyCache *apiKeyCache = nullptr;
 
 std::vector<std::string> split(const std::string &, char);
 RS_Status computeHash(const std::string &unhashed, std::string &hashed);
 
+APIKeyCache* start_api_key_cache() {
+  apiKeyCache = new APIKeyCache();
+  require(apiKeyCache != nullptr);
+  DEB_AUTH(("API Key Cache started: %p", apiKeyCache));
+  return apiKeyCache;
+}
+
+void stop_api_key_cache() {
+  DEB_AUTH(("API Key Cache stopped: %p", apiKeyCache));
+  if (apiKeyCache != nullptr) {
+    delete apiKeyCache;
+    apiKeyCache = nullptr;
+  }
+}
+
+void APIKeyCache::cleanup() {
+  /* Start by waking all threads */
+  DEB_AUTH(("Cleanup started"));
+  NdbMutex_Lock(m_sleepLock);
+  NdbMutex_Lock(m_rwLock);
+  m_evicted = true;
+  NdbCondition_Broadcast(m_sleepCond);
+  NdbMutex_Unlock(m_sleepLock);
+  NdbMutex_Unlock(m_rwLock);
+
+  /* Wait for all objects to complete cleanup */
+  NdbMutex_Lock(m_rwLock);
+  while (m_key_cache.size() > 0) {
+#ifdef DEBUG_AUTH
+    Uint32 key_cache_size = (Uint32)m_key_cache.size();
+#endif
+    NdbMutex_Unlock(m_rwLock);
+    DEB_AUTH(("m_key_cache.size() = %u", key_cache_size));
+    NdbSleep_MilliSleep(CLEANUP_SLEEP_TIME);
+  }
+  DEB_AUTH(("Cleanup finished"));
+  NdbMutex_Unlock(m_rwLock);
+}
+
 RS_Status authenticate(const std::string &apiKey, PKReadParams &params) {
   return apiKeyCache->validate_api_key(apiKey, {params.path.db});
+}
+
+RS_Status authenticate(const std::string &apiKey,
+                       const std::vector<std::string> &dbs) {
+  return apiKeyCache->validate_api_key(apiKey, dbs);
 }
 
 RS_Status APIKeyCache::validate_api_key_format(const std::string &apiKey) {
@@ -46,351 +128,374 @@ RS_Status APIKeyCache::validate_api_key_format(const std::string &apiKey) {
     return CRS_Status(HTTP_CODE::CLIENT_ERROR, "the apikey is nil").status;
   }
   auto splits = split(apiKey, '.');
-  if (splits.size() != 2 || splits[0].length() != 16 || splits[1].length() < 1) {
-    return CRS_Status(HTTP_CODE::CLIENT_ERROR, "the apikey has an incorrect format").status;
+  if (splits.size() != 2 ||
+      splits[0].length() != 16 ||
+      splits[1].length() < 1) {
+    DEB_AUTH(("Failed incorrect format, Line: %u", __LINE__));
+    return CRS_Status(HTTP_CODE::CLIENT_ERROR,
+                      "the apikey has an incorrect format").status;
   }
   return CRS_Status::SUCCESS.status;
 }
 
 RS_Status APIKeyCache::validate_api_key(const std::string &apiKey,
                                         const std::vector<std::string> &dbs) {
+#ifdef DEBUG_AUTH
+  DEB_AUTH(("authenticate apiKey: %s", apiKey.c_str()));
+  for (const auto &db : dbs) {
+    DEB_AUTH(("validate db: %s", db.c_str()));
+  }
+#endif
   RS_Status status = validate_api_key_format(apiKey);
   if (status.http_code != HTTP_CODE::SUCCESS) {
     return status;
   }
-
   if (dbs.empty()) {
+    DEB_AUTH(("Empty database authenticated, Line: %u", __LINE__));
     return CRS_Status::SUCCESS.status;
   }
 
   // Authenticates only using the the cache. No request sent to backend
   bool keyFoundInCache = false;
-  bool allowedAccess   = false;
-  status               = find_and_validate(apiKey, keyFoundInCache, allowedAccess, dbs);
+  bool allowedAccess = false;
+  status = find_and_validate(apiKey,
+                             keyFoundInCache,
+                             allowedAccess,
+                             dbs,
+                             false);
 
   if (keyFoundInCache) {
-    if (!allowedAccess) {
-      return CRS_Status(HTTP_CODE::CLIENT_ERROR,
-                        ("unauthorized. Found in cache: " +
-                         std::string(keyFoundInCache ? "true" : "false") +
-                         ", allowed access: " + std::string(allowedAccess ? "true" : "false"))
-                            .c_str())
-          .status;
+    if (allowedAccess) {
+      return CRS_Status::SUCCESS.status;
+    } else {
+      return status;
     }
-    return CRS_Status::SUCCESS.status;
   }
-
-  // Update the cache by fetching the API key from backend
+  /**
+   * Update the cache by fetching the API key from backend
+   * Only come here if the API Key wasn't found in cache.
+   */
   status = update_cache(apiKey);
   if (status.http_code != HTTP_CODE::SUCCESS) {
     return status;
   }
 
   // Authenticates only using the the cache. No request sent to backend
-  status = find_and_validate_again(apiKey, keyFoundInCache, allowedAccess, dbs);
-  if (!keyFoundInCache || !allowedAccess) {
-    return CRS_Status(HTTP_CODE::CLIENT_ERROR,
-                      ("api key is unauthorized; updated cache - found in cache: " +
-                       std::string(keyFoundInCache ? "true" : "false") +
-                       ", allowed access: " + std::string(allowedAccess ? "true" : "false"))
-                          .c_str())
-        .status;
-  }
-
-  return CRS_Status::SUCCESS.status;
+  status = find_and_validate(apiKey,
+                             keyFoundInCache,
+                             allowedAccess,
+                             dbs,
+                             true);
+  return status;
 }
 
-RS_Status APIKeyCache::validate_api_key_no_cache(const std::string &apiKey,
-                                                 const std::vector<std::string> &dbs) {
-  RS_Status status = validate_api_key_format(apiKey);
-  if (status.http_code != HTTP_CODE::SUCCESS) {
-    return status;
+RS_Status APIKeyCache::find_and_validate(const std::string &apiKey,
+                                         bool &keyFoundInCache,
+                                         bool &allowedAccess,
+                                         const std::vector<std::string> &dbs,
+                                         bool inc_refcount_done) {
+  NdbMutex_Lock(m_rwLock);
+  if (m_evicted) {
+    NdbMutex_Unlock(m_rwLock);
+    keyFoundInCache = true; // Make sure we return without inserting it
+    DEB_AUTH(("API Key cache shutdown, Line: %u", __LINE__));
+    return CRS_Status(HTTP_CODE::CLIENT_ERROR,
+      "API Key cache is shutting down").status;
   }
-
-  if (dbs.empty()) {
-    return CRS_Status::SUCCESS.status;
+  auto it = m_key_cache.find(apiKey);
+  if (it == m_key_cache.end()) {
+    NdbMutex_Unlock(m_rwLock);
+    require(!inc_refcount_done);
+    DEB_AUTH(("API Key not found, Line: %u", __LINE__));
+    return CRS_Status(HTTP_CODE::CLIENT_ERROR,
+      "API key not found in cache").status;
   }
+  auto userDBs = it->second;
 
-  HopsworksAPIKey key;
-  status = authenticate_user(apiKey, key);
-  if (status.http_code != HTTP_CODE::SUCCESS) {
-    return status;
+  keyFoundInCache = true;
+  if (userDBs == nullptr) {
+    NdbMutex_Unlock(m_rwLock);
+    require(!inc_refcount_done);
+    DEB_AUTH(("API Key found UserDBs null, Line: %u", __LINE__));
+    return CRS_Status(HTTP_CODE::CLIENT_ERROR,
+      "API key found in cache but userDBs is null").status;
   }
-
-  std::vector<std::string> userDBs;
-  status = get_user_databases(key, userDBs);
-  if (status.http_code != HTTP_CODE::SUCCESS) {
-    return status;
+  if (userDBs->m_state == UserDBs::IS_INVALID) {
+    if (inc_refcount_done) userDBs->m_ref_count--;
+#ifdef DEBUG_AUTH
+    int ref_count = userDBs->m_ref_count;
+#endif
+    NdbMutex_Unlock(m_rwLock);
+    DEB_AUTH(("API Key found invalid, Line: %u, refCount: %d",
+              __LINE__, ref_count));
+    return CRS_Status(HTTP_CODE::CLIENT_ERROR,
+      "API key found in cache but is invalid").status;
   }
-
-  // Check if the user has access to the database
+  NdbMutex_Lock(userDBs->m_waitLock);
+  NdbMutex_Unlock(m_rwLock);
+  while (userDBs->m_state == UserDBs::IS_VALIDATING) {
+    if (!inc_refcount_done) {
+      inc_refcount_done = true;
+      userDBs->m_ref_count++;
+    }
+    NdbCondition_Wait(userDBs->m_waitCond, userDBs->m_waitLock);
+  }
+  if (userDBs->m_state == UserDBs::IS_INVALID) {
+    if (inc_refcount_done) userDBs->m_ref_count--;
+#ifdef DEBUG_AUTH
+    int ref_count = userDBs->m_ref_count;
+#endif
+    NdbMutex_Unlock(userDBs->m_waitLock);
+    DEB_AUTH(("API Key found invalid, Line: %u, refCount: %d",
+              __LINE__, ref_count));
+    return CRS_Status(HTTP_CODE::CLIENT_ERROR,
+      "API key found in cache but invalid").status;
+  }
+  userDBs->m_lastUsed = NdbTick_getCurrentTicks();
   for (const auto &db : dbs) {
-    if (std::find(userDBs.begin(), userDBs.end(), db) == userDBs.end()) {
+    if (userDBs->userDBs.find(db) == userDBs->userDBs.end()) {
+      if (inc_refcount_done) userDBs->m_ref_count--;
+#ifdef DEBUG_AUTH
+      int ref_count = userDBs->m_ref_count;
+#endif
+      NdbMutex_Unlock(userDBs->m_waitLock);
+      allowedAccess = false;
+      DEB_AUTH(("API Key found valid, not authorized, Line: %u, refCount: %d",
+                __LINE__, ref_count));
       return CRS_Status(HTTP_CODE::CLIENT_ERROR,
-                        ("api key is unauthorized to access " + db).c_str())
-          .status;
+        ("API key not authorized to access " + db).c_str()).status;
     }
   }
-
+  // Decrement the reference count such that it can be released again
+  if (inc_refcount_done) userDBs->m_ref_count--;
+#ifdef DEBUG_AUTH
+  int ref_count = userDBs->m_ref_count;
+#endif
+  NdbMutex_Unlock(userDBs->m_waitLock);
+  allowedAccess = true;
+  DEB_AUTH(("API Key found valid, success, Line: %u, refCount: %d",
+            __LINE__, ref_count));
   return CRS_Status::SUCCESS.status;
 }
 
-RS_Status APIKeyCache::cleanup() {
-  WriteLock lock(key2UserDBsCacheLock);
-
-  // TODO Logger
-
-  // Clean up all entries
-  for (auto it = key2UserDBsCache.begin(); it != key2UserDBsCache.end(); it++) {
-    it->second->evicted = true;
-  }
-
-  key2UserDBsCache = std::unordered_map<std::string, std::shared_ptr<UserDBs>>();
-
-  return CRS_Status::SUCCESS.status;
+extern "C" void* api_key_thread_main(void *thr_arg) {
+  char *api_key_str = (char*)thr_arg;
+  std::string apiKey = api_key_str;
+  free(api_key_str);
+  apiKeyCache->cache_entry_updater(apiKey);
+  return nullptr;
 }
 
 RS_Status APIKeyCache::update_cache(const std::string &apiKey) {
-  // if the entry does not already exist in the
-  // cache then multiple clients will try to read and
-  // update the API key from the backend simultaneously.
-  // Trying to prevent multiple writers here
-
-  // Check if the key exists
-  bool shouldUpdate = false;
-  {
-    ReadLock readLock(key2UserDBsCacheLock);
-    if (key2UserDBsCache.find(apiKey) == key2UserDBsCache.end()) {
-      // The entry does not exist, mark for update
-      shouldUpdate = true;
-    } else {
-      // Increase reference count to the usdbs
-      key2UserDBsCache[apiKey]->refCount++;
+  NdbMutex_Lock(m_rwLock);
+  // Check if the key exists, might have been entered since we released lock
+  auto userDBs = m_key_cache.find(apiKey);
+  if (userDBs == m_key_cache.end()) {
+    // The entry does not exist, mark for update
+    char *api_key_str = (char*)malloc(apiKey.size() + 1);
+    if (api_key_str == nullptr) {
+      NdbMutex_Unlock(m_rwLock);
+      DEB_AUTH(("API Key malloc failed, Line: %u", __LINE__));
+      return CRS_Status(HTTP_CODE::CLIENT_ERROR,
+        "Failed to allocate API Key record in cache").status;
     }
-  }  // Mutex is automatically released here
-
-  if (shouldUpdate) {
-    // Lock again to update the cache securely
-    WriteLock lock(key2UserDBsCacheLock);
-    // Double-check pattern in case another thread has already updated the cache
-    if (key2UserDBsCache.find(apiKey) ==
-        key2UserDBsCache.end()) {  // the entry still does not exists. insert a new row
-      auto udbs             = std::shared_ptr<UserDBs>(new UserDBs());  // Copy constructor deleted
-      udbs->refreshInterval = refresh_interval_with_jitter();
-      key2UserDBsCache[apiKey] = udbs;
-      start_update_ticker(apiKey, key2UserDBsCache[apiKey]);
+    auto newUserDBs = new UserDBs();
+    if (newUserDBs == nullptr) {
+      NdbMutex_Unlock(m_rwLock);
+      free(api_key_str);
+      DEB_AUTH(("API Key create UserDBs failed, Line: %u", __LINE__));
+      return CRS_Status(HTTP_CODE::CLIENT_ERROR,
+        "Failed to allocate API Key record in cache").status;
     }
-    // Increase reference count to the usdbs
-    key2UserDBsCache[apiKey]->refCount++;
-  }
-
-  return CRS_Status::SUCCESS.status;
-}
-
-RS_Status APIKeyCache::update_record(std::vector<std::string> dbs, UserDBs *udbs) {
-  // caller holds the lock
-  if (udbs->evicted) {
+    strncpy(api_key_str, apiKey.c_str(), apiKey.size());
+    api_key_str[apiKey.size()] = 0;
+    NdbThread *thread = NdbThread_Create(api_key_thread_main,
+                                         (void**)api_key_str,
+                                          128 * 1024,
+                                          "Api Key Cache thread",
+                                          NDB_THREAD_PRIO_LOW);
+    if (thread == nullptr) {
+      delete newUserDBs;
+      free(api_key_str);
+      DEB_AUTH(("API Key thread create failed, Line: %u", __LINE__));
+      return CRS_Status(HTTP_CODE::CLIENT_ERROR,
+        "Failed to allocate API Key record in cache").status;
+    }
+    DEB_AUTH(("API Key %s inserted in cache with refCount: 1", apiKey.c_str()));
+    newUserDBs->m_refresh_interval = refresh_interval_with_jitter();
+    newUserDBs->m_ref_count = 1;
+    newUserDBs->m_state = UserDBs::IS_VALIDATING;
+    m_key_cache[apiKey] = newUserDBs;
+    DEB_AUTH_TIME(("Api key: %s, refresh interval %d",
+                   apiKey.c_str(), newUserDBs->m_refresh_interval));
+    NdbMutex_Unlock(m_rwLock);
     return CRS_Status::SUCCESS.status;
   }
+  // Increase reference count to the usdbs to avoid it being released
+  userDBs->second->m_ref_count++;
+  NdbMutex_Unlock(m_rwLock);
+  return CRS_Status::SUCCESS.status;
+}
 
+RS_Status APIKeyCache::update_record(std::vector<std::string> dbs,
+                                     UserDBs *userDBs) {
+  NDB_TICKS lastUpdated = NdbTick_getCurrentTicks();
   std::unordered_map<std::string, bool> dbsMap;
   for (const auto &db : dbs) {
+    DEB_AUTH_DBS(("Valid API Key with db: %s", db.c_str()));
     dbsMap[db] = true;
   }
-
-  udbs->userDBs     = dbsMap;
-  udbs->lastUpdated = std::chrono::system_clock::now();
-
+  userDBs->userDBs = dbsMap;
+  userDBs->m_lastUpdated = lastUpdated;
+  assert(userDBs->m_state == UserDBs::IS_VALIDATING ||
+         userDBs->m_state == UserDBs::IS_VALID);
+  userDBs->m_state = UserDBs::IS_VALID;
   return CRS_Status::SUCCESS.status;
 }
 
-std::chrono::system_clock::time_point APIKeyCache::last_used(const std::string &apiKey) {
-  ReadLock readLock(key2UserDBsCacheLock);
-  auto it = key2UserDBsCache.find(apiKey);
-  if (it == key2UserDBsCache.end()) {
-    return std::chrono::system_clock::time_point();
+void APIKeyCache::cache_entry_updater(const std::string &apiKey) {
+  NdbMutex_Lock(m_rwLock);
+  auto it = m_key_cache.find(apiKey);
+  if (it == m_key_cache.end()) {
+    NdbMutex_Unlock(m_rwLock);
+    require(false);
+    return;
   }
-  return it->second->lastUsed;
-}
-
-std::chrono::system_clock::time_point APIKeyCache::last_updated(const std::string &apiKey) {
-  ReadLock readLock(key2UserDBsCacheLock);
-  auto it = key2UserDBsCache.find(apiKey);
-  if (it == key2UserDBsCache.end()) {
-    return std::chrono::system_clock::time_point();
+  auto userDBs = it->second;
+  if (userDBs == nullptr) {
+    NdbMutex_Unlock(m_rwLock);
+    require(false);
+    return;
   }
-  return it->second->lastUpdated;
-}
-
-RS_Status APIKeyCache::start_update_ticker(const std::string &apiKey,
-                                           std::shared_ptr<UserDBs> & /*udbs*/) {
-  auto started = std::make_shared<std::atomic<bool>>(false);
-  std::thread([this, apiKey, started]() { cache_entry_updater(apiKey, started); }).detach();
-
-  while (!started->load()) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  }
-
-  return CRS_Status::SUCCESS.status;
-}
-
-RS_Status APIKeyCache::cache_entry_updater(const std::string &apiKey,
-                                           std::shared_ptr<std::atomic<bool>> started) {
-  auto it = key2UserDBsCache.find(apiKey);
-  if (it == key2UserDBsCache.end()) {
-    return CRS_Status(HTTP_CODE::CLIENT_ERROR, "API key not found in cache").status;
-  }
-
-  std::shared_ptr<UserDBs> shared_udbs = it->second;  // keeps UserDBs alive
-  UserDBs *udbs                        = shared_udbs.get();
-  if (udbs == nullptr) {
-    return CRS_Status(HTTP_CODE::SERVER_ERROR,
-                      ("Cache updater failed. Report programming error. API Key " + apiKey).c_str())
-        .status;
-  }
-
+  NdbMutex_Lock(userDBs->m_waitLock);
+  NdbMutex_Unlock(m_rwLock);
+  require(userDBs->m_state == UserDBs::IS_VALIDATING);
+  NdbMutex_Unlock(userDBs->m_waitLock);
   RS_Status status;
-
+  bool first = true;
+  (void)first;
   while (true) {
-    pthread_rwlock_wrlock(&udbs->rowLock);
-    started->store(true);
     bool fail = false;
 
     HopsworksAPIKey key;
-    if (!udbs->evicted) {
+    std::vector<std::string> dbs;
+    if (!m_evicted) {
       status = authenticate_user(apiKey, key);
       if (status.http_code != HTTP_CODE::SUCCESS) {
-        // TODO log
         fail = true;
       }
     }
 
-    if (!fail && !udbs->evicted) {
-      std::vector<std::string> dbs;
+    if (!fail && !m_evicted) {
       status = get_user_databases(key, dbs);
       if (status.http_code != HTTP_CODE::SUCCESS) {
-        // TODO log
-      }
-
-      status = update_record(dbs, udbs);
-      if (status.http_code != HTTP_CODE::SUCCESS) {
-        // TODO log
+        fail = true;
       }
     }
-
-    pthread_rwlock_unlock(&udbs->rowLock);
-
-    std::this_thread::sleep_for(udbs->refreshInterval);
-
-    if (udbs->evicted) {
-      // no need for cleanup as evicter cleans up
-      return CRS_Status::SUCCESS.status;
-    }
-
-    pthread_rwlock_rdlock(&udbs->rowLock);
-    auto lastUsed = udbs->lastUsed;
-    pthread_rwlock_unlock(&udbs->rowLock);
-
-    if (std::chrono::system_clock::now() - lastUsed >=
-        std::chrono::milliseconds(globalConfigs.security.apiKey.cacheUnusedEntriesEvictionMS)) {
-      WriteLock lock(key2UserDBsCacheLock);
-      if (udbs->refCount <= 0) {
-        udbs->evicted = true;
-        key2UserDBsCache.erase(apiKey);
-        // TODO debug logger that cache entry removed
+    /**
+     * Wake up all waiters for the API Key validation, if successful
+     * we will fill in the validated databases, otherwise it will be
+     * an empty list of databases and thus no one will be able to
+     * validate against it. The API Key is kept in the API Key Cache
+     * even if it is an incorrect one, but lastUpdated will only be
+     * updated at successful lookups in the API Key Cache.
+     */
+    NDB_TICKS lastUpdated = NdbTick_getCurrentTicks();
+    NdbMutex_Lock(userDBs->m_waitLock);
+    if (!fail && !m_evicted) {
+      if (first) {
+        userDBs->m_lastUsed = lastUpdated;
+        DEB_AUTH(("Valid API Key inserted: %s", apiKey.c_str()));
       } else {
+        DEB_AUTH(("Valid API Key updated: %s", apiKey.c_str()));
+      }
+      update_record(dbs, userDBs);
+    } else {
+      if (first) {
+        userDBs->m_lastUsed = lastUpdated;
+      }
+      DEB_AUTH(("Invalid API Key: %s", apiKey.c_str()));
+      userDBs->m_state = UserDBs::IS_INVALID;
+    }
+    first = false;
+    userDBs->m_lastUpdated = lastUpdated;
+    NdbCondition_Broadcast(userDBs->m_waitCond);
+#ifdef DEBUG_AUTH_THREAD
+    int ref_count = userDBs->m_ref_count;
+#endif
+    NdbMutex_Unlock(userDBs->m_waitLock);
+
+    /* Ensure it is easy to wake all threads up when time to close down */
+    DEB_AUTH_THREAD(("API key %s, thread sleep, refCount: %d",
+                    apiKey.c_str(), ref_count));
+    NdbMutex_Lock(m_sleepLock);
+    if (!m_evicted)
+      NdbCondition_WaitTimeout(m_sleepCond,
+                               m_sleepLock,
+                               userDBs->m_refresh_interval);
+    NdbMutex_Unlock(m_sleepLock);
+
+    while (m_evicted) {
+      DEB_AUTH_THREAD(("API key %s, thread shutdown", apiKey.c_str()));
+      /* First wait for all access to this API Key to finish */
+      NdbMutex_Lock(userDBs->m_waitLock);
+      int ref_count = userDBs->m_ref_count;
+      if (ref_count > 0) {
+        NdbMutex_Unlock(userDBs->m_waitLock);
+        DEB_AUTH_THREAD(("API key %s, refCount: %d",
+                         apiKey.c_str(), ref_count));
+        NdbSleep_MilliSleep(CLEANUP_SLEEP_TIME);
+        continue;
+      }
+      NdbMutex_Unlock(userDBs->m_waitLock);
+      /**
+       * Remove the API Key and update counter to ensure cleanup knows
+       * when done.
+       */
+      DEB_AUTH_THREAD(("API key %s, delete", apiKey.c_str()));
+      NdbMutex_Lock(m_rwLock);
+      m_key_cache.erase(apiKey);
+      NdbMutex_Unlock(m_rwLock);
+      return;
+    }
+
+    NdbMutex_Lock(userDBs->m_waitLock);
+    auto lastUsed = userDBs->m_lastUsed;
+#ifdef DEBUG_AUTH_THREAD
+    int ref_count_after = userDBs->m_ref_count;
+#endif
+    NdbMutex_Unlock(userDBs->m_waitLock);
+
+    DEB_AUTH_THREAD(("API key %s, thread wakeup, ref_count: %d",
+                     apiKey.c_str(), ref_count_after));
+    NDB_TICKS now = NdbTick_getCurrentTicks();
+    Uint64 milliSeconds = NdbTick_Elapsed(lastUsed, now).milliSec();
+    DEB_AUTH_THREAD(("API Key: %s %llu millis since last used",
+                     apiKey.c_str(), milliSeconds));
+    if (milliSeconds >=
+          (Uint64)globalConfigs.security.apiKey.cacheUnusedEntriesEvictionMS) {
+      NdbMutex_Lock(m_rwLock);
+      NdbMutex_Lock(userDBs->m_waitLock);
+      if (userDBs->m_ref_count <= 0) {
+        m_key_cache.erase(apiKey);
+        NdbMutex_Unlock(m_rwLock);
+        NdbMutex_Unlock(userDBs->m_waitLock);
+        return;
+      } else {
+        NdbMutex_Unlock(m_rwLock);
+        NdbMutex_Unlock(userDBs->m_waitLock);
         continue;
       }
       break;
     }
   }
-
-  return CRS_Status::SUCCESS.status;
+  return;
 }
 
-RS_Status APIKeyCache::find_and_validate(const std::string &apiKey, bool &keyFoundInCache,
-                                         bool &allowedAccess, const std::vector<std::string> &dbs) {
-  keyFoundInCache = false;
-  allowedAccess   = false;
-
-  pthread_rwlock_rdlock(&key2UserDBsCacheLock);
-  auto it = key2UserDBsCache.find(apiKey);
-  if (it == key2UserDBsCache.end()) {
-    pthread_rwlock_unlock(&key2UserDBsCacheLock);
-    return CRS_Status(HTTP_CODE::CLIENT_ERROR, "API key not found in cache").status;
-  }
-
-  auto userDBs = it->second;
-  if (userDBs == nullptr) {
-    pthread_rwlock_unlock(&key2UserDBsCacheLock);
-    return CRS_Status(HTTP_CODE::CLIENT_ERROR, "API key found in cache but userDBs is null").status;
-  }
-  pthread_rwlock_unlock(&key2UserDBsCacheLock);
-  ReadLock readLock(userDBs->rowLock);
-
-  // update TS
-  userDBs->lastUsed = std::chrono::system_clock::now();
-
-  keyFoundInCache = true;
-
-  for (const auto &db : dbs) {
-    if (userDBs->userDBs.find(db) == userDBs->userDBs.end()) {
-      allowedAccess = false;
-      return CRS_Status(HTTP_CODE::CLIENT_ERROR, ("API key not authorized to access " + db).c_str())
-          .status;
-    }
-  }
-  allowedAccess = true;
-
-  return CRS_Status::SUCCESS.status;
-}
-
-RS_Status APIKeyCache::find_and_validate_again(const std::string &apiKey, bool &keyFoundInCache,
-                                               bool &allowedAccess,
-                                               const std::vector<std::string> &dbs) {
-  keyFoundInCache = false;
-  allowedAccess   = false;
-
-  pthread_rwlock_rdlock(&key2UserDBsCacheLock);
-  auto it = key2UserDBsCache.find(apiKey);
-  if (it == key2UserDBsCache.end()) {
-    pthread_rwlock_unlock(&key2UserDBsCacheLock);
-    return CRS_Status(HTTP_CODE::CLIENT_ERROR, "API key not found in cache").status;
-  }
-
-  auto userDBs = it->second;
-  if (userDBs == nullptr) {
-    pthread_rwlock_unlock(&key2UserDBsCacheLock);
-    return CRS_Status(HTTP_CODE::CLIENT_ERROR, "API key found in cache but userDBs is null").status;
-  }
-  pthread_rwlock_unlock(&key2UserDBsCacheLock);
-  ReadLock readLock(userDBs->rowLock);
-
-  // update TS
-  userDBs->lastUsed = std::chrono::system_clock::now();
-
-  keyFoundInCache = true;
-
-  for (const auto &db : dbs) {
-    if (userDBs->userDBs.find(db) == userDBs->userDBs.end()) {
-      allowedAccess = false;
-      userDBs->refCount--;
-      return CRS_Status(HTTP_CODE::CLIENT_ERROR, ("API key not authorized to access " + db).c_str())
-          .status;
-    }
-  }
-
-  allowedAccess = true;
-
-  // Decrement the reference count
-  userDBs->refCount--;
-
-  return CRS_Status::SUCCESS.status;
-}
-
-RS_Status APIKeyCache::authenticate_user(const std::string &apiKey, HopsworksAPIKey &key) {
-  auto splits       = split(apiKey, '.');
-  auto prefix       = splits[0];
+RS_Status APIKeyCache::authenticate_user(const std::string &apiKey,
+                                         HopsworksAPIKey &key) {
+  auto splits = split(apiKey, '.');
+  auto prefix = splits[0];
   auto clientSecret = splits[1];
 
   RS_Status status = get_api_key(prefix, key);
@@ -408,11 +513,11 @@ RS_Status APIKeyCache::authenticate_user(const std::string &apiKey, HopsworksAPI
   if (hashed != key.secret) {
     return CRS_Status(HTTP_CODE::CLIENT_ERROR, "bad API key").status;
   }
-
   return CRS_Status::SUCCESS.status;
 }
 
-RS_Status APIKeyCache::get_user_databases(HopsworksAPIKey &key, std::vector<std::string> &dbs) {
+RS_Status APIKeyCache::get_user_databases(HopsworksAPIKey &key,
+                                          std::vector<std::string> &dbs) {
   RS_Status status = get_user_projects(key.user_id, dbs);
   if (status.http_code != HTTP_CODE::SUCCESS) {
     return status;
@@ -420,9 +525,10 @@ RS_Status APIKeyCache::get_user_databases(HopsworksAPIKey &key, std::vector<std:
   return CRS_Status::SUCCESS.status;
 }
 
-RS_Status APIKeyCache::get_user_projects(int uid, std::vector<std::string> &dbs) {
-  int count        = 0;
-  char **projects  = nullptr;
+RS_Status APIKeyCache::get_user_projects(int uid,
+                                         std::vector<std::string> &dbs) {
+  int count = 0;
+  char **projects = nullptr;
   RS_Status status = find_all_projects(uid, &projects, &count);
   if (status.http_code != HTTP_CODE::SUCCESS) {
     return status;
@@ -438,7 +544,8 @@ RS_Status APIKeyCache::get_user_projects(int uid, std::vector<std::string> &dbs)
   return CRS_Status::SUCCESS.status;
 }
 
-RS_Status APIKeyCache::get_api_key(const std::string &userKey, HopsworksAPIKey &key) {
+RS_Status APIKeyCache::get_api_key(const std::string &userKey,
+                                   HopsworksAPIKey &key) {
   RS_Status status = find_api_key(userKey.c_str(), &key);
   if (status.http_code != HTTP_CODE::SUCCESS) {
     return status;
@@ -457,58 +564,84 @@ std::vector<std::string> split(const std::string &str, char delim) {
 }
 
 RS_Status computeHash(const std::string &unhashed, std::string &hashed) {
-  RS_Status status = CRS_Status(HTTP_CODE::CLIENT_ERROR, "Failed to compute hash").status;
+  RS_Status status = CRS_Status(HTTP_CODE::CLIENT_ERROR,
+                       "Failed to compute hash").status;
 
   auto deleter = [](EVP_MD_CTX *ctx) { EVP_MD_CTX_free(ctx); };
-  std::unique_ptr<EVP_MD_CTX, decltype(deleter)> mdCtx(EVP_MD_CTX_new(), deleter);
+  std::unique_ptr<EVP_MD_CTX, decltype(deleter)>
+    mdCtx(EVP_MD_CTX_new(), deleter);
 
   if (mdCtx) {
     if (EVP_DigestInit_ex(mdCtx.get(), EVP_sha256(), nullptr) != 0) {
-      if (EVP_DigestUpdate(mdCtx.get(), unhashed.c_str(), unhashed.length()) != 0) {
+      if (EVP_DigestUpdate(mdCtx.get(),
+                           unhashed.c_str(),
+                           unhashed.length()) != 0) {
         unsigned char hash[EVP_MAX_MD_SIZE];
         unsigned int lengthOfHash = 0;
 
         if (EVP_DigestFinal_ex(mdCtx.get(), hash, &lengthOfHash) != 0) {
           std::stringstream ss;
           for (unsigned int i = 0; i < lengthOfHash; ++i) {
-            ss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(hash[i]);
+            ss << std::hex << std::setw(2)
+               << std::setfill('0') << static_cast<int>(hash[i]);
           }
-
           hashed = ss.str();
           status = CRS_Status::SUCCESS.status;
         }
       }
     }
   }
-
   return status;
 }
 
-unsigned APIKeyCache::size() {
-  ReadLock readLock(key2UserDBsCacheLock);
-  return key2UserDBsCache.size();
-}
-
-std::chrono::milliseconds APIKeyCache::refresh_interval_with_jitter() {
-  uint32_t cacheRefreshIntervalMS = globalConfigs.security.apiKey.cacheRefreshIntervalMS;
-  int jitterMS = static_cast<int>(globalConfigs.security.apiKey.cacheRefreshIntervalJitterMS);
+Int32 APIKeyCache::refresh_interval_with_jitter() {
+  Uint32 cacheRefreshIntervalMS =
+    globalConfigs.security.apiKey.cacheRefreshIntervalMS;
+  Int32 jitterMS = static_cast<int>(
+    globalConfigs.security.apiKey.cacheRefreshIntervalJitterMS);
   std::uniform_int_distribution<int32_t> dist(0, jitterMS);
-  int32_t jitter = dist(randomGenerator);
+  Int32 jitter = dist(randomGenerator);
   if (jitter % 2 == 0) {
     jitter = -jitter;
   }
-  return std::chrono::milliseconds(static_cast<int32_t>(cacheRefreshIntervalMS) + jitter);
+  return Int32(cacheRefreshIntervalMS) + jitter;
+}
+
+/* Below methods only used by unit test program */
+unsigned APIKeyCache::size() {
+  NdbMutex_Lock(m_rwLock);
+  unsigned size_cache = m_key_cache.size();
+  NdbMutex_Unlock(m_rwLock);
+  return size_cache;
 }
 
 std::string APIKeyCache::to_string() {
-  ReadLock readLock(key2UserDBsCacheLock);
+  NdbMutex_Lock(m_rwLock);
   std::stringstream ss;
-  for (const auto &entry : key2UserDBsCache) {
+  for (const auto &entry : m_key_cache) {
     ss << "API Key: " << entry.first << ", UserDBs: ";
     for (const auto &db : entry.second->userDBs) {
       ss << db.first << ", ";
     }
     ss << std::endl;
   }
+  NdbMutex_Unlock(m_rwLock);
   return ss.str();
 }
+
+Uint64 APIKeyCache::last_updated(const std::string &apiKey) {
+  NdbMutex_Lock(m_rwLock);
+  auto it = m_key_cache.find(apiKey);
+  if (it == m_key_cache.end()) {
+    NdbMutex_Unlock(m_rwLock);
+    NDB_TICKS now = NdbTick_getCurrentTicks();
+    return now.getUint64();
+  }
+  auto userDBs = it->second;
+  NdbMutex_Lock(userDBs->m_waitLock);
+  NdbMutex_Unlock(m_rwLock);
+  Uint64 lastUpdated = userDBs->m_lastUpdated.getUint64();
+  NdbMutex_Unlock(userDBs->m_waitLock);
+  return lastUpdated;
+}
+

--- a/storage/ndb/rest-server2/server/src/api_key.hpp
+++ b/storage/ndb/rest-server2/server/src/api_key.hpp
@@ -32,105 +32,101 @@
 #include <vector>
 #include <thread>
 #include <chrono>
-#include <pthread.h>
+#include <ndb_init.h>
+#include <ndb_types.h>
+#include <NdbTick.h>
+#include <NdbSleep.h>
+#include <NdbMutex.h>
+#include <NdbCondition.h>
+
+class APIKeyCache;
+APIKeyCache* start_api_key_cache();
+void stop_api_key_cache();
 
 RS_Status authenticate(const std::string &apiKey, PKReadParams &params);
+RS_Status authenticate(const std::string &apiKey,
+                       const std::vector<std::string> &);
 
 class UserDBs {
  public:
-  std::unordered_map<std::string, bool> userDBs;      // DBs
-  std::chrono::system_clock::time_point lastUsed;     // for removing unused entries
-  std::chrono::system_clock::time_point lastUpdated;  // last updated TS
-  pthread_rwlock_t rowLock{};                         // this is used to prevent concurrent updates
-  bool evicted = false;                               // is evicted or deleted
-  std::chrono::milliseconds refreshInterval;          // Cache refresh interval
-  std::atomic<int> refCount = 0;                      // Reference count
+  std::unordered_map<std::string, bool> userDBs;
+  NDB_TICKS m_lastUsed;
+  NDB_TICKS m_lastUpdated;
+  NdbMutex *m_waitLock;
+  NdbCondition *m_waitCond;
+  enum {
+    IS_VALIDATING = 0,
+    IS_INVALID = 1,
+    IS_VALID = 2
+  };
+  Uint8 m_state;
+  Int32 m_refresh_interval;
+  std::atomic<int> m_ref_count;
 
   UserDBs() {
-    pthread_rwlock_init(&rowLock, nullptr);
+    m_waitLock = NdbMutex_Create();
+    m_waitCond = NdbCondition_Create();
   }
 
   ~UserDBs() {
-    pthread_rwlock_destroy(&rowLock);
-  }
-
-  std::string to_string() {
-    std::string result = "UserDBs: ";
-    for (auto &db : userDBs) {
-      result += db.first + " ";
-    }
-    result += "LastUsed: " + std::to_string(std::chrono::system_clock::to_time_t(lastUsed));
-    result += " LastUpdated: " + std::to_string(std::chrono::system_clock::to_time_t(lastUpdated));
-    result += " Evicted: " + std::to_string(static_cast<int>(evicted));
-    result += " RefreshInterval: " + std::to_string(refreshInterval.count());
-    return result;
+    NdbMutex_Destroy(m_waitLock);
+    NdbCondition_Destroy(m_waitCond);
   }
 };
 
 class APIKeyCache {
  public:
-  std::unordered_map<std::string, std::shared_ptr<UserDBs>>
-      key2UserDBsCache;  // API Key -> User Databases
-  pthread_rwlock_t key2UserDBsCacheLock{};
-  std::mt19937 randomGenerator;
-
- public:
-  APIKeyCache() : key2UserDBsCache(), randomGenerator(std::random_device()()) {
-    pthread_rwlock_init(&key2UserDBsCacheLock, nullptr);
+  APIKeyCache() : m_key_cache(), randomGenerator(std::random_device()()) {
+    m_evicted = false;
+    m_rwLock = NdbMutex_Create();
+    m_sleepLock = NdbMutex_Create();
+    m_sleepCond = NdbCondition_Create();
   }
 
   ~APIKeyCache() {
     cleanup();
-    pthread_rwlock_destroy(&key2UserDBsCacheLock);
+    NdbMutex_Destroy(m_rwLock);
+    NdbMutex_Destroy(m_sleepLock);
+    NdbCondition_Destroy(m_sleepCond);
   }
-
-  static RS_Status validate_api_key_format(const std::string &);
 
   /*
   Checking whether the API key can access the given databases
   */
-  RS_Status validate_api_key(const std::string &, const std::vector<std::string> &);
+  RS_Status validate_api_key(const std::string &,
+                             const std::vector<std::string> &);
 
-  /*
-  Checking whether the API key can access the given databases, without caching
-  */
-  RS_Status validate_api_key_no_cache(const std::string &, const std::vector<std::string> &);
-
-  RS_Status cleanup();
-
-  RS_Status update_cache(const std::string &);
-
-  RS_Status update_record(std::vector<std::string>, UserDBs *);
-
-  std::chrono::system_clock::time_point last_used(const std::string &);
-
-  std::chrono::system_clock::time_point last_updated(const std::string &);
-
-  RS_Status start_update_ticker(const std::string &, std::shared_ptr<UserDBs> &);
-
-  RS_Status cache_entry_updater(const std::string &, std::shared_ptr<std::atomic<bool>>);
-
-  RS_Status find_and_validate(const std::string &, bool &, bool &,
-                              const std::vector<std::string> &);
-
-  RS_Status find_and_validate_again(const std::string &, bool &, bool &,
-                                    const std::vector<std::string> &);
-
-  RS_Status authenticate_user(const std::string &, HopsworksAPIKey &);
-
+  Uint64 last_updated(const std::string &);
+  std::string to_string();
   unsigned size();
 
+  void cache_entry_updater(const std::string &);
+
+ private:
+  // API Key -> User Databases
+  std::unordered_map<std::string, UserDBs*> m_key_cache;
+  std::mt19937 randomGenerator;
+
+  bool m_evicted = false;
+  NdbMutex *m_rwLock;
+  NdbMutex *m_sleepLock;
+  NdbCondition *m_sleepCond;
+
+  static RS_Status validate_api_key_format(const std::string &);
+
+  void cleanup();
+  RS_Status update_cache(const std::string &);
+  RS_Status update_record(std::vector<std::string>, UserDBs *);
+  RS_Status find_and_validate(const std::string &,
+                              bool &,
+                              bool &,
+                              const std::vector<std::string> &,
+                              bool);
+
+  RS_Status authenticate_user(const std::string &, HopsworksAPIKey &);
   RS_Status get_user_databases(HopsworksAPIKey &, std::vector<std::string> &);
-
   RS_Status get_user_projects(int, std::vector<std::string> &);
-
   RS_Status get_api_key(const std::string &, HopsworksAPIKey &);
-
-  std::chrono::milliseconds refresh_interval_with_jitter();
-
-  std::string to_string();
+  Int32 refresh_interval_with_jitter();
 };
-
-extern std::shared_ptr<APIKeyCache> apiKeyCache;
-
 #endif  // STORAGE_NDB_REST_SERVER2_SERVER_SRC_API_KEY_HPP_

--- a/storage/ndb/rest-server2/server/src/batch_feature_store_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/batch_feature_store_ctrl.cpp
@@ -120,7 +120,7 @@ void BatchFeatureStoreCtrl::batch_featureStore(
       return;
     }
     // Validate access right to ALL feature stores including shared feature
-    auto status = apiKeyCache->validate_api_key(api_key, metadata->featureStoreNames);
+    auto status = authenticate(api_key, metadata->featureStoreNames);
     if (static_cast<drogon::HttpStatusCode>(status.http_code) != drogon::HttpStatusCode::k200OK) {
       resp->setBody(std::string(status.message));
       resp->setStatusCode(drogon::HttpStatusCode::k401Unauthorized);

--- a/storage/ndb/rest-server2/server/src/batch_feature_store_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/batch_feature_store_ctrl.cpp
@@ -37,7 +37,6 @@
 #include <vector>
 
 metadata::FeatureViewMetaDataCache batch_fvMetaCache;
-APIKeyCache batch_featureStore_apiKeyCache;
 
 void BatchFeatureStoreCtrl::batch_featureStore(
     const drogon::HttpRequestPtr &req,

--- a/storage/ndb/rest-server2/server/src/batch_feature_store_ctrl.hpp
+++ b/storage/ndb/rest-server2/server/src/batch_feature_store_ctrl.hpp
@@ -43,7 +43,6 @@ class BatchFeatureStoreCtrl : public drogon::HttpController<BatchFeatureStoreCtr
 };
 
 extern metadata::FeatureViewMetaDataCache batch_fvMetaCache;
-extern APIKeyCache batch_featureStore_apiKeyCache;
 
 unsigned checkFeatureStatus(const feature_store_data_structs::BatchFeatureStoreRequest &fsReq,
                             const metadata::FeatureViewMetadata &metadata,

--- a/storage/ndb/rest-server2/server/src/feature_store_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/feature_store_ctrl.cpp
@@ -533,7 +533,7 @@ void FeatureStoreCtrl::featureStore(
       return;
     }
     // Validate access right to ALL feature stores including shared feature
-    auto status = apiKeyCache->validate_api_key(api_key, metadata->featureStoreNames);
+    auto status = authenticate(api_key, metadata->featureStoreNames);
     if (static_cast<drogon::HttpStatusCode>(status.http_code) != drogon::HttpStatusCode::k200OK) {
       resp->setBody(std::string(status.message));
       resp->setStatusCode(drogon::HttpStatusCode::k401Unauthorized);

--- a/storage/ndb/rest-server2/server/src/json_parser.cpp
+++ b/storage/ndb/rest-server2/server/src/json_parser.cpp
@@ -52,8 +52,10 @@ public:
 // They are declared static (local to this compilation unit) in order to let the
 // compiler prune unused ones more easily.
 #define DEFINE_PARSER(TargetDatatype, ValueDatatype, ...) \
-  static inline bool parse(TargetDatatype& target, ValueDatatype& value) __VA_ARGS__ \
-  static inline bool parse(TargetDatatype& target, ValueDatatype&& value) __VA_ARGS__
+  [[maybe_unused]] static inline bool parse(TargetDatatype& target, \
+                                            ValueDatatype& value) __VA_ARGS__ \
+  [[maybe_unused]] static inline bool parse(TargetDatatype& target, \
+                                            ValueDatatype&& value) __VA_ARGS__
 
 // Usually, the value will be a simdjson value.
 #define DEFINE_VALUE_PARSER(Datatype, ...) \

--- a/storage/ndb/rest-server2/server/src/rdrs_dal.cpp
+++ b/storage/ndb/rest-server2/server/src/rdrs_dal.cpp
@@ -176,21 +176,21 @@ RS_Status pk_batch_read(unsigned int no_req, RS_Buffer *req_buffs, RS_Buffer *re
 
 //--------------------------------------------------------------------------------------------------
 
-RS_Status ronsql_dal(const char* database, RonSQLExecParams& ep) {
+RS_Status ronsql_dal(const char* database, RonSQLExecParams* ep) {
   Ndb *ndb_object  = nullptr;
   RS_Status status = rdrsRonDBConnectionPool->GetNdbObject(&ndb_object);
   if (status.http_code != SUCCESS) {
     return status;
   }
 
-  assert(ep.ndb == NULL);
+  assert(ep->ndb == NULL);
   assert(ndb_object != NULL);
-  ep.ndb = ndb_object;
+  ep->ndb = ndb_object;
   const char* saved_database_name = ndb_object->getDatabaseName();
   ndb_object->setDatabaseName(database);
-  status = ronsql_op(ep);
+  status = ronsql_op(*ep);
   ndb_object->setDatabaseName(saved_database_name);
-  ep.ndb = NULL;
+  ep->ndb = NULL;
 
   rdrsRonDBConnectionPool->ReturnNdbObject(ndb_object, &status);
   return status;

--- a/storage/ndb/rest-server2/server/src/rdrs_dal.h
+++ b/storage/ndb/rest-server2/server/src/rdrs_dal.h
@@ -148,7 +148,7 @@ struct RonSQLExecParams; /*
                              * "storage/ndb/src/ronsql/RonSQLCommon.hpp" but we
                              * can't include a .hpp file here.
                              */
-RS_Status ronsql_dal(const char* database, RonSQLExecParams& ep);
+RS_Status ronsql_dal(const char* database, struct RonSQLExecParams*);
 
 /**
  * Returns statistis about RonDB connection

--- a/storage/ndb/rest-server2/server/src/rdrs_rondb_connection_pool.cpp
+++ b/storage/ndb/rest-server2/server/src/rdrs_rondb_connection_pool.cpp
@@ -34,7 +34,6 @@ RDRSRonDBConnectionPool::~RDRSRonDBConnectionPool() {
   dataConnection     = nullptr;
   metadataConnection = nullptr;
   is_shutdown        = true;
-  ndb_end(1);  // sometimes causes seg faults when called repeatedly from unit tests
 }
 
 RS_Status RDRSRonDBConnectionPool::Check() {
@@ -45,11 +44,6 @@ RS_Status RDRSRonDBConnectionPool::Check() {
 }
 
 RS_Status RDRSRonDBConnectionPool::Init() {
-  int retCode = 0;
-  retCode     = ndb_init();
-  if (retCode != 0) {
-    return RS_SERVER_ERROR(ERROR_001 + std::string(" RetCode: ") + std::to_string(retCode));
-  }
   return RS_OK;
 }
 

--- a/storage/ndb/rest-server2/server/src/ronsql_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/ronsql_ctrl.cpp
@@ -103,7 +103,7 @@ void RonSQLCtrl::ronsql(const drogon::HttpRequestPtr &req,
     }
   }
 
-  status = ronsql_dal(database.c_str(), params);
+  status = ronsql_dal(database.c_str(), &params);
 
   if (json_output) {
     out_stream << "}\n";

--- a/storage/ndb/rest-server2/server/test/CMakeLists.txt
+++ b/storage/ndb/rest-server2/server/test/CMakeLists.txt
@@ -51,37 +51,28 @@ INCLUDE_DIRECTORIES(${RDRS_SIMDJSON_INCLUDE_DIR})
 INCLUDE_DIRECTORIES(${AVROCPP_INCLUDE_DIR})
 LINK_DIRECTORIES(${RDRS_DROGON_LIB_DIR})
 
-add_executable(
-	api_key_test
-	api_key_test.cpp
-)
+NDB_ADD_EXECUTABLE(api_key_test api_key_test.cpp
+                   STATIC_NDBCLIENT)
 
-add_executable(
+NDB_ADD_EXECUTABLE(
   feature_store_test
   feature_store_test.cpp
+  STATIC_NDBCLIENT
 )
 
-target_link_libraries(
+TARGET_LINK_LIBRARIES(
 	api_key_test
 	gtest_main
+        ndbgeneral
 	rdrs2_lib
 	${GTEST_LIBRARIES}
-	Drogon::Drogon
-	simdjson::simdjson
-	Jsoncpp_lib
-	pthread
-        ndbgeneral
 )
 
-target_link_libraries(
+TARGET_LINK_LIBRARIES(
   feature_store_test
   gtest_main
-  ${AVROCPP_LIBRARIES}
   rdrs2_lib
   ${GTEST_LIBRARIES}
-  Drogon::Drogon
-  simdjson::simdjson
-  Jsoncpp_lib
   pthread
 )
 

--- a/storage/ndb/rest-server2/server/test_go/Makefile
+++ b/storage/ndb/rest-server2/server/test_go/Makefile
@@ -25,7 +25,7 @@ SERVER_BIN="rdrs2"
 OUTPUT_DIR?=./bin/server/${SERVER_BIN}
 
 # RonDB build dir that contains libs needed for the API serer
-RDRS_LIB_DIR?=$(PWD)/../../../../../build/library_output_directory
+RDRS_LIB_DIR?=$(PWD)/../../../../../debug_build/library_output_directory
 
 # Configuration to use for testing
 # testing using mtr: $(PWD)/resources/config/config_mtr.json

--- a/storage/ndb/src/common/util/ndb_init.cpp
+++ b/storage/ndb/src/common/util/ndb_init.cpp
@@ -86,7 +86,9 @@ void ndb_init_internal(Uint32 caller) {
   if (init_all) NdbMutex_SysInit();
   if (caller != THREAD_REGISTER_USER) {
     if (!g_ndb_connection_mutex) g_ndb_connection_mutex = NdbMutex_Create();
-    if (!g_eventLogger) g_eventLogger = create_event_logger();
+    if (!g_eventLogger) {
+      g_eventLogger = create_event_logger();
+    }
     if ((g_ndb_connection_mutex == nullptr) || (g_eventLogger == nullptr)) {
       {
         const char *err = "ndb_init() failed - exit\n";


### PR DESCRIPTION
Major rewrite of API Key cache to have enough protection and still have a fairly high throughput.

Fixed usage of ndb_init and ndb_end, should be at beginning of main function and at end of the same. Meant removing it from init_rondb_connection and shutdown_rondb_connection.

Fixed compile issue with json_parser.cpp

Fixed API Key unit test program to properly initialise API Key cache before each test case.

Added lots of debugging for finding issues now and in the future.

Aligned build process with how RonDB programs are built.

Fixed minor issue in ronsql_dal in rdrs_dal.h.

Rewrote API Key and its test cases to use RonDB portability layer where appropriate.