### PR TITLE
RONDB: 717, RONDB-718: Ensure API Key for ping and health only requir…

### DIFF
--- a/storage/ndb/rest-server2/server/src/config_structs_def.hpp
+++ b/storage/ndb/rest-server2/server/src/config_structs_def.hpp
@@ -71,6 +71,8 @@ CLASS
  CM(std::string, serverIP,   ServerIP,   "0.0.0.0")
  CM(Uint16,    serverPort, ServerPort, 5406)
  CM(unsigned,    numThreads, NumThreads, 16)
+ CM(bool,        healthRequiresAPIKey, HealthRequiresAPIKey, false)
+ CM(bool,        pingRequiresAPIKey, PingRequiresAPIKey, false)
  PROBLEM(!enable, "REST must be enabled")
  PROBLEM(serverIP.empty(), "REST server IP cannot be empty")
  PROBLEM(serverPort == 0, "REST server port cannot be zero")

--- a/storage/ndb/rest-server2/server/src/health_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/health_ctrl.cpp
@@ -66,7 +66,8 @@ void HealthCtrl::health(
     return;
   }
   // Authenticate
-  if (likely(globalConfigs.security.apiKey.useHopsworksAPIKeys)) {
+  if (globalConfigs.security.apiKey.useHopsworksAPIKeys &&
+      globalConfigs.rest.healthRequiresAPIKey) {
     auto api_key = req->getHeader(API_KEY_NAME_LOWER_CASE);
     auto status = authenticate_empty(api_key);
     if (unlikely(static_cast<drogon::HttpStatusCode>(status.http_code) !=

--- a/storage/ndb/rest-server2/server/src/ping_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/ping_ctrl.cpp
@@ -63,7 +63,8 @@ void PingCtrl::ping(const drogon::HttpRequestPtr &req,
     return;
   }
   // Authenticate
-  if (likely(globalConfigs.security.apiKey.useHopsworksAPIKeys)) {
+  if (globalConfigs.security.apiKey.useHopsworksAPIKeys &&
+      globalConfigs.rest.pingRequiresAPIKey) {
     auto api_key = req->getHeader(API_KEY_NAME_LOWER_CASE);
     auto status = authenticate_empty(api_key);
     if (unlikely(static_cast<drogon::HttpStatusCode>(status.http_code) !=


### PR DESCRIPTION
…ed when API keys in general are required plus a config variable enabling ping and stat to use a configuration variable