### PR TITLE
RONDB-753 Feature TTL [Part 1]

### DIFF
--- a/include/my_base.h
+++ b/include/my_base.h
@@ -421,7 +421,13 @@ enum ha_extra_function {
   */
   HA_EXTRA_ENABLE_UNIQUE_RECORD_FILTER,
   /* Disable and free unique record filter. */
-  HA_EXTRA_DISABLE_UNIQUE_RECORD_FILTER
+  HA_EXTRA_DISABLE_UNIQUE_RECORD_FILTER,
+  /*
+   * Zart
+   * TTL
+   */
+  HA_EXTRA_IGNORE_TTL,
+  HA_EXTRA_NO_IGNORE_TTL,
 };
 
 /* Compatible option, to be deleted in 6.0 */

--- a/mysql-test/ttl_test.py
+++ b/mysql-test/ttl_test.py
@@ -1,0 +1,3258 @@
+import threading
+import pymysql
+import time
+import subprocess
+
+BIN_DIR="/home/zhao/workspace/kernelmaker/rondb-bin/bin"
+
+MYSQLD_PORT_P=3306
+DATA_DIR_P_1="/home/zhao/workspace/rondb-run/ndbmtd_1"
+DATA_DIR_P_2="/home/zhao/workspace/rondb-run/ndbmtd_2"
+
+MGMD_PORT_R=1188
+MYSQLD_PORT_R=3308
+
+def case_1_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(5)
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 100, "ASSERT"
+            #print(f"ThdA: [{col_a}, {col_b.strftime('%Y-%m-%d %H:%M:%S')}, {col_c}]")
+        time.sleep(6)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_1_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200)")
+        assert False, "ASSERT"
+    except pymysql.err.IntegrityError as e:
+        assert e.args[0] == 1062, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+
+    try:
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 100, "ASSERT"
+        time.sleep(6)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_2_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(4)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_2_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(5)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_3_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(13)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_3_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_4_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(5)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(7)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_4_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(8)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_5_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(10)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_5_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(6)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_6_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(13)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_6_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_7_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(5)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 201, "ASSERT"
+        time.sleep(7)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_7_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200) ON DUPLICATE KEY UPDATE col_c = 201, col_b = NOW()")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 201, "ASSERT"
+        time.sleep(8)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+
+    cur.close()
+    B_succ = True
+
+
+def case_8_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(4)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_8_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200) ON DUPLICATE KEY UPDATE col_c = 201, col_b = NOW()")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(5)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_9_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(13)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_9_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200) ON DUPLICATE KEY UPDATE col_c = 201, col_b = NOW()")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_10_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(5)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(7)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_10_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200) ON DUPLICATE KEY UPDATE col_c = 201, col_b = NOW()")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(8)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_11_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(4)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_11_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200) ON DUPLICATE KEY UPDATE col_c = 201, col_b = NOW()")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(5)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_12_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(14)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_12_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200) ON DUPLICATE KEY UPDATE col_c = 201, col_b = NOW()")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_13_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(5)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(5)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_13_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("UPDATE sz SET col_c = 200 WHERE col_a = 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 1 and matched_rows == 1, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(6)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_14_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_14_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("UPDATE sz SET col_c = 200 WHERE col_a = 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_15_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(13)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_15_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("UPDATE sz SET col_c = 200 WHERE col_a = 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_16_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(5)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_16_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("UPDATE sz SET col_c = 200 WHERE col_a = 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("COMMIT")
+        time.sleep(6)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_17_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_17_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("UPDATE sz SET col_c = 200 WHERE col_a = 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_18_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(13)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_18_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("UPDATE sz SET col_c = 200 WHERE col_a = 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_19_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(5)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_19_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_a = 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 1 and matched_rows == 1, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_20_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_20_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_a = 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_21_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(5)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_21_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_a = 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_22_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("ROLLBACK")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_22_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_a = 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_23_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(5)
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        time.sleep(6)
+        cur.execute("SET DEBUG_SYNC = 'now SIGNAL go_ahead'");
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_23_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("SET DEBUG_SYNC = 'zhao_wait_for_row_get_expired_after_reading_4 WAIT_FOR go_ahead'");
+        cur.execute("DELETE FROM sz")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        #print(f"c: {changed_rows}, m: {matched_rows}")
+        assert changed_rows == 1 and matched_rows == 1, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_24_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(7)
+        cur.execute("COMMIT")
+        time.sleep(4)
+        cur.execute("SET DEBUG_SYNC = 'now SIGNAL go_ahead'");
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT1"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 201, "ASSERT2"
+        cur.execute("SELECT * FROM sz")
+        time.sleep(4)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT3"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_24_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("SET DEBUG_SYNC = 'zhao_wait_for_row_get_expired_after_reading_1 WAIT_FOR go_ahead'");
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200) ON DUPLICATE KEY UPDATE col_c = 201, col_b = NOW()")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 2 and matched_rows == 2, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT1"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 201, "ASSERT2"
+        time.sleep(5)
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT3"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+
+    cur.close()
+    B_succ = True
+
+
+def case_25_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(7)
+        cur.execute("COMMIT")
+        time.sleep(4)
+        cur.execute("SET DEBUG_SYNC = 'now SIGNAL go_ahead'");
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT1"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 201, "ASSERT2"
+        cur.execute("SELECT * FROM sz")
+        time.sleep(3)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_25_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("SET DEBUG_SYNC = 'zhao_wait_for_row_get_expired_after_reading_2 WAIT_FOR go_ahead'");
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200) ON DUPLICATE KEY UPDATE col_c = 201, col_b = NOW()")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 2 and matched_rows == 2, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT1"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 201, "ASSERT2"
+        time.sleep(5)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+
+    cur.close()
+    B_succ = True
+
+def case_26_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 101)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 102)")
+        cur.execute("INSERT INTO sz VALUES(3, SYSDATE(), 103)")
+        cur.execute("INSERT INTO sz VALUES(4, SYSDATE(), 104)")
+        cur.execute("INSERT INTO sz VALUES(5, SYSDATE(), 105)")
+        cur.execute("INSERT INTO sz VALUES(6, SYSDATE(), 106)")
+        cur.execute("COMMIT")
+
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            #assert col_a == 1 and col_c == 201, "ASSERT2"
+            print(f"[{col_a}, {col_b}, {col_c}]")
+        print(f"---")
+        cur.execute("SELECT * FROM sz WHERE col_a > 2")
+        results = cur.fetchall()
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            #assert col_a == 1 and col_c == 201, "ASSERT2"
+            print(f"[{col_a}, {col_b}, {col_c}]")
+        print(f"---")
+        cur.execute("SELECT * FROM sz WHERE col_c > 102")
+        results = cur.fetchall()
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            #assert col_a == 1 and col_c == 201, "ASSERT2"
+            print(f"[{col_a}, {col_b}, {col_c}]")
+        print(f"---")
+        cur.execute("SELECT * FROM sz WHERE col_a > 2 and col_c <= 105")
+        results = cur.fetchall()
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            #assert col_a == 1 and col_c == 201, "ASSERT2"
+            print(f"[{col_a}, {col_b}, {col_c}]")
+        print(f"---")
+        cur.execute("SELECT * FROM sz WHERE col_a > 2 and col_c <= 105 ORDER BY col_a")
+        results = cur.fetchall()
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            #assert col_a == 1 and col_c == 201, "ASSERT2"
+            print(f"[{col_a}, {col_b}, {col_c}]")
+        print(f"---")
+        cur.execute("SELECT * FROM sz WHERE col_a > 2 and col_c <= 105 ORDER BY col_c")
+        # cur.execute("SELECT * FROM sz WHERE col_a >= 3")
+        # cur.execute("SELECT * FROM sz WHERE col_a >= 3 and col_a <= 5")
+        # cur.execute("SELECT * FROM sz WHERE col_a >= 3 and col_c >= 104")
+        # cur.execute("UPDATE sz SET col_c = 666 WHERE col_a >= 3 and col_c >= 104")
+        # cur.execute("SET DEBUG_SYNC = 'zhao_wait_for_row_get_expired_after_reading_3 WAIT_FOR go_ahead'");
+        # cur.execute("UPDATE sz SET col_c = 666 WHERE col_a <= 1")
+        results = cur.fetchall()
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            #assert col_a == 1 and col_c == 201, "ASSERT2"
+            print(f"[{col_a}, {col_b}, {col_c}]")
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_26_thdB(conn):
+    global B_succ
+    try:
+        cur = conn.cursor()
+        #time.sleep(12)
+        #cur.execute("SET DEBUG_SYNC = 'now SIGNAL go_ahead'");
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+
+    cur.close()
+    B_succ = True
+
+
+def case_27_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 101)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 102)")
+        cur.execute("INSERT INTO sz VALUES(3, SYSDATE(), 103)")
+        cur.execute("INSERT INTO sz VALUES(4, SYSDATE(), 104)")
+        cur.execute("INSERT INTO sz VALUES(5, SYSDATE(), 105)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        time.sleep(11)
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = ON")
+        cur.execute("DELETE FROM sz")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 5 and matched_rows == 5, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = OFF")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 101)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 102)")
+        cur.execute("INSERT INTO sz VALUES(3, SYSDATE(), 103)")
+        cur.execute("INSERT INTO sz VALUES(4, SYSDATE(), 104)")
+        cur.execute("INSERT INTO sz VALUES(5, SYSDATE(), 105)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        time.sleep(11)
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_a > 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = ON")
+        cur.execute("DELETE FROM sz WHERE col_a > 1")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 4 and matched_rows == 4, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = OFF")
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 101)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 102)")
+        cur.execute("INSERT INTO sz VALUES(3, SYSDATE(), 103)")
+        cur.execute("INSERT INTO sz VALUES(4, SYSDATE(), 104)")
+        cur.execute("INSERT INTO sz VALUES(5, SYSDATE(), 105)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        time.sleep(11)
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_a > 1 and col_c < 104")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = ON")
+        cur.execute("DELETE FROM sz WHERE col_a > 1 and col_c < 104")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 2 and matched_rows == 2, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = OFF")
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 101)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 102)")
+        cur.execute("INSERT INTO sz VALUES(3, SYSDATE(), 103)")
+        cur.execute("INSERT INTO sz VALUES(4, SYSDATE(), 104)")
+        cur.execute("INSERT INTO sz VALUES(5, SYSDATE(), 105)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        time.sleep(11)
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_a > 1 or col_c < 104")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = ON")
+        cur.execute("DELETE FROM sz WHERE col_a > 1 or col_c < 104")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 5 and matched_rows == 5, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = OFF")
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 101)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 102)")
+        cur.execute("INSERT INTO sz VALUES(3, SYSDATE(), 103)")
+        cur.execute("INSERT INTO sz VALUES(4, SYSDATE(), 104)")
+        cur.execute("INSERT INTO sz VALUES(5, SYSDATE(), 105)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        time.sleep(11)
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_c > 101 and col_c < 104")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = ON")
+        cur.execute("DELETE FROM sz WHERE col_c > 101 and col_c < 104")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 2 and matched_rows == 2, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = OFF")
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 101)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 102)")
+        cur.execute("INSERT INTO sz VALUES(3, SYSDATE(), 103)")
+        cur.execute("INSERT INTO sz VALUES(4, SYSDATE(), 104)")
+        cur.execute("INSERT INTO sz VALUES(5, SYSDATE(), 105)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        time.sleep(11)
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_c > 101 or col_c < 104")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = ON")
+        cur.execute("DELETE FROM sz WHERE col_c > 101 or col_c < 104")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 5 and matched_rows == 5, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = OFF")
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 101)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 102)")
+        cur.execute("INSERT INTO sz VALUES(3, SYSDATE(), 103)")
+        cur.execute("INSERT INTO sz VALUES(4, SYSDATE(), 104)")
+        cur.execute("INSERT INTO sz VALUES(5, SYSDATE(), 105)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        time.sleep(11)
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_c = 103")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = ON")
+        cur.execute("DELETE FROM sz WHERE col_c = 103")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 1 and matched_rows == 1, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = OFF")
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 101)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 102)")
+        cur.execute("INSERT INTO sz VALUES(3, SYSDATE(), 103)")
+        cur.execute("INSERT INTO sz VALUES(4, SYSDATE(), 104)")
+        cur.execute("INSERT INTO sz VALUES(5, SYSDATE(), 105)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        time.sleep(11)
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_a = 4")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = ON")
+        cur.execute("DELETE FROM sz WHERE col_a = 4")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 1 and matched_rows == 1, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = OFF")
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 101)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 102)")
+        cur.execute("INSERT INTO sz VALUES(3, SYSDATE(), 103)")
+        cur.execute("INSERT INTO sz VALUES(4, SYSDATE(), 104)")
+        cur.execute("INSERT INTO sz VALUES(5, SYSDATE(), 105)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        time.sleep(11)
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_c <= 105 LIMIT 2")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 0 and matched_rows == 0, "ASSERT"
+        cur.execute("SET ttl_expired_rows_visiable_in_delete = ON")
+        cur.execute("DELETE FROM sz WHERE col_c <= 105 LIMIT 2")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 2 and matched_rows == 2, "ASSERT"
+        cur.execute("DELETE FROM sz WHERE col_c <= 105 LIMIT 2")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 2 and matched_rows == 2, "ASSERT"
+        cur.execute("DELETE FROM sz WHERE col_c <= 105 LIMIT 2")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 1 and matched_rows == 1, "ASSERT"
+        cur.execute("COMMIT")
+
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_27_thdB(conn):
+    global B_succ
+    try:
+        cur = conn.cursor()
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_28_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, sysdate(), 1), (2, sysdate(), 2), (3, sysdate(), 3), (4, sysdate(), 4), (5, sysdate(), 5), (6, sysdate(), 6), (7, sysdate(), 7), (8, sysdate(), 8), (9, sysdate(), 9), (10, sysdate(), 10)")
+        cur.execute("COMMIT")
+        time.sleep(2)
+        cur.execute("BEGIN")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 10, "ASSERT"
+        cur.execute("SELECT * FROM sz where col_a = 6")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        cur.execute("SELECT * FROM sz where col_a >= 6")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        cur.execute("SELECT * FROM sz where col_c = 8")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        cur.execute("SELECT * FROM sz where col_c <= 8")
+        results = cur.fetchall()
+        assert len(results) == 8, "ASSERT"
+        time.sleep(9)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, sysdate(), 1), (2, sysdate(), 2), (3, sysdate(), 3), (4, sysdate(), 4), (5, sysdate(), 5), (6, sysdate(), 6), (7, sysdate(), 7), (8, sysdate(), 8), (9, sysdate(), 9), (10, sysdate(), 10)")
+        cur.execute("COMMIT")
+        time.sleep(2)
+
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_28_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(15)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("SELECT * FROM sz WHERE col_a <= 5 FOR SHARE")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        time.sleep(6)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_a = 3")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_a = 8")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_a >= 3")
+        results = cur.fetchall()
+        assert len(results) == 3, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_a <= 9")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+
+        cur.execute("SELECT * FROM sz WHERE col_c = 3")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_c = 8")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_c >= 3")
+        results = cur.fetchall()
+        assert len(results) == 3, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_c <= 9")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("BEGIN")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_a = 3")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_a = 8")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_a >= 3")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_a <= 9")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+
+        cur.execute("SELECT * FROM sz WHERE col_c = 3")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_c = 8")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_c >= 3")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz WHERE col_c <= 9")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("COMMIT")
+
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        time.sleep(2)
+        cur.close()
+        return
+
+    cur.close()
+    B_succ = True
+
+
+def case_29_pre(A_conn, B_conn):
+    try:
+        cur = A_conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS sz1")
+        cur.execute("CREATE TABLE test.sz1 ("
+                    "col_a INT, "
+                    "col_b DATETIME, "
+                    "col_c INT, "
+                    "PRIMARY KEY(col_a)) "
+                    "ENGINE = NDB, "
+                    "COMMENT=\"NDB_TABLE=FULLY_REPLICATED=1,TTL=10@col_b\"")
+    except Exception as e:
+        print(f"PRE Create DB/TABLE failed: {e}")
+        A_conn.close()
+        B_conn.close()
+        exit (-1)
+
+def case_29_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz1 VALUES(1, sysdate(), 1), (2, sysdate(), 2), (3, sysdate(), 3), (4, sysdate(), 4), (5, sysdate(), 5), (6, sysdate(), 6), (7, sysdate(), 7), (8, sysdate(), 8), (9, sysdate(), 9), (10, sysdate(), 10)")
+        cur.execute("COMMIT")
+        time.sleep(2)
+        cur.execute("BEGIN")
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 10, "ASSERT"
+        cur.execute("SELECT * FROM sz1 where col_a = 6")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        cur.execute("SELECT * FROM sz1 where col_a >= 6")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        cur.execute("SELECT * FROM sz1 where col_c = 8")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        cur.execute("SELECT * FROM sz1 where col_c <= 8")
+        results = cur.fetchall()
+        assert len(results) == 8, "ASSERT"
+        time.sleep(9)
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz1 VALUES(1, sysdate(), 1), (2, sysdate(), 2), (3, sysdate(), 3), (4, sysdate(), 4), (5, sysdate(), 5), (6, sysdate(), 6), (7, sysdate(), 7), (8, sysdate(), 8), (9, sysdate(), 9), (10, sysdate(), 10)")
+        cur.execute("COMMIT")
+        time.sleep(2)
+
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_29_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(15)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("SELECT * FROM sz1 WHERE col_a <= 5 FOR SHARE")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        time.sleep(7)
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_a = 3")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_a = 8")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_a >= 3")
+        results = cur.fetchall()
+        assert len(results) == 3, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_a <= 9")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+
+        cur.execute("SELECT * FROM sz1 WHERE col_c = 3")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_c = 8")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_c >= 3")
+        results = cur.fetchall()
+        assert len(results) == 3, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_c <= 9")
+        results = cur.fetchall()
+        assert len(results) == 5, "ASSERT"
+        cur.execute("COMMIT")
+
+        cur.execute("BEGIN")
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_a = 3")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_a = 8")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_a >= 3")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_a <= 9")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+
+        cur.execute("SELECT * FROM sz1 WHERE col_c = 3")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_c = 8")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_c >= 3")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("SELECT * FROM sz1 WHERE col_c <= 9")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("DROP TABLE sz1")
+
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        time.sleep(2)
+        cur.close()
+        return
+
+    cur.close()
+    B_succ = True
+
+def case_29_post(A_conn, B_conn):
+    try:
+        cur = A_conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS sz1")
+    except Exception as e:
+        print(f"POST Drop DB/TABLE failed: {e}")
+        A_conn.close()
+        B_conn.close()
+        exit (-1)
+
+
+def case_45_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, sysdate(), 1), (2, sysdate(), 2), (3, sysdate(), 3), (4, sysdate(), 4), (5, sysdate(), 5), (6, sysdate(), 6), (7, sysdate(), 7), (8, sysdate(), 8), (9, sysdate(), 9), (10, sysdate(), 10)")
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz WHERE col_c >= 7 FOR UPDATE")
+        results = cur.fetchall()
+        assert len(results) == 4, "ASSERT1"
+        cur.execute("UPDATE sz SET col_c = 100  WHERE col_c <= 3")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 3 and matched_rows == 3, "ASSERT2"
+        cur.execute("SELECT * FROM sz WHERE col_a <= 3 FOR SHARE")
+        results = cur.fetchall()
+        assert len(results) == 3, "ASSERT3"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 100, "ASSERT4"
+        cur.execute("DELETE FROM sz WHERE col_c >= 20")
+        changed_rows = conn.affected_rows()
+        matched_rows = cur.rowcount
+        assert changed_rows == 3 and matched_rows == 3, "ASSERT5"
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 7, "ASSERT6"
+        cur.execute("COMMIT")
+
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT7"
+
+
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_45_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("SELECT * FROM sz FOR SHARE")
+        #cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        time.sleep(5)
+        cur.execute("SELECT * FROM sz FOR UPDATE")
+        #cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        time.sleep(5)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        time.sleep(2)
+        cur.close()
+        return
+
+    cur.close()
+    B_succ = True
+
+
+def case_30_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(5)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(7)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_30_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("REPLACE INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(8)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+
+    cur.close()
+    B_succ = True
+
+
+def case_31_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(4)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_31_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("REPLACE INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(5)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_32_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(13)
+        cur.execute("COMMIT")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_32_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("REPLACE INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_33_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(5)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(7)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_33_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("REPLACE INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(8)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_34_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(4)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_34_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("REPLACE INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            col_b = row[1]
+            col_c = row[2]
+            assert col_a == 1 and col_c == 200, "ASSERT"
+        time.sleep(5)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_35_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(14)
+        cur.execute("ROLLBACK")
+        time.sleep(1)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_35_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(2)
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("REPLACE INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_36_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_36_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_a = row[0]
+            assert col_a == 1, "ASSERT"
+        time.sleep(6)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        assert check_rep(conn) == True, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_37_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_37_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        time.sleep(6)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        assert check_rep(conn) == True, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_38_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        time.sleep(2)
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        time.sleep(11)
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 300)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 300, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_38_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        time.sleep(6)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        assert check_rep(conn) == True, "ASSERT"
+
+        time.sleep(4)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 200, "ASSERT"
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 300, "ASSERT"
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        assert check_rep(conn) == True, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_39_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100) ON DUPLICATE KEY UPDATE col_c = 101")
+        time.sleep(3)
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 200) ON DUPLICATE KEY UPDATE col_c = 201")
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        time.sleep(2)
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 300) ON DUPLICATE KEY UPDATE col_c = 301")
+        cur.execute("COMMIT")
+        time.sleep(4)
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 400) ON DUPLICATE KEY UPDATE col_c = 401")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 401, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_39_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(4)
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT1"
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT2"
+        assert check_rep(conn) == True, "ASSERT3"
+
+        time.sleep(4)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT4"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 300, "ASSERT5"
+        time.sleep(5)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT6"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 401, "ASSERT7"
+        time.sleep(4)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT8"
+        assert check_rep(conn) == True, "ASSERT9"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_40_pre(A_conn, B_conn):
+    try:
+        cur = A_conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS sz1")
+        cur.execute("CREATE TABLE test.sz1 ("
+                    "col_a INT, "
+                    "col_b DATETIME, "
+                    "col_c INT)"
+                    "ENGINE = NDB, "
+                    "COMMENT=\"NDB_TABLE=FULLY_REPLICATED=1,TTL=10@col_b\"")
+    except Exception as e:
+        print(f"PRE Create DB/TABLE failed: {e}")
+        A_conn.close()
+        B_conn.close()
+        exit (-1)
+
+def case_40_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz1 VALUES(1, SYSDATE(), 100) ON DUPLICATE KEY UPDATE col_c = 101")
+        time.sleep(3)
+        cur.execute("INSERT INTO sz1 VALUES(1, SYSDATE(), 200) ON DUPLICATE KEY UPDATE col_c = 201")
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 2, "ASSERT"
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        time.sleep(2)
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz1 VALUES(1, SYSDATE(), 300) ON DUPLICATE KEY UPDATE col_c = 301")
+        cur.execute("COMMIT")
+        time.sleep(6)
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz1 VALUES(1, SYSDATE(), 400) ON DUPLICATE KEY UPDATE col_c = 401")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 2, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_40_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(5)
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT1"
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT2"
+        assert check_rep(conn) == True, "ASSERT3"
+
+        time.sleep(4)
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT4"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 300, "ASSERT5"
+        time.sleep(4)
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 2, "ASSERT6"
+        time.sleep(10)
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT7"
+        assert check_rep(conn) == True, "ASSERT8"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+def case_40_post(A_conn, B_conn):
+    try:
+        cur = A_conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS sz1")
+    except Exception as e:
+        print(f"POST Drop DB/TABLE failed: {e}")
+        A_conn.close()
+        B_conn.close()
+        exit (-1)
+
+
+def case_41_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        time.sleep(5)
+        cur.execute("BEGIN")
+        cur.execute("REPLACE INTO sz VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 200, "ASSERT"
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+
+        time.sleep(2)
+        cur.execute("BEGIN")
+        cur.execute("REPLACE INTO sz VALUES(1, SYSDATE(), 300)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 300, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_41_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(6)
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 200, "ASSERT"
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        assert check_rep(conn) == True, "ASSERT"
+
+        time.sleep(2)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 300, "ASSERT"
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        assert check_rep(conn) == True, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+
+def case_42_pre(A_conn, B_conn):
+    try:
+        cur = A_conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS sz1")
+        cur.execute("CREATE TABLE test.sz1 ("
+                    "col_a INT, "
+                    "col_b DATETIME, "
+                    "col_c INT)"
+                    "ENGINE = NDB, "
+                    "COMMENT=\"NDB_TABLE=FULLY_REPLICATED=1,TTL=10@col_b\"")
+    except Exception as e:
+        print(f"PRE Create DB/TABLE failed: {e}")
+        A_conn.close()
+        B_conn.close()
+        exit (-1)
+
+def case_42_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz1 VALUES(1, SYSDATE(), 100)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        time.sleep(5)
+        cur.execute("BEGIN")
+        cur.execute("REPLACE INTO sz1 VALUES(1, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 2, "ASSERT"
+        time.sleep(11)
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+
+        time.sleep(5)
+        cur.execute("BEGIN")
+        cur.execute("REPLACE INTO sz1 VALUES(1, SYSDATE(), 300)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 300, "ASSERT"
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_42_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(8)
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 2, "ASSERT1"
+        time.sleep(9)
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT2"
+        assert check_rep(conn) == True, "ASSERT3"
+
+        time.sleep(6)
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT4"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 300, "ASSERT5"
+        time.sleep(9)
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT6"
+        assert check_rep(conn) == True, "ASSERT7"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+def case_42_post(A_conn, B_conn):
+    try:
+        cur = A_conn.cursor()
+        cur.execute("DROP TABLE IF EXISTS sz1")
+    except Exception as e:
+        print(f"POST Drop DB/TABLE failed: {e}")
+        A_conn.close()
+        B_conn.close()
+        exit (-1)
+
+
+def case_43_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 200)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 2, "ASSERT"
+        time.sleep(3)
+        cur.execute("BEGIN")
+        cur.execute("UPDATE sz SET col_c = 200")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz WHERE col_a = 1")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 200, "ASSERT"
+        time.sleep(3)
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz WHERE col_c >= 100")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_43_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(1)
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 2, "ASSERT"
+        time.sleep(3)
+        cur.execute("SELECT * FROM sz WHERE col_a = 1")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 200, "ASSERT"
+        assert check_rep(conn) == True, "ASSERT"
+        time.sleep(3)
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 0, "ASSERT"
+        assert check_rep(conn) == True, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+def case_44_pre(A_conn, B_conn):
+    return
+
+def case_44_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz VALUES(1, SYSDATE(), 100)")
+        cur.execute("INSERT INTO sz VALUES(2, SYSDATE(), 200)")
+        cur.execute("INSERT INTO sz VALUES(3, DATE_ADD(SYSDATE(), INTERVAL 1 DAY), 300)")
+        cur.execute("INSERT INTO sz VALUES(4, SYSDATE(), 400)")
+        time.sleep(11)
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_44_thdB(conn):
+    global B_succ
+    try:
+        time.sleep(12)
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM sz")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 300, "ASSERT"
+        assert check_rep(conn) == True, "ASSERT"
+    except Exception as e:
+        print(f"Thd B failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    B_succ = True
+
+def case_44_post(A_conn, B_conn):
+    try:
+        cur = A_conn.cursor()
+        cur.execute("BEGIN")
+        cur.execute("DELETE FROM sz")
+        cur.execute("COMMIT")
+    except Exception as e:
+        print(f"POST Drop DB/TABLE failed: {e}")
+        A_conn.close()
+        B_conn.close()
+        exit (-1)
+
+
+def case_46_pre(A_conn, B_conn):
+    try:
+        B_cur = B_conn.cursor()
+        B_cur.execute("STOP REPLICA")
+        B_cur.execute("DROP DATABASE IF EXISTS test")
+
+        cur = A_conn.cursor()
+        cur.execute("DROP DATABASE IF EXISTS test")
+        cur.execute("CREATE DATABASE test")
+        cur.execute("USE test")
+        cur.execute("CREATE TABLE test.sz1 ("
+                    "col_a INT, "
+                    "col_b DATETIME, "
+                    "col_c INT, "
+                    "PRIMARY KEY(col_a)) "
+                    "ENGINE = NDB, "
+                    "COMMENT=\"NDB_TABLE=TTL=10@col_b\"")
+        cur.execute("CREATE TABLE test.sz2 ("
+                    "col_a INT, "
+                    "col_b DATETIME, "
+                    "col_c INT)"
+                    "ENGINE = NDB, "
+                    "COMMENT=\"NDB_TABLE=TTL=10@col_b\"")
+        cur.execute("CREATE TABLE test.sz3 ("
+                    "col_a INT, "
+                    "col_b DATETIME, "
+                    "col_c INT, "
+                    "PRIMARY KEY(col_a)) "
+                    "ENGINE = NDB")
+    except Exception as e:
+        print(f"PRE Create DB/TABLE failed: {e}")
+        A_conn.close()
+        B_conn.close()
+        exit (-1)
+
+def case_46_thdA(conn):
+    global A_succ
+    try:
+        cur = conn.cursor()
+        cur.execute("USE test")
+        cur.execute("BEGIN")
+        cur.execute("INSERT INTO sz1 VALUES(1, SYSDATE(), 100)")
+        cur.execute("INSERT INTO sz1 VALUES(2, SYSDATE(), 200)")
+        cur.execute("INSERT INTO sz1 VALUES(3, DATE_ADD(SYSDATE(), INTERVAL 1 DAY), 300)")
+        cur.execute("INSERT INTO sz1 VALUES(4, SYSDATE(), 400)")
+        cur.execute("INSERT INTO sz2 VALUES(1, SYSDATE(), 100)")
+        cur.execute("INSERT INTO sz2 VALUES(2, SYSDATE(), 200)")
+        cur.execute("INSERT INTO sz2 VALUES(3, DATE_ADD(SYSDATE(), INTERVAL 1 DAY), 300)")
+        cur.execute("INSERT INTO sz2 VALUES(4, SYSDATE(), 400)")
+        cur.execute("INSERT INTO sz3 VALUES(1, SYSDATE(), 100)")
+        cur.execute("INSERT INTO sz3 VALUES(2, SYSDATE(), 200)")
+        cur.execute("INSERT INTO sz3 VALUES(3, DATE_ADD(SYSDATE(), INTERVAL 1 DAY), 300)")
+        cur.execute("INSERT INTO sz3 VALUES(4, SYSDATE(), 400)")
+        cur.execute("COMMIT")
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 4, "ASSERT"
+        cur.execute("SELECT * FROM sz2")
+        results = cur.fetchall()
+        assert len(results) == 4, "ASSERT"
+        cur.execute("SELECT * FROM sz3")
+        results = cur.fetchall()
+        assert len(results) == 4, "ASSERT"
+        time.sleep(11)
+
+        cur.execute("SELECT * FROM sz1")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 300, "ASSERT"
+        cur.execute("SELECT * FROM sz2")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            col_c = row[2]
+            assert col_c == 300, "ASSERT"
+        cur.execute("SELECT * FROM sz3")
+        results = cur.fetchall()
+        assert len(results) == 4, "ASSERT"
+        subprocess.run([BIN_DIR+"/ndb_mgm", "-e", "start backup"],
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except Exception as e:
+        print(f"Thd A failed: {e}")
+        cur.close()
+        return
+    cur.close()
+    A_succ = True
+
+def case_46_thdB(conn):
+    global B_succ
+    time.sleep(17)
+    subprocess.run([BIN_DIR+"/ndb_restore",
+                    "--ndb-connectstring=127.0.0.1:"+str(MGMD_PORT_R),
+                    "--nodeid=2", "--backupid=1",
+                    "--backup-path="+DATA_DIR_P_1+"/ndb_data/BACKUP/BACKUP-1",
+                    "--restore_meta", "--no-restore-disk-objects"],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.run([BIN_DIR+"/ndb_restore",
+                    "--ndb-connectstring=127.0.0.1:"+str(MGMD_PORT_R),
+                    "--nodeid=2", "--backupid=1",
+                    "--backup-path="+DATA_DIR_P_1+"/ndb_data/BACKUP/BACKUP-1",
+                    "--restore-data"],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    subprocess.run([BIN_DIR+"/ndb_restore",
+                    "--ndb-connectstring=127.0.0.1:"+str(MGMD_PORT_R),
+                    "--nodeid=3", "--backupid=1",
+                    "--backup-path="+DATA_DIR_P_2+"/ndb_data/BACKUP/BACKUP-1",
+                    "--restore-data"],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(10)
+    while True:
+        try:
+            new_conn = pymysql.connect(host='127.0.0.1',
+                                   port=MYSQLD_PORT_R,
+                                   user='root')
+            cur = new_conn.cursor()
+            cur.execute("USE test")
+            cur.execute("SELECT * FROM sz1")
+            results = cur.fetchall()
+            assert len(results) == 1, "ASSERT"
+            for row in results:
+                col_c = row[2]
+                assert col_c == 300, "ASSERT"
+            cur.execute("SELECT * FROM sz2")
+            results = cur.fetchall()
+            assert len(results) == 1, "ASSERT"
+            for row in results:
+                col_c = row[2]
+                assert col_c == 300, "ASSERT"
+            cur.execute("SELECT * FROM sz3")
+            results = cur.fetchall()
+            assert len(results) == 4, "ASSERT"
+            break
+        except pymysql.MySQLError as e:
+            errno = e.args[0]
+            if errno in [1412, 1049]:
+                #1412 - Table definition has changed, please retry transaction
+                #1049 - Unknown database 'test'
+                print(f"Waiting for synchronizing restored schema...Retry {e}")
+                time.sleep(10)
+                cur.close()
+                new_conn.close()
+                continue
+            else:
+                print(f"Thd B failed: {e}")
+                cur.close()
+                new_conn.close()
+                return
+        except Exception as e:
+            print(f"Thd B failed: {e}")
+            cur.close()
+            new_conn.close()
+            return
+    cur.close()
+    new_conn.close()
+    B_succ = True
+
+def case_46_post(A_conn, B_conn):
+    try:
+        cur = A_conn.cursor()
+        #cur.execute("DROP TABLE IF EXISTS sz1")
+        #cur.execute("DROP TABLE IF EXISTS sz2")
+        #cur.execute("DROP TABLE IF EXISTS sz3")
+    except Exception as e:
+        print(f"POST Drop DB/TABLE failed: {e}")
+        A_conn.close()
+        B_conn.close()
+        exit (-1)
+
+
+def check_rep(conn):
+    ret = False;
+    try:
+        cur = conn.cursor()
+        cur.execute("SHOW VARIABLES LIKE 'server_id'")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            server_id = row[1]
+            assert server_id == "2", "ASSERT"
+
+        cur.execute("SHOW REPLICA STATUS")
+        results = cur.fetchall()
+        assert len(results) == 1, "ASSERT"
+        for row in results:
+            io_running = row[10]
+            sql_running = row[11]
+            last_errno = row[18]
+            last_io_errno = row[34]
+            last_sql_errno = row[36]
+            if io_running == "Yes" and sql_running == "Yes" and \
+               last_errno == 0 and \
+               last_io_errno == 0 and last_sql_errno == 0:
+                   ret = True
+            return ret
+    except Exception as e:
+        print(f"check_rep failed: {e}")
+        cur.close()
+        return ret
+
+
+def case(num):
+    global A_succ, B_succ
+    global funcs_thdA, funcs_thdB
+    A_succ = False
+    B_succ = False
+
+    cases_require_debug_sync = [23, 24, 25]
+    cases_binlog = [36, 37, 38, 39, 40, 41, 42, 43, 44]
+    cases_backup_restore = [46]
+    cases_need_extra_process = [29, 40, 42, 44, 46]
+
+
+    # 1. Connect
+    try:
+        A_conn = pymysql.connect(host='127.0.0.1',
+                               port=MYSQLD_PORT_P,
+                               database='test',
+                               user='root')
+    except Exception as e:
+        print(f"Thd A connects to DB failed: {e}")
+        exit(-1)
+    A_succ = True
+    try:
+        if num in cases_binlog:
+            B_conn = pymysql.connect(host='127.0.0.1',
+                                   port=MYSQLD_PORT_R,
+                                   database='test',
+                                   user='root')
+        elif num in cases_backup_restore:
+            B_conn = pymysql.connect(host='127.0.0.1',
+                                   port=MYSQLD_PORT_R,
+                                   user='root')
+        else:
+            B_conn = pymysql.connect(host='127.0.0.1',
+                                   port=MYSQLD_PORT_P,
+                                   database='test',
+                                   user='root')
+    except Exception as e:
+        print(f"Thd B connects to DB failed: {e}")
+        A_conn.close()
+        exit(-1)
+    B_succ = True
+
+    # 2. Verify DEBUG_SYNC for some cases
+    if num in cases_require_debug_sync:
+        try:
+            cur = A_conn.cursor();
+            cur.execute("SHOW VARIABLES LIKE 'DEBUG_SYNC'")
+            results = cur.fetchall()
+            # print(f"debug_sync: {results[0][0]}, {results[0][1]}")
+            if results[0][1].find("ON") == -1:
+                print(f"case {num} require MySQL DEBUG_SYNC, turn it on and retry...")
+                cur.close()
+                A_conn.close()
+                B_conn.close()
+                exit(-1)
+
+            cur = B_conn.cursor();
+            cur.execute("SHOW VARIABLES LIKE 'DEBUG_SYNC'")
+            results = cur.fetchall()
+            if results[0][1].find("ON") == -1:
+                print(f"case {num} require MySQL DEBUG_SYNC, turn it on and retry...")
+                cur.close()
+                A_conn.close()
+                B_conn.close()
+                exit(-1)
+        except Exception as e:
+            print(f"TRY DEBUG_SYNC failed: {e}")
+            cur.close()
+            A_conn.close()
+            B_conn.close()
+            exit(-1)
+    
+    # 3. Call preprocess() if needed
+    if num in cases_need_extra_process:
+        pre_func_name = f"case_{num}_pre"
+        globals()[pre_func_name](A_conn, B_conn)
+
+    # 4. Test
+    if (A_succ and B_succ):
+        A_succ = False
+        B_succ = False
+        A_thd = threading.Thread(target=funcs_thdA[num - 1], args=(A_conn,))
+        B_thd = threading.Thread(target=funcs_thdB[num - 1], args=(B_conn,))
+
+        A_thd.start()
+        B_thd.start()
+
+        A_thd.join()
+        B_thd.join()
+        if (A_succ and B_succ):
+            print(f"case_{num} passed")
+        else:
+            print(f"case_{num} failed")
+        # 5. Call postprocess() if needed
+        if num in cases_need_extra_process:
+            post_func_name = f"case_{num}_post"
+            globals()[post_func_name](A_conn, B_conn)
+
+        A_conn.close()
+        B_conn.close()
+    else:
+        print(f"case_{num} failed")
+
+funcs_thdA = []
+funcs_thdB = []
+A_succ = False
+B_succ = False
+if __name__ == '__main__':
+
+    case_num = 46
+    # 1. create database and table
+    try:
+        conn = pymysql.connect(host='127.0.0.1',
+                               port=MYSQLD_PORT_P,
+                               user='root')
+    except Exception as e:
+        print(f"Connect to DB failed: {e}")
+        exit (-1)
+    try:
+        cur = conn.cursor()
+        cur.execute("DROP DATABASE IF EXISTS test")
+        cur.execute("CREATE DATABASE IF NOT EXISTS test")
+        cur.execute("CREATE TABLE test.sz ("
+                    "col_a INT, "
+                    "col_b DATETIME, "
+                    "col_c INT, "
+                    "PRIMARY KEY(col_a)) "
+                    "ENGINE = NDB, "
+                    "COMMENT=\"NDB_TABLE=TTL=10@col_b\"")
+    except Exception as e:
+        print(f"Create DB/TABLE failed: {e}")
+        conn.close()
+        exit (-1)
+    conn.close()
+    time.sleep(1)
+
+    for i in range (1, case_num + 1):
+        func_name = f"case_{i}_thdA"
+        funcs_thdA.append(eval(func_name))
+        func_name = f"case_{i}_thdB"
+        funcs_thdB.append(eval(func_name))
+
+    #INSERT
+    case(1)
+    case(2)
+    case(3)
+    case(4)
+    case(5)
+
+    #INSERT ON DUPLICATE KEY UPDATE
+    case(6)
+    case(7)
+    case(8)
+    case(9)
+    case(10)
+    case(11)
+    case(12)
+
+    #UPDATE
+    case(13)
+    case(14)
+    case(15)
+    case(16)
+    case(17)
+    case(18)
+
+    #DELETE
+    case(19)
+    case(20)
+    case(21)
+    case(22)
+    case(23)
+    case(27)
+
+    case(23)
+    case(25)
+    ##case(26)
+    case(24)
+
+    #READ LOCKED
+    case(28)
+    case(29) # FULLY_REPLICATED
+    case(45)
+
+    #REPLACE INTO
+    case(30)
+    case(31)
+    case(32)
+    case(33)
+    case(34)
+    case(35)
+
+    #BINLOG
+    case(36)
+    case(37)
+    case(38)
+    case(39)
+    case(40)
+    case(41)
+    case(42)
+    case(43)
+    case(44)
+    case(45)
+
+    ##BACKUP RESTORE
+    case(46)

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -8121,7 +8121,6 @@ int handler::ha_reset() {
   // Forget the record buffer.
   m_record_buffer = nullptr;
   m_unique = nullptr;
-  // fprintf(stderr, "Zart ha_reset, table_name: %s\n", table->s->table_name.str);
 
   const int retval = reset();
   return retval;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2909,6 +2909,11 @@ int handler::ha_close(void) {
 */
 
 int handler::ha_index_init(uint idx, bool sorted) {
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table_share->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart handler::ha_index_init\n");
+  }
+#endif  // TTL_TRACE_HANDLER
   DBUG_EXECUTE_IF("ha_index_init_fail", return HA_ERR_TABLE_DEF_CHANGED;);
   int result;
   DBUG_TRACE;
@@ -2929,6 +2934,11 @@ int handler::ha_index_init(uint idx, bool sorted) {
 */
 
 int handler::ha_index_end() {
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table_share->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart handler::ha_index_end\n");
+  }
+#endif  // TTL_TRACE_HANDLER
   DBUG_TRACE;
   /* SQL HANDLER function can call this without having it locked. */
   assert(table->open_by_handler || table_share->tmp_table != NO_TMP_TABLE ||
@@ -2953,6 +2963,11 @@ int handler::ha_index_end() {
 */
 
 int handler::ha_rnd_init(bool scan) {
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table_share->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart handler::ha_rnd_init\n");
+  }
+#endif  // TTL_TRACE_HANDLER
   DBUG_EXECUTE_IF("ha_rnd_init_fail", return HA_ERR_TABLE_DEF_CHANGED;);
   int result;
   DBUG_TRACE;
@@ -2972,6 +2987,11 @@ int handler::ha_rnd_init(bool scan) {
 */
 
 int handler::ha_rnd_end() {
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table_share->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart handler::ha_rnd_end\n");
+  }
+#endif  // TTL_TRACE_HANDLER
   DBUG_TRACE;
   /* SQL HANDLER function can call this without having it locked. */
   assert(table->open_by_handler || table_share->tmp_table != NO_TMP_TABLE ||
@@ -2994,6 +3014,11 @@ int handler::ha_rnd_end() {
 */
 
 int handler::ha_rnd_next(uchar *buf) {
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table_share->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart handler::ha_rnd_next\n");
+  }
+#endif  // TTL_TRACE_HANDLER
   int result;
   DBUG_EXECUTE_IF("ha_rnd_next_deadlock", return HA_ERR_LOCK_DEADLOCK;);
   DBUG_TRACE;
@@ -3025,6 +3050,11 @@ int handler::ha_rnd_next(uchar *buf) {
 */
 
 int handler::ha_rnd_pos(uchar *buf, uchar *pos) {
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table_share->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart handler::ha_rnd_pos\n");
+  }
+#endif  // TTL_TRACE_HANDLER
   int result;
   DBUG_TRACE;
   assert(table_share->tmp_table != NO_TMP_TABLE || m_lock_type != F_UNLCK);
@@ -6484,7 +6514,11 @@ int handler::multi_range_read_init(RANGE_SEQ_IF *seq_funcs,
 int handler::ha_multi_range_read_next(char **range_info) {
   int result;
   DBUG_TRACE;
-
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table_share->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart handler::ha_multi_range_read_next\n");
+  }
+#endif  // TTL_TRACE_HANDLER
   // Set status for the need to update generated fields
   m_update_generated_read_fields = table->has_gcol();
 
@@ -6516,6 +6550,11 @@ int handler::multi_range_read_next(char **range_info) {
   int range_res = 0;
   bool dup_found = false;
   DBUG_TRACE;
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table_share->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart, handler::multi_range_read_next\n");
+  }
+#endif  // TTL_TRACE_HANDLER
   // For a multi-valued index the unique filter have to be used for correct
   // result
   assert(!(table->key_info[active_index].flags & HA_MULTI_VALUED_KEY) ||
@@ -7421,6 +7460,11 @@ int handler::read_range_first(const key_range *start_key,
 int handler::ha_read_range_first(const key_range *start_key,
                                  const key_range *end_key, bool eq_range,
                                  bool sorted) {
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table_share->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart handler::ha_read_range_first\n");
+  }
+#endif  // TTL_TRACE_HANDLER
   int result;
   DBUG_TRACE;
 
@@ -7441,6 +7485,11 @@ int handler::ha_read_range_next() {
   int result;
   DBUG_TRACE;
 
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table_share->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart handler::ha_read_range_next\n");
+  }
+#endif  // TTL_TRACE_HANDLER
   // Set status for the need to update generated fields
   m_update_generated_read_fields = table->has_gcol();
 
@@ -8063,6 +8112,8 @@ int handler::ha_reset() {
   /* Reset the handler flags used for dupilcate record handling */
   table->file->extra(HA_EXTRA_NO_IGNORE_DUP_KEY);
   table->file->extra(HA_EXTRA_WRITE_CANNOT_REPLACE);
+  /* Reset the handle flags used for ignoring TTL */
+  table->file->extra(HA_EXTRA_NO_IGNORE_TTL);
   /* Reset information about pushed engine conditions */
   pushed_cond = nullptr;
   /* Reset information about pushed index conditions */
@@ -8070,6 +8121,7 @@ int handler::ha_reset() {
   // Forget the record buffer.
   m_record_buffer = nullptr;
   m_unique = nullptr;
+  // fprintf(stderr, "Zart ha_reset, table_name: %s\n", table->s->table_name.str);
 
   const int retval = reset();
   return retval;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -835,6 +835,14 @@ struct st_handler_tablename {
 */
 #define UNDEF_NODEGROUP 65535
 
+/*
+ * Zart
+ * Turn on them to trace handler
+ */
+#undef TTL_TRACE_HANDLER
+// #define TTL_TRACE_HANDLER 1
+#define TTL_TABLE_NAME "sz"
+
 // FUTURE: Combine these two enums into one enum class
 enum ts_command_type {
   TS_CMD_NOT_DEFINED = -1,

--- a/sql/range_optimizer/index_range_scan.cc
+++ b/sql/range_optimizer/index_range_scan.cc
@@ -260,6 +260,11 @@ bool InitIndexRangeScan(TABLE *table, handler *file, int index,
                         unsigned mrr_flags, bool in_ror_merged_scan,
                         MY_BITMAP *column_bitmap) {
   DBUG_TRACE;
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table->s->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart InitIndexRangeScan\n");
+  }
+#endif  // TTL_TRACE_HANDLER
 
   /* set keyread to true if index is covering */
   if (!table->no_keyread && table->covering_keys.is_set(index))
@@ -361,7 +366,11 @@ int IndexRangeScanIterator::Read() {
   MY_BITMAP *const save_read_set = table()->read_set;
   MY_BITMAP *const save_write_set = table()->write_set;
   DBUG_TRACE;
-
+#ifdef TTL_TRACE_HANDLER
+  if (strcmp(table()->s->table_name.str, TTL_TABLE_NAME) == 0) {
+    fprintf(stderr, "Zart IndexRangeScanIterator::Read\n");
+  }
+#endif  // TTL_TRACE_HANDLER
   if (in_ror_merged_scan) {
     /*
       We don't need to signal the bitmap change as the bitmap is always the

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -306,7 +306,7 @@ bool Sql_cmd_delete::delete_from_single_table(THD *thd) {
    * Zart
    * TTL
    */
-  if(thd->variables.ttl_expired_rows_visiable_in_delete) {
+  if(thd->variables.ttl_expired_rows_visible_in_delete) {
     table->file->ha_extra(HA_EXTRA_IGNORE_TTL);
   }
 
@@ -615,7 +615,7 @@ bool Sql_cmd_delete::delete_from_single_table(THD *thd) {
       }
 
       assert(!thd->is_error());
-      DEBUG_SYNC(thd, "zhao_wait_for_row_get_expired_after_reading_4");
+      DEBUG_SYNC(thd, "ttl_wait_for_row_get_expired_after_reading_4");
 /*
  * Zart
  * TTL

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1866,7 +1866,7 @@ bool write_record(THD *thd, TABLE *table, COPY_INFO *info, COPY_INFO *update) {
        * TODO (Zhao)
        * ignore ttl in scan?
        */
-      DEBUG_SYNC(thd, "zhao_wait_for_row_get_expired_after_reading_1");
+      DEBUG_SYNC(thd, "ttl_wait_for_row_get_expired_after_reading_1");
       // table->file->ha_extra(HA_EXTRA_IGNORE_TTL);
 
       /* Read all columns for the row we are going to replace */
@@ -2024,7 +2024,7 @@ bool write_record(THD *thd, TABLE *table, COPY_INFO *info, COPY_INFO *update) {
             goto ok_or_after_trg_err;
           }
 
-          DEBUG_SYNC(thd, "zhao_wait_for_row_get_expired_after_reading_2");
+          DEBUG_SYNC(thd, "ttl_wait_for_row_get_expired_after_reading_2");
           /*
            * Zart
            * Already set before

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -1862,6 +1862,13 @@ bool write_record(THD *thd, TABLE *table, COPY_INFO *info, COPY_INFO *update) {
 
       DEBUG_SYNC(thd, "write_row_replace");
 
+      /*
+       * TODO (Zhao)
+       * ignore ttl in scan?
+       */
+      DEBUG_SYNC(thd, "zhao_wait_for_row_get_expired_after_reading_1");
+      // table->file->ha_extra(HA_EXTRA_IGNORE_TTL);
+
       /* Read all columns for the row we are going to replace */
       table->use_all_columns();
       /*
@@ -2017,6 +2024,12 @@ bool write_record(THD *thd, TABLE *table, COPY_INFO *info, COPY_INFO *update) {
             goto ok_or_after_trg_err;
           }
 
+          DEBUG_SYNC(thd, "zhao_wait_for_row_get_expired_after_reading_2");
+          /*
+           * Zart
+           * Already set before
+           */
+          // table->file->ha_extra(HA_EXTRA_IGNORE_TTL);
           if ((error = table->file->ha_update_row(table->record[1],
                                                   table->record[0])) &&
               error != HA_ERR_RECORD_IS_THE_SAME) {

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -960,6 +960,7 @@ bool Sql_cmd_update::update_single_table(THD *thd) {
           continue;
         }
 
+        DEBUG_SYNC(thd, "zhao_wait_for_row_get_expired_after_reading_3");
         if (will_batch) {
           /*
             Typically a batched handler can execute the batched jobs when:

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -960,7 +960,7 @@ bool Sql_cmd_update::update_single_table(THD *thd) {
           continue;
         }
 
-        DEBUG_SYNC(thd, "zhao_wait_for_row_get_expired_after_reading_3");
+        DEBUG_SYNC(thd, "ttl_wait_for_row_get_expired_after_reading_3");
         if (will_batch) {
           /*
             Typically a batched handler can execute the batched jobs when:

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3322,6 +3322,22 @@ static Sys_var_ulong Sys_connection_memory_chunk_size(
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_session_admin),
     ON_UPDATE(nullptr));
 
+static Sys_var_ulong Sys_ttl_debug_sleep_secs(
+    "ttl_debug_sleep_secs",
+    "sleep few seconds for debug TTL",
+    SESSION_VAR(ttl_debug_sleep_secs), CMD_LINE(REQUIRED_ARG),
+    VALID_RANGE(0, 3600), DEFAULT(0), BLOCK_SIZE(1),
+    NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_session_admin),
+    ON_UPDATE(nullptr));
+
+static Sys_var_bool Sys_ttl_expired_rows_visiable_in_delete(
+    "ttl_expired_rows_visiable_in_delete",
+    "TTL expired rows are visiable in delete statement",
+    SESSION_VAR(ttl_expired_rows_visiable_in_delete), CMD_LINE(OPT_ARG),
+    DEFAULT(false),
+    NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_session_admin),
+    ON_UPDATE(nullptr));
+
 static Sys_var_bool Sys_connection_global_memory_tracking(
     "global_connection_memory_tracking",
     "Enable updating the global memory counter and checking "

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3331,9 +3331,9 @@ static Sys_var_ulong Sys_ttl_debug_sleep_secs(
     ON_UPDATE(nullptr));
 
 static Sys_var_bool Sys_ttl_expired_rows_visiable_in_delete(
-    "ttl_expired_rows_visiable_in_delete",
-    "TTL expired rows are visiable in delete statement",
-    SESSION_VAR(ttl_expired_rows_visiable_in_delete), CMD_LINE(OPT_ARG),
+    "ttl_expired_rows_visible_in_delete",
+    "TTL expired rows are visible in delete statement",
+    SESSION_VAR(ttl_expired_rows_visible_in_delete), CMD_LINE(OPT_ARG),
     DEFAULT(false),
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_session_admin),
     ON_UPDATE(nullptr));

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -512,7 +512,7 @@ struct System_variables {
   bool restrict_fk_on_non_standard_key;
 
   long ttl_debug_sleep_secs;
-  bool ttl_expired_rows_visiable_in_delete;
+  bool ttl_expired_rows_visible_in_delete;
 };
 
 static_assert(std::is_trivially_copyable<System_variables>::value);

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -510,6 +510,9 @@ struct System_variables {
     @sa Sys_restrict_fk_on_non_standard_key
   */
   bool restrict_fk_on_non_standard_key;
+
+  long ttl_debug_sleep_secs;
+  bool ttl_expired_rows_visiable_in_delete;
 };
 
 static_assert(std::is_trivially_copyable<System_variables>::value);

--- a/storage/ndb/include/kernel/kernel_types.h
+++ b/storage/ndb/include/kernel/kernel_types.h
@@ -45,7 +45,8 @@ enum Operation_t {
   ZWRITE = 4,
   ZREAD_EX = 5,
   ZREFRESH = 6,
-  ZUNLOCK = 7
+  ZUNLOCK = 7,
+  ZINSERT_TTL = 10 // ZINSERT | 0x08
 };
 
 /**

--- a/storage/ndb/include/kernel/signaldata/AccFrag.hpp
+++ b/storage/ndb/include/kernel/signaldata/AccFrag.hpp
@@ -42,7 +42,7 @@ class AccFragReq {
    */
   friend class Dbacc;
 public:
-  static constexpr Uint32 SignalLength = 13;
+  static constexpr Uint32 SignalLength = 15;
 
  private:
   Uint32 userPtr;
@@ -58,6 +58,8 @@ public:
   Uint32 lhDirBits;
   Uint32 keyLength;
   Uint32 hashFunctionFlag;
+  Uint32 ttlSec;
+  Uint32 ttlColumnNo;
 };
 
 class AccFragConf {

--- a/storage/ndb/include/kernel/signaldata/AccKeyReq.hpp
+++ b/storage/ndb/include/kernel/signaldata/AccKeyReq.hpp
@@ -55,6 +55,7 @@ struct AccKeyReq {
   static bool getTakeOver(Uint32 requestInfo);
   static bool getLockReq(Uint32 requestInfo);
   static bool getNoWait(Uint32 requestInfo);
+  static bool getTTL(Uint32 requestInfo);
 
   static Uint32 setOperation(Uint32 requestInfo, Uint32 op);
   static Uint32 setLockType(Uint32 requestInfo, Uint32 locktype);
@@ -63,6 +64,7 @@ struct AccKeyReq {
   static Uint32 setTakeOver(Uint32 requestInfo, bool takeover);
   static Uint32 setLockReq(Uint32 requestInfo, bool lockreq);
   static Uint32 setNoWait(Uint32 requestInfo, bool lockreq);
+  static Uint32 setTTL(Uint32 requestInfo, bool is_ttl);
 
  private:
   enum RequestInfo {
@@ -80,6 +82,8 @@ struct AccKeyReq {
     RI_NOWAIT_MASK = 1,
     RI_LOCK_REQ_SHIFT = 31,
     RI_LOCK_REQ_MASK = 1,
+    RI_TTL_SHIFT = 11,
+    RI_TTL_MASK = 1,
   };
 };
 
@@ -109,6 +113,10 @@ inline bool AccKeyReq::getLockReq(Uint32 requestInfo) {
 
 inline bool AccKeyReq::getNoWait(Uint32 requestInfo) {
   return (requestInfo >> RI_NOWAIT_SHIFT) & RI_NOWAIT_MASK;
+}
+
+inline bool AccKeyReq::getTTL(Uint32 requestInfo) {
+  return (requestInfo >> RI_TTL_SHIFT) & RI_TTL_MASK;
 }
 
 inline Uint32 AccKeyReq::setOperation(Uint32 requestInfo, Uint32 op) {
@@ -148,6 +156,14 @@ inline Uint32 AccKeyReq::setLockReq(Uint32 requestInfo, bool lockreq) {
 inline Uint32 AccKeyReq::setNoWait(Uint32 requestInfo, bool nowait) {
   return (requestInfo & ~(RI_NOWAIT_MASK << RI_NOWAIT_SHIFT)) |
          (nowait ? 1U << RI_NOWAIT_SHIFT : 0);
+}
+
+inline
+Uint32
+AccKeyReq::setTTL(Uint32 requestInfo, bool is_ttl)
+{
+  return (requestInfo & ~(RI_TTL_MASK << RI_TTL_SHIFT))
+    | (is_ttl ? 1U << RI_TTL_SHIFT : 0);
 }
 
 #endif

--- a/storage/ndb/include/kernel/signaldata/AccLock.hpp
+++ b/storage/ndb/include/kernel/signaldata/AccLock.hpp
@@ -76,6 +76,7 @@ class AccLockReq {
   Uint32 transId1;
   Uint32 transId2;
   Uint32 isCopyFragScan;
+  Uint32 ignore_ttl;
 };
 
 #undef JAM_FILE_ID

--- a/storage/ndb/include/kernel/signaldata/CreateTab.hpp
+++ b/storage/ndb/include/kernel/signaldata/CreateTab.hpp
@@ -36,6 +36,7 @@ struct CreateTabReq {
   static constexpr Uint32 OldSignalLengthLDM = 6 + 11;
   static constexpr Uint32 SignalLengthLDM = 6 + 12;
   static constexpr Uint32 NewSignalLengthLDM = 6 + 13;
+  static constexpr Uint32 NewSignalLengthLDMWithTTL = 6 + 15;
 
   enum RequestType {};
 
@@ -62,6 +63,12 @@ struct CreateTabReq {
   Uint32 extraRowAuthorBits;
   Uint32 useVarSizedDiskData;
   Uint32 hashFunctionFlag;
+
+  /*
+   * TTL
+   */
+  Uint32 ttlSec;
+  Uint32 ttlColumnNo;
 
   SECTION(DICT_TAB_INFO = 0);
   SECTION(FRAGMENTATION = 1);
@@ -109,8 +116,14 @@ struct TcSchVerReq {
   Uint32 fullyReplicated;
   Uint32 hashFunctionFlag;
   Uint32 diskBased;
+  /*
+   * TTL
+   */
+  Uint32 ttlSec;
+  Uint32 ttlColumnNo;
+  Uint32 primaryTableId;
 
-  static constexpr Uint32 SignalLength = 13;
+  static constexpr Uint32 SignalLength = 16;
 };
 
 struct TcSchVerConf {

--- a/storage/ndb/include/kernel/signaldata/DictTabInfo.hpp
+++ b/storage/ndb/include/kernel/signaldata/DictTabInfo.hpp
@@ -167,6 +167,12 @@ class DictTabInfo {
 
     HashFunctionFlag   = 163,
 
+    /*
+     * TTL
+     */
+    TTLSec = 164,
+    TTLColumnNo = 165,
+
     TableEnd           = 999,
     
     AttributeName          = 1000, // String, Mandatory
@@ -391,6 +397,9 @@ class DictTabInfo {
 
     Uint32 UseVarSizedDiskDataFlag;
     Uint32 HashFunctionFlag;
+
+    Uint32 TTLSec;
+    Uint32 TTLColumnNo;
 
     Table() {}
     void init();

--- a/storage/ndb/include/kernel/signaldata/LqhKey.hpp
+++ b/storage/ndb/include/kernel/signaldata/LqhKey.hpp
@@ -220,6 +220,12 @@ class LqhKeyReq {
 
   static UintR getNoWaitFlag(const UintR &requestInfo);
   static void setNoWaitFlag(UintR &requestInfo, UintR val);
+  /*
+   * Zart
+   * TTL
+   */
+  static void setTTLIgnoreFlag(UintR &requestInfo, UintR val);
+  static UintR getTTLIgnoreFlag(const UintR &requestInfo);
 
   enum RequestInfo {
     RI_KEYLEN_SHIFT = 0,
@@ -230,8 +236,12 @@ class LqhKeyReq {
     RI_NOWAIT_SHIFT = 3,
     RI_REPLICA_APPLIER_SHIFT = 5,
 
+    /*
+     * Zart
+     * TTL
+     */
+    RI_TTL_IGNORE_SHIFT = 6,
     /* Currently unused */
-    RI_CLEAR_SHIFT6 = 6,
     RI_CLEAR_SHIFT7 = 7,
     RI_CLEAR_SHIFT8 = 8,
     RI_CLEAR_SHIFT9 = 9,
@@ -490,6 +500,12 @@ inline void LqhKeyReq::setSimpleFlag(UintR &requestInfo, UintR val) {
 
 inline void LqhKeyReq::setOperation(UintR &requestInfo, UintR val) {
   ASSERT_MAX(val, RI_OPERATION_MASK, "LqhKeyReq::setOperation");
+  /*
+   * Zart
+   * Need to clear the previous operation bits before setting a
+   * new one
+   */
+  requestInfo &= ~((Uint32)RI_OPERATION_MASK << RI_OPERATION_SHIFT);
   requestInfo |= (val << RI_OPERATION_SHIFT);
 }
 
@@ -617,8 +633,7 @@ inline UintR LqhKeyReq::getDisableFkConstraints(const UintR &requestInfo) {
 }
 
 inline UintR LqhKeyReq::getLongClearBits(const UintR &requestInfo) {
-  const Uint32 mask = (1 << RI_CLEAR_SHIFT6) |
-                      (1 << RI_CLEAR_SHIFT7) | (1 << RI_CLEAR_SHIFT8) |
+  const Uint32 mask = (1 << RI_CLEAR_SHIFT7) | (1 << RI_CLEAR_SHIFT8) |
                       (1 << RI_CLEAR_SHIFT9);
 
   return (requestInfo & mask);
@@ -658,6 +673,15 @@ inline void LqhKeyReq::setReplicaApplierFlag(UintR &requestInfo, UintR val) {
 
 inline UintR LqhKeyReq::getReplicaApplierFlag(const UintR &requestInfo) {
   return (requestInfo >> RI_REPLICA_APPLIER_SHIFT) & 1;
+}
+
+inline void LqhKeyReq::setTTLIgnoreFlag(UintR &requestInfo, UintR val){
+  ASSERT_BOOL(val, "LqhKeyReq::setTTLIgnoreFlag");
+  requestInfo |= (val << RI_TTL_IGNORE_SHIFT);
+}
+
+inline UintR LqhKeyReq::getTTLIgnoreFlag(const UintR & requestInfo){
+  return (requestInfo >> RI_TTL_IGNORE_SHIFT) & 1;
 }
 
 inline Uint32 table_version_major_lqhkeyreq(Uint32 x) {

--- a/storage/ndb/include/kernel/signaldata/LqhTransConf.hpp
+++ b/storage/ndb/include/kernel/signaldata/LqhTransConf.hpp
@@ -200,7 +200,9 @@ inline void LqhTransConf::setDirtyFlag(UintR &requestInfo, UintR val) {
 }
 
 inline void LqhTransConf::setOperation(UintR &requestInfo, UintR val) {
-  ASSERT_MAX(val, LTC_OPERATION_MASK, "LqhTransConf::setOperation");
+  if (val != ZINSERT_TTL) {
+    ASSERT_MAX(val, LTC_OPERATION_MASK, "LqhTransConf::setOperation");
+  }
   requestInfo |= (val << LTC_OPERATION_SHIFT);
 }
 

--- a/storage/ndb/include/kernel/signaldata/ScanFrag.hpp
+++ b/storage/ndb/include/kernel/signaldata/ScanFrag.hpp
@@ -141,6 +141,9 @@ class ScanFragReq {
 
   static void setAggregationFlag(Uint32 & requestInfo, Uint32 val);
   static Uint32 getAggregationFlag(const Uint32 & requestInfo);
+
+  static void setTTLIgnoreFragFlag(Uint32 & requestInfo, Uint32 val);
+  static Uint32 getTTLIgnoreFragFlag(const Uint32 & requestInfo);
 };
 
 /*
@@ -344,11 +347,12 @@ class ScanFragNextReq {
  * f = First match flag      - 1  Bit 21
  * q = Query thread flag     - 1  Bit 22
  * g = Aggregation flag      - 1  Bit 23
+ * I = TTL ignore flag       - 1  Bit 24
  *
  *           1111111111222222222233
  * 01234567890123456789012345678901
  *  rrcdlxhkrztppppaaaaaaaaaaaaaaaa   Short variant ( < 6.4.0)
- *  rrcdlxhkrztppppCsaim  g           Long variant (6.4.0 +)
+ *  rrcdlxhkrztppppCsaim  gI          Long variant (6.4.0 +)
  */
 #define SF_LOCK_MODE_SHIFT (5)
 #define SF_LOCK_MODE_MASK (1)
@@ -380,6 +384,7 @@ class ScanFragNextReq {
 #define SF_FIRST_MATCH_SHIFT (21)
 #define SF_QUERY_THREAD_SHIFT (22)
 #define SF_AGGREGATION_SHIFT (23)
+#define SF_TTL_IGNORE_SHIFT (24)
 
 inline Uint32 ScanFragReq::getLockMode(const Uint32 &requestInfo) {
   return (requestInfo >> SF_LOCK_MODE_SHIFT) & SF_LOCK_MODE_MASK;
@@ -583,6 +588,20 @@ inline Uint32 ScanFragReq::getNotInterpretedFlag(const Uint32 &requestInfo) {
 inline void ScanFragReq::setNotInterpretedFlag(UintR &requestInfo, UintR val) {
   ASSERT_BOOL(val, "ScanFragReq::setStatScanFlag");
   requestInfo |= (val << SF_NOT_INTERPRETED_SHIFT);
+}
+
+inline
+void
+ScanFragReq::setTTLIgnoreFragFlag(Uint32 & requestInfo, UintR val) {
+  ASSERT_BOOL(val, "ScanFragReq::setTTLIgnoreFragFlag");
+  requestInfo= (requestInfo & ~(1 << SF_TTL_IGNORE_SHIFT)) |
+               (val << SF_TTL_IGNORE_SHIFT);
+}
+
+inline
+Uint32
+ScanFragReq::getTTLIgnoreFragFlag(const Uint32 & requestInfo) {
+  return (requestInfo >> SF_TTL_IGNORE_SHIFT) & 1;
 }
 
 /**

--- a/storage/ndb/include/kernel/signaldata/ScanTab.hpp
+++ b/storage/ndb/include/kernel/signaldata/ScanTab.hpp
@@ -122,6 +122,7 @@ class ScanTabReq {
   static Uint32 getExtendedConf(const Uint32 &);
   static Uint8 getReadCommittedBaseFlag(const UintR &requestInfo);
   static Uint32 getMultiFragFlag(const Uint32 &requestInfo);
+  static Uint32 getTTLIgnoreFlag(const Uint32 &requestInfo);
 
   /**
    * Set:ers for requestInfo
@@ -145,6 +146,7 @@ class ScanTabReq {
   static void setExtendedConf(Uint32 &requestInfo, Uint32 val);
   static void setReadCommittedBaseFlag(Uint32 &requestInfo, Uint32 val);
   static void setMultiFragFlag(Uint32 &requestInfo, Uint32 val);
+  static void setTTLIgnoreFlag(Uint32 &requestInfo, Uint32 val);
 };
 
 /**
@@ -174,11 +176,12 @@ class ScanTabReq {
  a = Pass all confs flag   - 1  Bit 28
  f = 4 word conf           - 1  Bit 29
  R = Read Committed base   - 1  Bit 30
+ I = IgnoreTTL             - 1  Bit 3
 
            1111111111222222222233
  01234567890123456789012345678901
  pppppppplnhcktzxbbbbbbbbbbdjafR
-        g
+    I   g
 */
 
 #define PARALLEL_SHIFT (0)
@@ -225,6 +228,8 @@ class ScanTabReq {
 #define SCAN_EXTENDED_CONF_SHIFT (29)
 #define SCAN_READ_COMMITTED_BASE_SHIFT (30)
 #define SCAN_MULTI_FRAG_SHIFT (31)
+
+#define SCAN_TTL_IGNORE_SHIFT (3)
 
 inline Uint8 ScanTabReq::getReadCommittedBaseFlag(const UintR &requestInfo) {
   return (Uint8)((requestInfo >> SCAN_READ_COMMITTED_BASE_SHIFT) & 1);
@@ -414,6 +419,23 @@ inline void ScanTabReq::setMultiFragFlag(UintR &requestInfo, Uint32 flag) {
                 (flag << SCAN_MULTI_FRAG_SHIFT);
 }
 
+/*
+ * Zart
+ * TTL
+ */
+inline
+UintR
+ScanTabReq::getTTLIgnoreFlag(const UintR & requestInfo) {
+  return (requestInfo >> SCAN_TTL_IGNORE_SHIFT) & 1;
+}
+
+inline
+void
+ScanTabReq::setTTLIgnoreFlag(UintR & requestInfo, Uint32 flag) {
+  ASSERT_BOOL(flag, "TcKeyReq::setTTLIgnoreFlag");
+  requestInfo= (requestInfo & ~(1 << SCAN_TTL_IGNORE_SHIFT)) |
+               (flag << SCAN_TTL_IGNORE_SHIFT);
+}
 /**
  *
  * SENDER:  Dbtc

--- a/storage/ndb/include/kernel/signaldata/TcKeyReq.hpp
+++ b/storage/ndb/include/kernel/signaldata/TcKeyReq.hpp
@@ -251,6 +251,12 @@ class TcKeyReq {
    */
   static void setNoWaitFlag(UintR &requestInfo, UintR val);
   static UintR getNoWaitFlag(const UintR &requestInfo);
+  /**
+   * Zart
+   * TTL
+   */
+  static void setTTLIgnoreFlag(UintR &requestInfo, UintR val);
+  static UintR getTTLIgnoreFlag(const UintR &requestInfo);
 };
 
 /**
@@ -378,11 +384,12 @@ class TcKeyReq {
  * - Replica applier should not stop due to out of rate limits in database
  * ----------------------------------------------------------------------
  A = Replica applier       - 1  Bit 25
+ I = IgnoreTTL             - 1  Bit 26
 
            1111111111222222222233
  01234567890123456789012345678901
  dnb cooop lsyyeiaaarkkkkkkkkkkkk  (Short TCKEYREQ)
- dnbvcooopqlsyyeixDfrRwBUQA        (Long TCKEYREQ)
+ dnbvcooopqlsyyeixDfrRwBUQAI        (Long TCKEYREQ)
 */
 
 #define TCKEY_NODISK_SHIFT (1)
@@ -423,6 +430,11 @@ class TcKeyReq {
 
 #define TC_PASS_QUEUEING_SHIFT (24)
 #define TC_REPLICA_APPLIER_SHIFT (25)
+/*
+ * Zart
+ * TTL
+ */
+#define TC_TTL_IGNORE_SHIFT (26)
 
 /**
  * Scan Info
@@ -772,6 +784,20 @@ inline void TcKeyReq::setNoWaitFlag(UintR &requestInfo, UintR val) {
 
 inline UintR TcKeyReq::getNoWaitFlag(const UintR &requestInfo) {
   return (requestInfo >> TC_NOWAIT_SHIFT) & 1;
+}
+
+inline
+void
+TcKeyReq::setTTLIgnoreFlag(UintR & requestInfo, UintR flag){
+  ASSERT_BOOL(flag, "TcKeyReq::setTTLIgnoreFlag");
+  requestInfo |= (flag << TC_TTL_IGNORE_SHIFT);
+}
+
+inline
+UintR
+TcKeyReq::getTTLIgnoreFlag(const UintR & requestInfo)
+{
+  return (requestInfo >> TC_TTL_IGNORE_SHIFT) & 1;
 }
 
 #undef JAM_FILE_ID

--- a/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
+++ b/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
@@ -273,8 +273,9 @@
 #define CFG_DB_ENCRYPTED_FILE_SYSTEM 680
 #define CFG_DB_REQUIRE_TLS 681
 
-#define CFG_DB_ACTIVATE_RATE_LIMITS   687
 /* Start RonDB only configuration parameters */
+#define CFG_DB_ENABLE_TTL 686
+#define CFG_DB_ACTIVATE_RATE_LIMITS   687
 #define CFG_DB_MAX_NUM_SCHEMA_OBJECTS 688
 
 #define CFG_DB_USE_TC_THREADS         689

--- a/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
+++ b/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
@@ -274,7 +274,6 @@
 #define CFG_DB_REQUIRE_TLS 681
 
 /* Start RonDB only configuration parameters */
-#define CFG_DB_ENABLE_TTL 686
 #define CFG_DB_ACTIVATE_RATE_LIMITS   687
 #define CFG_DB_MAX_NUM_SCHEMA_OBJECTS 688
 

--- a/storage/ndb/include/ndb_global.h
+++ b/storage/ndb/include/ndb_global.h
@@ -275,4 +275,13 @@ struct GenericSectionPtr {
   struct GenericSectionIterator *sectionIter;
 };
 
+/*
+ * Zart
+ * Turn on them to debug TTL
+ */
+#undef TTL_DEBUG
+// #define TTL_DEBUG 1
+#define TTL_TABLE_ID 17
+#define NEED_PRINT(X) ((X) >= TTL_TABLE_ID)
+
 #endif

--- a/storage/ndb/include/ndbapi/NdbDictionary.hpp
+++ b/storage/ndb/include/ndbapi/NdbDictionary.hpp
@@ -1297,6 +1297,31 @@ class NdbDictionary {
      */
     bool hasDefaultValues() const;
 
+    /*
+     * Set TTL seconds
+     */
+    void setTTLSec(Uint32 sec);
+
+    /*
+     * Get TTL seconds
+     */
+    Uint32 getTTLSec();
+
+    /*
+     * Set TTL column no
+     */
+    void setTTLColumnNo(Uint32 no);
+
+    /*
+     * Get TTL column no
+     */
+    Uint32 getTTLColumnNo();
+
+    /*
+     * Is TTL enabled
+     */
+    bool isTTLEnabled();
+
   private:
 #ifndef DOXYGEN_SHOULD_SKIP_INTERNAL
     friend class Ndb;

--- a/storage/ndb/include/ndbapi/NdbOperation.hpp
+++ b/storage/ndb/include/ndbapi/NdbOperation.hpp
@@ -1127,8 +1127,7 @@ class NdbOperation {
       OO_REPLICA_APPLIER = 0x4000,
       /*
        * Zart
-       * TODO (Zhao)
-       * Force operation ignore TTL
+       * TTL
        */
       OO_TTL_IGNORE    = 0x8000
     };
@@ -1573,7 +1572,7 @@ class NdbOperation {
   };
   /*
    * Zart
-   * Expand it to 16 bits
+   * Expanded it to 16 bits
    */
   Uint16 m_flags;
 

--- a/storage/ndb/include/ndbapi/NdbOperation.hpp
+++ b/storage/ndb/include/ndbapi/NdbOperation.hpp
@@ -1125,6 +1125,12 @@ class NdbOperation {
       OO_NOWAIT = 0x1000,
       OO_GET_FINAL_VALUE = 0x2000,
       OO_REPLICA_APPLIER = 0x4000,
+      /*
+       * Zart
+       * TODO (Zhao)
+       * Force operation ignore TTL
+       */
+      OO_TTL_IGNORE    = 0x8000
     };
 
     /* An operation-specific abort option.
@@ -1562,9 +1568,14 @@ class NdbOperation {
     OF_DISABLE_FK = 0x10,
     OF_NOWAIT = 0x20,
     OF_BLOB_PART_READ = 0x40,
-    OF_REPLICA_APPLIER = 0x80
+    OF_REPLICA_APPLIER = 0x80,
+    OF_TTL_IGNORE = 0x100
   };
-  Uint8 m_flags;
+  /*
+   * Zart
+   * Expand it to 16 bits
+   */
+  Uint16 m_flags;
 
   Uint8 _unused1;
 

--- a/storage/ndb/include/ndbapi/NdbScanOperation.hpp
+++ b/storage/ndb/include/ndbapi/NdbScanOperation.hpp
@@ -162,7 +162,8 @@ class NdbScanOperation : public NdbOperation {
                 SO_PARTITION_ID = 0x10,
                 SO_INTERPRETED  = 0x20,
                 SO_CUSTOMDATA   = 0x40,
-                SO_PART_INFO    = 0x80
+                SO_PART_INFO    = 0x80,
+                SO_TTL_IGNORE   = 0x100
     };
 
     /* Flags controlling scan behaviour

--- a/storage/ndb/plugin/ha_ndbcluster.h
+++ b/storage/ndb/plugin/ha_ndbcluster.h
@@ -738,6 +738,11 @@ class ha_ndbcluster : public handler, public Partition_handler {
   NdbIndexScanOperation *m_multi_cursor;
 
   int update_stats(THD *thd, bool do_read_stat);
+  /*
+   * Zart
+   * TTL
+   */
+  bool m_ttl_ignore;
 };
 
 bool is_cluster_failure_code(int error);

--- a/storage/ndb/src/common/debugger/signaldata/DictTabInfo.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/DictTabInfo.cpp
@@ -93,6 +93,8 @@ DictTabInfo::TableMapping[] = {
   DTI_MAP_INT(Table, FullyReplicatedTriggerId, FullyReplicatedTriggerId),
   DTI_MAP_INT(Table, UseVarSizedDiskDataFlag, UseVarSizedDiskDataFlag),
   DTI_MAP_INT(Table, HashFunctionFlag, HashFunctionFlag),
+  DTI_MAP_INT(Table, TTLSec, TTLSec),
+  DTI_MAP_INT(Table, TTLColumnNo, TTLColumnNo),
   DTIBREAK(AttributeName)
 };
 
@@ -211,6 +213,9 @@ void DictTabInfo::Table::init() {
   PartitionCount = 0;
   HashFunctionFlag = 0;
   UseVarSizedDiskDataFlag = 0;
+
+  TTLSec = RNIL;
+  TTLColumnNo = RNIL;
 }
 
 void DictTabInfo::Attribute::init() {

--- a/storage/ndb/src/common/debugger/signaldata/LqhKey.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/LqhKey.cpp
@@ -84,6 +84,7 @@ bool printLQHKEYREQ(FILE *output, const Uint32 *theData, Uint32 len,
   if (LqhKeyReq::getNoTriggersFlag(reqInfo)) fprintf(output, "NoTriggers ");
   if (LqhKeyReq::getUtilFlag(reqInfo)) fprintf(output, "UtilFlag ");
   if (LqhKeyReq::getNoWaitFlag(reqInfo)) fprintf(output, "NoWait ");
+  if(LqhKeyReq::getTTLIgnoreFlag(reqInfo)) fprintf(output, "ttl_ignore ");
 
   fprintf(output, "ScanInfo/noFiredTriggers: H\'%x\n", sig->scanInfo);
 

--- a/storage/ndb/src/common/debugger/signaldata/TcKeyReq.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/TcKeyReq.cpp
@@ -104,6 +104,9 @@ bool printTCKEYREQ(FILE *output, const Uint32 *theData, Uint32 len,
     if (sig->getPassQueueingFlag(sig->requestInfo))
       fprintf(output, " passQueue");
 
+    if (sig->getTTLIgnoreFlag(sig->requestInfo))
+      fprintf(output, " ttl_ignore");
+
     fprintf(output, "\n");
   }
 

--- a/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
+++ b/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
@@ -583,6 +583,18 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     "true" },
 
   {
+    CFG_DB_ENABLE_TTL,
+    "EnableTTL",
+    DB_TOKEN,
+    "whether enable TTL or not",
+    ConfigInfo::CI_USED,
+    false,
+    ConfigInfo::CI_BOOL,
+    "true",
+    "false",
+    "true" },
+
+  {
     CFG_DB_MAX_NUM_SCHEMA_OBJECTS,
     "MaxNoOfSchemaObjects",
     DB_TOKEN,

--- a/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
+++ b/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
@@ -583,18 +583,6 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     "true" },
 
   {
-    CFG_DB_ENABLE_TTL,
-    "EnableTTL",
-    DB_TOKEN,
-    "whether enable TTL or not",
-    ConfigInfo::CI_USED,
-    false,
-    ConfigInfo::CI_BOOL,
-    "true",
-    "false",
-    "true" },
-
-  {
     CFG_DB_MAX_NUM_SCHEMA_OBJECTS,
     "MaxNoOfSchemaObjects",
     DB_TOKEN,

--- a/storage/ndb/src/kernel/blocks/backup/Backup.cpp
+++ b/storage/ndb/src/kernel/blocks/backup/Backup.cpp
@@ -8029,6 +8029,12 @@ Backup::sendScanFragReq(Signal* signal,
     ScanFragReq::setKeyinfoFlag(req->requestInfo, 0);
     ScanFragReq::setTupScanFlag(req->requestInfo, 1);
     ScanFragReq::setNotInterpretedFlag(req->requestInfo, 1);
+    /*
+     * Zart
+     * TTL
+     * Ignore TTL in backup scan
+     */
+    ScanFragReq::setTTLIgnoreFragFlag(req->requestInfo, 1);
     if (ptr.p->is_lcp()) {
       ScanFragReq::setScanPrio(req->requestInfo, 1);
       ScanFragReq::setNoDiskFlag(req->requestInfo, 1);
@@ -14870,6 +14876,14 @@ void Backup::lcp_write_ctl_file(Signal *signal, BackupRecordPtr ptr) {
           dataFilePtr.p->m_lcp_inserts, dataFilePtr.p->m_lcp_writes,
           ptr.p->m_num_parts_in_this_lcp);
       print_extended_lcp_stat();
+      /*
+       * Zart
+       * TODO (Zhao)
+       * assert here
+       * m_row_count 1 == m_lcp_inserts 0
+       *
+       * SOVLED
+       */
       ndbrequire(ptr.p->m_save_error_code != 0 ||
                  ptr.p->m_row_count == dataFilePtr.p->m_lcp_inserts ||
                  ((ptr.p->m_num_parts_in_this_lcp !=

--- a/storage/ndb/src/kernel/blocks/dbacc/Dbacc.hpp
+++ b/storage/ndb/src/kernel/blocks/dbacc/Dbacc.hpp
@@ -1211,8 +1211,8 @@ private:
 #endif
   bool is_ttl_table(Fragmentrec* fragptr) {
     ndbrequire(fragptr != nullptr);
-    return (c_ttl_enabled &&
-            fragptr->ttlSec != RNIL && fragptr->ttlColumnNo != RNIL);
+    return (fragptr->ttlSec != RNIL &&
+            fragptr->ttlColumnNo != RNIL);
   }
 
  public:
@@ -1266,7 +1266,6 @@ private:
   static const Uint32 c_transient_pool_count = 2;
   TransientFastSlotPool *c_transient_pools[c_transient_pool_count];
   Bitmask<1> c_transient_pools_shrinking;
-  Uint32 c_ttl_enabled;
 
 public:
   Dbacc *m_curr_acc;

--- a/storage/ndb/src/kernel/blocks/dbacc/DbaccMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbacc/DbaccMain.cpp
@@ -481,10 +481,6 @@ void Dbacc::execREAD_CONFIG_REQ(Signal *signal) {
   initRecords(p);
 
   initialiseRecordsLab(signal, 0, ref, senderData);
-  c_ttl_enabled = 0;
-  ndb_mgm_get_int_parameter(p, CFG_DB_ENABLE_TTL,
-                            &c_ttl_enabled);
-  g_eventLogger->info("Zart, [ACC]TTL enabled: %u", c_ttl_enabled);
   return;
 }
 

--- a/storage/ndb/src/kernel/blocks/dbdict/Dbdict.hpp
+++ b/storage/ndb/src/kernel/blocks/dbdict/Dbdict.hpp
@@ -287,6 +287,8 @@ class Dbdict : public SimulatedBlock {
     {
       m_upgrade_trigger_handling.m_upgrade = false;
       fullyReplicatedTriggerId = RNIL;
+      ttlSec = RNIL;
+      ttlColumnNo = RNIL;
     }
     static bool isCompatible(Uint32 type)
     { return DictTabInfo::isTable(type) || DictTabInfo::isIndex(type); }
@@ -482,6 +484,12 @@ class Dbdict : public SimulatedBlock {
 
     // pending background request (IndexStatRep::RequestType)
     Uint32 indexStatBgRequest;
+
+    /*
+     * TTL
+     */
+    Uint32 ttlSec;
+    Uint32 ttlColumnNo;
   };
   typedef TransientPool<TableRecord> TableRecord_pool;
   typedef DLFifoList<TableRecord_pool> TableRecord_list;

--- a/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
@@ -4798,7 +4798,6 @@ public:
   Uint64 c_total_rows_copy_fragreq;
   Uint64 c_total_words_copy_fragreq;
 #endif
-  Uint32 c_ttl_enabled;
 
   void update_cpu_usage(Signal*);
   void adjust_copyFragReq_rates(bool);

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
@@ -2650,11 +2650,11 @@ void Dblqh::execCREATE_TAB_REQ(Signal *signal) {
     jam();
     req->hashFunctionFlag = 0;
   }
-  if (signal->length() < CreateTabReq::NewSignalLengthLDMWithTTL) {
-    jam();
-    req->ttlSec = RNIL;
-    req->ttlColumnNo = RNIL;
-  }
+  /*
+   * CreateTabReq is a local signal, no need to consider
+   * the length compatibility.
+   */
+  ndbassert(signal->length() == CreateTabReq::NewSignalLengthLDMWithTTL);
 
   DEB_HASH(("(%u) lqh_tab(%u) hashFunctionFlag: %u",
             instance(),

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
@@ -2521,13 +2521,6 @@ void Dblqh::execREAD_CONFIG_REQ(Signal *signal) {
   pc.m_block = this;
   m_databaseRecordPool.init(RT_DBLQH_DATABASE_RECORD, pc);
   m_databaseRecordHash.setSize(16384);
-
-  c_ttl_enabled = 0;
-  ndb_mgm_get_int_parameter(p, CFG_DB_ENABLE_TTL,
-                            &c_ttl_enabled);
-#ifdef TTL_DEBUG
-  g_eventLogger->info("Zart, [LQH]TTL enabled: %u", c_ttl_enabled);
-#endif  // TTL_DEBUG
 }
 
 void Dblqh::init_restart_synch() {
@@ -4586,8 +4579,7 @@ bool Dblqh::is_ttl_table(Uint32 table_id) {
   TablerecPtr t_tabptr;
   t_tabptr.i = table_id;
   ptrCheckGuard(t_tabptr, ctabrecFileSize, tablerec);
-  return (c_ttl_enabled &&
-          t_tabptr.p->m_ttl_sec != RNIL &&
+  return (t_tabptr.p->m_ttl_sec != RNIL &&
           t_tabptr.p->m_ttl_col_no != RNIL);
 }
 void

--- a/storage/ndb/src/kernel/blocks/dbtc/Dbtc.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/Dbtc.hpp
@@ -3398,7 +3398,6 @@ class Dbtc : public SimulatedBlock {
   Uint32 m_max_writes_per_trans;
   Uint32 c_trans_error_loglevel;
   Uint32 m_take_over_operations;
-  Uint32 c_ttl_enabled;
 
   void dump_trans(ApiConnectRecordPtr transPtr);
   bool hasOp(ApiConnectRecordPtr transPtr, Uint32 op);
@@ -3531,8 +3530,7 @@ class Dbtc : public SimulatedBlock {
 
   bool is_ttl_table(TableRecord* tabptr) {
     ndbrequire(tabptr != nullptr);
-    return (c_ttl_enabled &&
-            tabptr->m_ttl_sec != RNIL &&
+    return (tabptr->m_ttl_sec != RNIL &&
             tabptr->m_ttl_col_no != RNIL);
   }
   bool is_ttl_table(Uint32 table_id) {

--- a/storage/ndb/src/kernel/blocks/dbtc/Dbtc.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/Dbtc.hpp
@@ -1571,6 +1571,10 @@ class Dbtc : public SimulatedBlock {
 
     Uint32 scanTakeOverInd;
     Uint32 unlockNodeId; /* NodeId for unlock operation */
+    /* Zart
+     * TTL
+     */
+    Uint8 m_ttl_ignore;
     /* End of TCKEYREQ/TCINDXREQ only fields */
   };
 
@@ -1688,6 +1692,9 @@ class Dbtc : public SimulatedBlock {
     Uint8 noOfDistrKeys;
     Uint8 hasVarKeys;
     Uint8 m_disk_based;
+    Uint32 m_ttl_sec;
+    Uint32 m_ttl_col_no;
+    Uint32 m_primary_table_id;
 
     bool checkTable(Uint32 schemaVersion) const {
       return !get_dropping() &&
@@ -2277,7 +2284,8 @@ class Dbtc : public SimulatedBlock {
   void sendDihGetNodesLab(Signal *, ScanRecordPtr, ApiConnectRecordPtr);
   bool sendDihGetNodeReq(Signal *, ScanRecordPtr,
                          ScanFragLocationPtr &fragLocationPtr,
-                         Uint32 scanFragId, bool is_multi_spj_scan);
+                         Uint32 scanFragId, bool is_multi_spj_scan,
+                         bool ttl_can_go_to_replica);
   void get_next_frag_location(ScanFragLocationPtr fragLocationPtr,
                               Uint32 &fragId, Uint32 &primaryBlockRef,
                               Uint32 &preferredBlockRef);
@@ -3390,6 +3398,7 @@ class Dbtc : public SimulatedBlock {
   Uint32 m_max_writes_per_trans;
   Uint32 c_trans_error_loglevel;
   Uint32 m_take_over_operations;
+  Uint32 c_ttl_enabled;
 
   void dump_trans(ApiConnectRecordPtr transPtr);
   bool hasOp(ApiConnectRecordPtr transPtr, Uint32 op);
@@ -3519,6 +3528,21 @@ class Dbtc : public SimulatedBlock {
                               ApiConnectRecordPtr apiConnectptr);
 
   void printCrashApiConnectrec(ApiConnectRecordPtr apiConnectptr);
+
+  bool is_ttl_table(TableRecord* tabptr) {
+    ndbrequire(tabptr != nullptr);
+    return (c_ttl_enabled &&
+            tabptr->m_ttl_sec != RNIL &&
+            tabptr->m_ttl_col_no != RNIL);
+  }
+  bool is_ttl_table(Uint32 table_id) {
+    ndbrequire(table_id != RNIL);
+    TableRecordPtr tmp_tabPtr;
+    tmp_tabPtr.i = table_id;
+    ptrCheckGuard(tmp_tabPtr, ctabrecFilesize, tableRecord);
+    return is_ttl_table(tmp_tabPtr.p);
+  }
+
 public:
   DistributionHandler m_distribution_handle;
 

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
@@ -1448,12 +1448,6 @@ void Dbtc::execREAD_CONFIG_REQ(Signal *signal) {
   }
   m_databaseRecordPool.init(RT_DBTC_DATABASE_RECORD, pc);
   m_databaseRecordHash.setSize(16384);
-  c_ttl_enabled = 0;
-  ndb_mgm_get_int_parameter(p, CFG_DB_ENABLE_TTL,
-                            &c_ttl_enabled);
-#ifdef TTL_DEBUG
-  g_eventLogger->info("Zart, [TC]TTL enabled: %u", c_ttl_enabled);
-#endif  // TTL_DEBUG
 }
 
 void Dbtc::execSTTOR(Signal *signal) {

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
@@ -1031,6 +1031,21 @@ void Dbtc::execTC_SCHVERREQ(Signal *signal) {
     jam();
     tabptr.p->m_flags |= TableRecord::TR_FULLY_REPLICATED;
   }
+  /*
+   * Zart
+   * TTL
+   */
+  tabptr.p->m_ttl_sec = req->ttlSec;
+  tabptr.p->m_ttl_col_no = req->ttlColumnNo;
+  tabptr.p->m_primary_table_id = req->primaryTableId;
+#ifdef TTL_DEBUG
+  if (NEED_PRINT(tabptr.i)) {
+    g_eventLogger->info("Zart, [TC]Gen Tablerec, table_id: %u, TTL sec: %u, "
+                        "TTL column no: %u, primaryTableId: %u",
+        tabptr.i, tabptr.p->m_ttl_sec, tabptr.p->m_ttl_col_no,
+        tabptr.p->m_primary_table_id);
+  }
+#endif  // TTL_DEBUG
 
   tabptr.p->m_disk_based = req->diskBased;
 
@@ -1433,6 +1448,12 @@ void Dbtc::execREAD_CONFIG_REQ(Signal *signal) {
   }
   m_databaseRecordPool.init(RT_DBTC_DATABASE_RECORD, pc);
   m_databaseRecordHash.setSize(16384);
+  c_ttl_enabled = 0;
+  ndb_mgm_get_int_parameter(p, CFG_DB_ENABLE_TTL,
+                            &c_ttl_enabled);
+#ifdef TTL_DEBUG
+  g_eventLogger->info("Zart, [TC]TTL enabled: %u", c_ttl_enabled);
+#endif  // TTL_DEBUG
 }
 
 void Dbtc::execSTTOR(Signal *signal) {
@@ -4094,12 +4115,19 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
         TcKeyReq::getReadCommittedBaseFlag(Treqinfo);
 
     regCachePtr->m_noWait = TcKeyReq::getNoWaitFlag(Treqinfo);
+    regCachePtr->m_ttl_ignore = TcKeyReq::getTTLIgnoreFlag(Treqinfo);
   } else {
     TkeyLength = TcKeyReq::getKeyLength(Treqinfo);
     TattrLen = TcKeyReq::getAttrinfoLen(tcKeyReq->attrLen);
     titcLenAiInTckeyreq = TcKeyReq::getAIInTcKeyReq(Treqinfo);
     regCachePtr->m_read_committed_base = 0;
     regCachePtr->m_noWait = 0;
+    /*
+     * Zart
+     * TODO (Zhao)
+     * unable to ignore TTL in ShortTcKeyReq?
+     */
+    regCachePtr->m_ttl_ignore = 0;
   }
   bool util_flag = ZFALSE;
   if (unlikely(refToMain(sendersBlockRef) == DBUTIL))
@@ -4577,6 +4605,9 @@ void Dbtc::tckeyreq050Lab(Signal *signal, CacheRecordPtr const cachePtr,
   TcConnectRecord *const regTcPtr = tcConnectptr.p;
   ApiConnectRecord *const regApiPtr = apiConnectptr.p;
 
+  bool ttl_table = false;
+  bool ttl_can_go_to_replica = false;
+
   UintR TtcTimer = ctcTimer;
   UintR ThashValue = thashValue;
   UintR TdistrHashValue = tdistrHashValue;
@@ -4593,6 +4624,35 @@ void Dbtc::tckeyreq050Lab(Signal *signal, CacheRecordPtr const cachePtr,
     terrorCode = localTabptr.p->getErrorCode(schemaVersion);
     TCKEY_abort(signal, 58, apiConnectptr);
     return;
+  }
+  /*
+   * Zart
+   * TTL
+   * if the current table is TTL table, check whether allow
+   * this operation to go to replica or not
+   */
+  {
+    Uint32 read_back = localTabptr.p->m_flags & TableRecord::TR_READ_BACKUP;
+    Uint32 fully_replicated =
+             localTabptr.p->m_flags & TableRecord::TR_FULLY_REPLICATED;
+    Uint32 op = regTcPtr->operation;
+    Uint32 op_count = regApiPtr->tcConnect.getCount();
+    Uint8 TopSimple = regTcPtr->opSimple;
+    Uint8 TopDirty = regTcPtr->dirtyOp;
+    Uint8 Tread_committed_base = regCachePtr->m_read_committed_base;
+
+    if (DictTabInfo::isTable(localTabptr.p->tableType)) {
+      ttl_table = is_ttl_table(localTabptr.p);
+    } else {
+      ttl_table = is_ttl_table(localTabptr.p->m_primary_table_id);
+    }
+
+    if (!ttl_table ||
+        (ttl_table && (read_back || fully_replicated) && op == ZREAD &&
+        (TopSimple != 0 || TopDirty != 0 || Tread_committed_base) &&
+        op_count == 1)) {
+      ttl_can_go_to_replica = true;
+    }
   }
 
   /**
@@ -4628,6 +4688,19 @@ void Dbtc::tckeyreq050Lab(Signal *signal, CacheRecordPtr const cachePtr,
           regCachePtr->m_read_committed_base) {
         jam();
         req->anyNode = 1;
+        /*
+         * Zart
+         * TTL
+         * [CASE 1.1] key look-up on TTL & FULLY_REPLICATED table
+         */
+        if (!ttl_can_go_to_replica) {
+#ifdef TTL_DEBUG
+          g_eventLogger->info("Zart, Dbtc::tckeyreq050Lab(), FULLY_REPLICATED "
+                              "table: %u is not allowed to go to any node",
+                              localTabptr.i);
+#endif  // TTL_DEBUG
+          req->anyNode = 0;
+        }
       }
     } else if (Tspecial_op_flags & TcConnectRecord::SOF_REORG_COPY) {
       /**
@@ -4736,6 +4809,50 @@ void Dbtc::tckeyreq050Lab(Signal *signal, CacheRecordPtr const cachePtr,
 
   regCachePtr->fragmentDistributionKey = (tnodeinfo >> 16) & 255;
   Uint32 TreadBackup = (localTabptr.p->m_flags & TableRecord::TR_READ_BACKUP);
+  /*
+   * Zart
+   * If the current table is TTL table, adjust TreadBackup based on
+   * ttl_can_go_to_replica
+   * [CASE 1.2] key look-up on TTL & READ_BACKUP table
+   */
+  if (ttl_table && !ttl_can_go_to_replica) {
+#ifdef TTL_DEBUG
+    g_eventLogger->info("Zart, Dbtc::tckeyreq050Lab(), DISALLOW the operation to go to "
+                        "replica for ttl table id: %u, op: %u"
+                        "read_backup: %u, fully_replicated: %u "
+                        "TopSimple: %u, TopDirty: %u, "
+                        "m_write_count: %u, m_exec_count: %u, "
+                        "m_exec_write_count: %u, m_simple_read_count: %u "
+                        "ApiConnectRecord: %u, count: %u",
+                        localTabptr.i, Toperation,
+                        TreadBackup,
+                        localTabptr.p->m_flags & TableRecord::TR_FULLY_REPLICATED,
+                        regTcPtr->opSimple, regTcPtr->dirtyOp,
+                        regApiPtr->m_write_count, regApiPtr->m_exec_count,
+                        regApiPtr->m_exec_write_count, regApiPtr->m_simple_read_count,
+                        apiConnectptr.i,
+                        regApiPtr->tcConnect.getCount());
+#endif  // TTL_DEBUG
+    TreadBackup = 0;
+  } else if (ttl_table) {
+#ifdef TTL_DEBUG
+    g_eventLogger->info("Zart, Dbtc::tckeyreq050Lab(), ALLOW the operation to go to "
+                        "replica for ttl table id: %u, op: %u"
+                        "read_backup: %u, fully_replicated: %u "
+                        "TopSimple: %u, TopDirty: %u, "
+                        "m_write_count: %u, m_exec_count: %u, "
+                        "m_exec_write_count: %u, m_simple_read_count: %u "
+                        "ApiConnectRecord: %u, count: %u",
+                        localTabptr.i, Toperation,
+                        TreadBackup,
+                        localTabptr.p->m_flags & TableRecord::TR_FULLY_REPLICATED,
+                        regTcPtr->opSimple, regTcPtr->dirtyOp,
+                        regApiPtr->m_write_count, regApiPtr->m_exec_count,
+                        regApiPtr->m_exec_write_count, regApiPtr->m_simple_read_count,
+                        apiConnectptr.i,
+                        regApiPtr->tcConnect.getCount());
+#endif  // TTL_DEBUG
+  }
   if (Toperation == ZREAD || Toperation == ZREAD_EX) {
     Uint8 TopSimple = regTcPtr->opSimple;
     Uint8 TopDirty = regTcPtr->dirtyOp;
@@ -4871,9 +4988,9 @@ void Dbtc::tckeyreq050Lab(Signal *signal, CacheRecordPtr const cachePtr,
     if (regTcPtr->tcNodedata[0] != cownNodeid &&  // Primary replica is remote, and
         !checkingFKConstraint &&                  // Not verifying a FK-constraint.
         !batchUnsafe &&                           // Not an unsafe batched read
-        ((TopSimple != 0 && TopDirty == 0) ||                        // 1)
-         (TreadBackup != 0 && (TopSimple != 0 || TopDirty != 0)) ||  // 2)
-         (TreadBackup != 0 && regCachePtr->m_read_committed_base)))  // 3)
+        ((TopSimple != 0 && TopDirty == 0 && ttl_can_go_to_replica) ||   // 1)
+         (TreadBackup != 0 && (TopSimple != 0 || TopDirty != 0)) ||      // 2)
+         (TreadBackup != 0 && regCachePtr->m_read_committed_base)))      // 3)
     {
       jamDebug();
       /*-------------------------------------------------------------*/
@@ -5262,6 +5379,7 @@ void Dbtc::sendlqhkeyreq(Signal *signal, BlockReference TBRef,
                            ApiConnectRecord::TF_REPLICA_APPLIER;
   LqhKeyReq::setReplicaApplierFlag(Tdata10,
     (replica_applier == ApiConnectRecord::TF_REPLICA_APPLIER));
+  LqhKeyReq::setTTLIgnoreFlag(Tdata10, regCachePtr->m_ttl_ignore);
 
   /* -----------------------------------------------------------------------
    * If we are sending a short LQHKEYREQ, then there will be some AttrInfo
@@ -11216,6 +11334,7 @@ void Dbtc::logScanTimeout(Signal *signal, ScanFragRecPtr scanFragPtr,
   bool range = ScanFragReq::getRangeScanFlag(scanPtr.p->scanRequestInfo);
   bool nodisk = ScanFragReq::getNoDiskFlag(scanPtr.p->scanRequestInfo);
   bool aggregation = ScanFragReq::getAggregationFlag(scanPtr.p->scanRequestInfo);
+  bool ttl_ignore = ScanFragReq::getTTLIgnoreFragFlag(scanPtr.p->scanRequestInfo);
 
   Uint32 runningCount = 0, deliveredCount = 0, queuedCount = 0;
   {
@@ -11235,7 +11354,7 @@ void Dbtc::logScanTimeout(Signal *signal, ScanFragRecPtr scanFragPtr,
 
   g_eventLogger->info("TC %u : Scan timeout "
                       "[0x%08x 0x%08x] state %u tab %u dist %u ri 0x%x "
-                      " (%s%s%s%s%s%s%s) frags r %u d %u q %u "
+                      " (%s%s%s%s%s%s%s%s) frags r %u d %u q %u "
                       "frag state %u, fid %u node %u instance %u",
                       instance(),
                       apiPtr.p->transid[0],
@@ -11251,6 +11370,7 @@ void Dbtc::logScanTimeout(Signal *signal, ScanFragRecPtr scanFragPtr,
                       (range?"range ":""),
                       (nodisk?"nodisk ":"disk "),
                       (aggregation?"aggregation ":"noaggregation "),
+                      (ttl_ignore?"ttl ignore" : "ttl"),
                       runningCount,
                       deliveredCount,
                       queuedCount,
@@ -15756,6 +15876,7 @@ Uint32 Dbtc::initScanrec(ScanRecordPtr scanptr, const ScanTabReq *scanTabReq,
   ScanFragReq::setNoDiskFlag(tmp, ScanTabReq::getNoDiskFlag(ri));
   ScanFragReq::setMultiFragFlag(tmp, ScanTabReq::getMultiFragFlag(ri));
   ScanFragReq::setAggregationFlag(tmp, ScanTabReq::getAggregation(ri));
+  ScanFragReq::setTTLIgnoreFragFlag(tmp, ScanTabReq::getTTLIgnoreFlag(ri));
 
   if (unlikely(ScanTabReq::getViaSPJFlag(ri))) {
     jam();
@@ -15945,6 +16066,21 @@ void Dbtc::diFcountReqLab(Signal *signal, ScanRecordPtr scanptr,
        scanptr.p->m_read_committed_base) &&
       ((tabPtr.p->m_flags & TableRecord::TR_FULLY_REPLICATED) != 0);
 
+  /*
+   * Zart
+   * TTL
+   * TTL & FULLY_REPLICATED table
+   * we don't need to handle scanptr.p->m_read_any_node here,
+   * since we will handle this situation in 
+   * execDIH_SCAN_TAB_CONF() ->
+   * sendDihGetNodesLab() ->
+   * sendDihGetNodeReq()
+   * below
+   *
+   * if m_read_any_node == 1
+   *   This is a committed read. We want any fragment which is readable.
+   */
+  
   /*************************************************
    * THE FIRST STEP TO RECEIVE IS SUCCESSFULLY COMPLETED.
    ***************************************************/
@@ -16102,6 +16238,52 @@ void Dbtc::sendDihGetNodesLab(Signal *signal, ScanRecordPtr scanptr,
     fragLocationPtr.p->m_first_index = 0;
     fragLocationPtr.p->m_next_index = 0;
   }
+  /*
+   * Zart
+   * TTL
+   * if the current table is TTL table, check whether allow
+   * this scan to go to replica or not
+   */
+  bool ttl_can_go_to_replica = false;
+  {
+    Uint32 read_back = tabPtr.p->m_flags & TableRecord::TR_READ_BACKUP;
+    Uint32 fully_replicated =
+             tabPtr.p->m_flags & TableRecord::TR_FULLY_REPLICATED;
+    ndbassert(apiConnectptr.p->buddyPtr != RNIL);
+    ApiConnectRecordPtr buddyApiPtr;
+    buddyApiPtr.i = apiConnectptr.p->buddyPtr;
+    ndbrequire(c_apiConnectRecordPool.getValidPtr(buddyApiPtr));
+
+    Uint32 op_count = buddyApiPtr.p->tcConnect.getCount();
+
+    bool ttl_table = false;
+    if (DictTabInfo::isTable(tabPtr.p->tableType)) {
+      ttl_table = is_ttl_table(tabPtr.p);
+    } else {
+      ttl_table = is_ttl_table(tabPtr.p->m_primary_table_id);
+    }
+
+    bool rc = ScanFragReq::getReadCommittedFlag(scanptr.p->scanRequestInfo);
+    bool rcb = scanptr.p->m_read_committed_base;
+    bool lockmode = ScanFragReq::getLockMode(scanptr.p->scanRequestInfo);
+    bool holdlock = ScanFragReq::getHoldLockFlag(scanptr.p->scanRequestInfo);
+
+#ifdef TTL_DEBUG
+    g_eventLogger->info("Zart, Dbtc::sendDihGetNodesLab(), ttl_table: [%u]%u, "
+                        "read_back: %u, fully_replicated: %u rc: %u, lockmode: %u, "
+                        "holdlock: %u, "
+                        "ApiConnectRecord: %u, count: %u",
+                        tabPtr.i,
+                        ttl_table, read_back, fully_replicated,
+                        rc, lockmode, holdlock,
+                        buddyApiPtr.i, op_count);
+#endif  // TTL_DEBUG
+    if (!ttl_table || (ttl_table && (read_back || fully_replicated) &&
+        (rc || rcb) && op_count == 0)) {
+      ndbrequire(!ttl_table || (!lockmode && !holdlock));
+      ttl_can_go_to_replica = true;
+    }
+  }
   do {
     ndbassert(scanP->scanState == ScanRecord::RUNNING);
     ndbassert(tabPtr.p->checkTable(schemaVersion) == true);
@@ -16138,7 +16320,8 @@ void Dbtc::sendDihGetNodesLab(Signal *signal, ScanRecordPtr scanptr,
 
     const bool success =
         sendDihGetNodeReq(signal, scanptr, fragLocationPtr,
-                          scanP->scanNextFragId, is_multi_spj_scan);
+                          scanP->scanNextFragId, is_multi_spj_scan,
+                          ttl_can_go_to_replica);
     if (unlikely(!success)) {
       jam();
       return;  // sendDihGetNodeReq called scanError() upon failure.
@@ -16346,7 +16529,8 @@ void Dbtc::releaseScanResources(Signal *signal, ScanRecordPtr scanPtr,
 
 bool Dbtc::sendDihGetNodeReq(Signal *signal, ScanRecordPtr scanptr,
                              ScanFragLocationPtr &fragLocationPtr,
-                             Uint32 scanFragId, bool is_multi_spj_scan) {
+                             Uint32 scanFragId, bool is_multi_spj_scan,
+                             bool ttl_can_go_to_replica) {
   jamDebug();
   DiGetNodesReq *const req = (DiGetNodesReq *)&signal->theData[0];
 
@@ -16355,6 +16539,21 @@ bool Dbtc::sendDihGetNodeReq(Signal *signal, ScanRecordPtr scanptr,
   Uint32 distr_key_indicator = ZTRUE;
   req->scan_indicator = ZTRUE;
   req->anyNode = scanptr.p->m_read_any_node;
+  /*
+   * Zart
+   * TTL
+   * [CASE 2.1 ]Scan on TTL & FULLY_REPLICATED table
+   */
+  if (!ttl_can_go_to_replica) {
+#ifdef TTL_DEBUG
+    g_eventLogger->info("Zart,  Dbtc::sendDihGetNodeReq(), ignore FULLY_REPLICATED "
+                         "for TTL table id: [%u], frag id: %u, m_read_any_node before: %u",
+                          scanptr.p->scanTableref,
+                          scanFragId,
+                          scanptr.p->m_read_any_node);
+#endif  // TTL_DEBUG
+    req->anyNode = 0;
+  }
   req->jamBufferPtr = jamBuffer();
   req->get_next_fragid_indicator = 0;
   req->only_readable_nodes = 1;
@@ -16432,6 +16631,26 @@ bool Dbtc::sendDihGetNodeReq(Signal *signal, ScanRecordPtr scanptr,
    */
   NodeId primaryNodeId = nodeId;
   Uint32 TreadBackup = (tabPtr.p->m_flags & TableRecord::TR_READ_BACKUP);
+  /*
+   * Zart
+   * TTL
+   * Since READ_BACKUP will read replica instead of primary, it doesn't
+   * work with TTL table's read what you have locked
+   * Skip READ_BACKUP for TTL table
+   *
+   * [CASE 2.2] Scan on TTL & READ_BACKUP table
+   */
+  if (!ttl_can_go_to_replica) {
+#ifdef TTL_DEBUG
+    g_eventLogger->info("Zart,  Dbtc::sendDihGetNodeReq(), ignore TR_READ_BACKUP "
+                         "for TTL table id: [%u], frag id: %u, TreadBackup before: %u",
+                          tabPtr.i,
+                          scanFragId,
+                          TreadBackup);
+#endif  // TTL_DEBUG
+    TreadBackup = false;
+  }
+
   if (TreadBackup &&
       (ScanFragReq::getReadCommittedFlag(scanptr.p->scanRequestInfo) ||
        scanptr.p->m_read_committed_base)) {
@@ -18228,6 +18447,9 @@ void Dbtc::initTable(Signal *signal) {
     tabptr.p->noOfDistrKeys = 0;
     tabptr.p->hasVarKeys = 0;
     tabptr.p->databaseRecord = RNIL64;
+    tabptr.p->m_ttl_sec = RNIL;
+    tabptr.p->m_ttl_col_no = RNIL;
+    tabptr.p->m_primary_table_id = RNIL;
   }  // for
 }  // Dbtc::initTable()
 

--- a/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
@@ -3952,8 +3952,6 @@ public:
   Uint32 c_min_list_size[MAX_FREE_LIST + 1];
   Uint32 c_max_list_size[MAX_FREE_LIST + 1];
 
-  Uint32 c_ttl_enabled;
-
   void initGlobalTemporaryVars();
   void reportMemoryUsage(Signal *signal, int incDec);
 
@@ -4399,8 +4397,7 @@ public:
 
   bool is_ttl_table(Tablerec* tabptr) {
     ndbassert(tabptr != nullptr);
-    return (c_ttl_enabled &&
-            tabptr->m_ttl_sec != RNIL && tabptr->m_ttl_col_no != RNIL);
+    return (tabptr->m_ttl_sec != RNIL && tabptr->m_ttl_col_no != RNIL);
   }
 
   bool is_ttl_table(Uint32 table_id) {

--- a/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
@@ -2706,6 +2706,10 @@ private:
                                 LinearSectionPtr ptr[],
                                 Uint32 nptr);
 
+  int checkTTL(Tablerec* regTabPtr,
+               KeyReqStruct *req_struct,
+               bool* has_error,
+               int* err_no);
 // *****************************************************************
 // Setting up the environment for reads, inserts, updates and deletes.
 // *****************************************************************

--- a/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
@@ -982,7 +982,9 @@ struct Operationrec {
     m_commit_state(CommitNotStarted),
     m_any_value(0),
     op_type(ZREAD),
-    trans_state(Uint32(TRANS_DISCONNECTED))
+    trans_state(Uint32(TRANS_DISCONNECTED)),
+    original_op_type(ZREAD),
+    ttl_ignore(0)
   {
     op_struct.bit_field.in_active_list = false;
     op_struct.bit_field.tupVersion = ZNIL;
@@ -1144,6 +1146,12 @@ struct Operationrec {
       RF_MULTI_NOT_EXIST = 3,  /* Refresh op !first in trans, row deleted */
       RF_MULTI_EXIST = 4       /* Refresh op !first in trans, row exists */
     };
+    /*
+     * Zart
+     * keep original operation type
+     */
+    Uint32 original_op_type;
+    Uint8 ttl_ignore;
   };
 
   Uint32 m_base_header_bits;
@@ -1307,7 +1315,9 @@ Uint32 cnoOfMaxAllocatedTriggerRec;
           deferredInsertTriggers(triggerPool),
           deferredUpdateTriggers(triggerPool),
           deferredDeleteTriggers(triggerPool),
-          tuxCustomTriggers(triggerPool) {}
+          tuxCustomTriggers(triggerPool),
+          m_ttl_sec(RNIL),
+          m_ttl_col_no(RNIL) {}
 
     AttributeMask notNullAttributeMask;
     AttributeMask blobAttributeMask;
@@ -1493,6 +1503,12 @@ Uint32 cnoOfMaxAllocatedTriggerRec;
     } m_reorg_suma_filter;
     State tableStatus;
     Local_key m_default_value_location;
+
+    /*
+     * TTL
+     */
+    Uint32 m_ttl_sec;
+    Uint32 m_ttl_col_no;
   };
   Uint32 m_read_ctl_file_data[BackupFormat::LCP_CTL_FILE_BUFFER_SIZE_IN_WORDS];
   /*
@@ -3932,6 +3948,8 @@ public:
   Uint32 c_min_list_size[MAX_FREE_LIST + 1];
   Uint32 c_max_list_size[MAX_FREE_LIST + 1];
 
+  Uint32 c_ttl_enabled;
+
   void initGlobalTemporaryVars();
   void reportMemoryUsage(Signal *signal, int incDec);
 
@@ -4374,6 +4392,19 @@ public:
   Bitmask<1> c_transient_pools_shrinking;
 
   void release_scan_lock(ScanLockPtr);
+
+  bool is_ttl_table(Tablerec* tabptr) {
+    ndbassert(tabptr != nullptr);
+    return (c_ttl_enabled &&
+            tabptr->m_ttl_sec != RNIL && tabptr->m_ttl_col_no != RNIL);
+  }
+
+  bool is_ttl_table(Uint32 table_id) {
+    TablerecPtr tablePtr;
+    tablePtr.i = table_id;
+    ptrCheckGuard(tablePtr, cnoOfTablerec, tablerec);
+    return is_ttl_table(tablePtr.p);
+  }
 
 public:
   Dbtup *m_curr_tup;

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupGen.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupGen.cpp
@@ -668,13 +668,6 @@ void Dbtup::execREAD_CONFIG_REQ(Signal *signal) {
   NewVARIABLE *bat = allocateBat(1);
   bat[0].WA = &m_read_ctl_file_data[0];
   bat[0].nrr = (BackupFormat::LCP_CTL_FILE_BUFFER_SIZE_IN_WORDS * 4);
-
-  c_ttl_enabled = 0;
-  ndb_mgm_get_int_parameter(p, CFG_DB_ENABLE_TTL,
-                            &c_ttl_enabled);
-#ifdef TTL_DEBUG
-  g_eventLogger->info("Zart, [TUP]TTL enabled: %u", c_ttl_enabled);
-#endif  // TTL_DEBUG
 }
 
 void Dbtup::initRecords(const ndb_mgm_configuration_iterator *mgm_cfg) {

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupGen.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupGen.cpp
@@ -668,6 +668,13 @@ void Dbtup::execREAD_CONFIG_REQ(Signal *signal) {
   NewVARIABLE *bat = allocateBat(1);
   bat[0].WA = &m_read_ctl_file_data[0];
   bat[0].nrr = (BackupFormat::LCP_CTL_FILE_BUFFER_SIZE_IN_WORDS * 4);
+
+  c_ttl_enabled = 0;
+  ndb_mgm_get_int_parameter(p, CFG_DB_ENABLE_TTL,
+                            &c_ttl_enabled);
+#ifdef TTL_DEBUG
+  g_eventLogger->info("Zart, [TUP]TTL enabled: %u", c_ttl_enabled);
+#endif  // TTL_DEBUG
 }
 
 void Dbtup::initRecords(const ndb_mgm_configuration_iterator *mgm_cfg) {

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupMeta.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupMeta.cpp
@@ -192,6 +192,18 @@ void Dbtup::execCREATE_TAB_REQ(Signal *signal) {
             regTabPtr.i,
             req->hashFunctionFlag));
 
+  // Zart
+  regTabPtr.p->m_ttl_sec = req->ttlSec;
+  regTabPtr.p->m_ttl_col_no = req->ttlColumnNo;
+#ifdef TTL_DEBUG
+  if (NEED_PRINT(regTabPtr.i)) { /*req->tableId */
+    g_eventLogger->info("Zart, [TUP]Gen Tablerec, table_id: %u, TTL sec: %u, "
+                        "TTL column no: %u", regTabPtr.i,
+                        regTabPtr.p->m_ttl_sec,
+                        regTabPtr.p->m_ttl_col_no);
+  }
+#endif  // TTL_DEBUG
+
   regTabPtr.p->m_offsets[MM].m_disk_ref_offset = 0;
   regTabPtr.p->m_offsets[MM].m_null_words = 0;
   regTabPtr.p->m_offsets[MM].m_fix_header_size = 0;

--- a/storage/ndb/src/ndbapi/NdbDictionary.cpp
+++ b/storage/ndb/src/ndbapi/NdbDictionary.cpp
@@ -812,6 +812,31 @@ NdbDictionary::Table::use_new_hash_function() const
   return m_impl.m_use_new_hash_function;
 }
 
+void
+NdbDictionary::Table::setTTLSec(Uint32 sec) {
+  m_impl.m_ttl_sec = sec;
+}
+
+Uint32
+NdbDictionary::Table::getTTLSec() {
+  return m_impl.m_ttl_sec;
+}
+
+void
+NdbDictionary::Table::setTTLColumnNo(Uint32 no) {
+  m_impl.m_ttl_col_no = no;
+}
+
+Uint32
+NdbDictionary::Table::getTTLColumnNo() {
+  return m_impl.m_ttl_col_no;
+}
+
+bool
+NdbDictionary::Table::isTTLEnabled() {
+  return (m_impl.m_ttl_sec != RNIL && m_impl.m_ttl_col_no != RNIL);
+}
+
 /*****************************************************************
  * Index facade
  */

--- a/storage/ndb/src/ndbapi/NdbDictionaryImpl.hpp
+++ b/storage/ndb/src/ndbapi/NdbDictionaryImpl.hpp
@@ -399,6 +399,12 @@ class NdbTableImpl : public NdbDictionary::Table, public NdbDictObjectImpl {
 
   Uint32 m_hash_map_id;
   Uint32 m_hash_map_version;
+
+  /**
+   * TTL
+   */
+  Uint32 m_ttl_sec;
+  Uint32 m_ttl_col_no;
 };
 
 class NdbIndexImpl : public NdbDictionary::Index, public NdbDictObjectImpl {

--- a/storage/ndb/src/ndbapi/NdbOperationDefine.cpp
+++ b/storage/ndb/src/ndbapi/NdbOperationDefine.cpp
@@ -1532,5 +1532,14 @@ int NdbOperation::handleOperationOptions(const OperationType type,
     op->m_flags |= OF_NOWAIT;
   }
 
+  /*
+   * Zart
+   * Ignore TTL
+   */
+  if (opts->optionsPresent & OperationOptions::OO_TTL_IGNORE)
+  {
+    op->m_flags |= OF_TTL_IGNORE;
+  }
+
   return 0;
 }

--- a/storage/ndb/src/ndbapi/NdbOperationExec.cpp
+++ b/storage/ndb/src/ndbapi/NdbOperationExec.cpp
@@ -154,6 +154,12 @@ void NdbOperation::setRequestInfoTCKEYREQ(bool lastFlag, bool longSignal) {
       requestInfo,
       theReadCommittedBaseIndicator & static_cast<Uint8>(longSignal));
   TcKeyReq::setNoWaitFlag(requestInfo, (m_flags & OF_NOWAIT) != 0);
+  /*
+   * Zart
+   * TTL
+   */
+  TcKeyReq::setTTLIgnoreFlag(requestInfo,
+                          (m_flags & OF_TTL_IGNORE) != 0);
   req->requestInfo = requestInfo;
 }
 

--- a/storage/ndb/src/ndbapi/NdbScanOperation.cpp
+++ b/storage/ndb/src/ndbapi/NdbScanOperation.cpp
@@ -463,6 +463,15 @@ inline int NdbScanOperation::scanImpl(
     if (getBlobHandlesNdbRecord(m_transConnection, readMask) == -1) return -1;
   }
 
+  /*
+   * Zart
+   * TTL
+   */
+  if (options->optionsPresent & ScanOptions::SO_TTL_IGNORE) {
+    m_flags |= OF_TTL_IGNORE;
+  }
+
+
   /* Add interpreted code words to ATTRINFO signal
    * chain as necessary
    */
@@ -2165,6 +2174,12 @@ int NdbScanOperation::prepareSendScan(Uint32 /*aTC_ConnectPtr*/,
   if (m_aggregation_code != nullptr) {
     ScanTabReq::setAggregation(reqInfo, 1);
   }
+  /*
+   * Zart
+   * TTL
+   */
+  ScanTabReq::setTTLIgnoreFlag(reqInfo, (m_flags & OF_TTL_IGNORE) != 0);
+
   req->requestInfo = reqInfo;
   req->distributionKey = theDistributionKey;
   theSCAN_TABREQ->setLength(ScanTabReq::StaticLength + theDistrKeyIndicator_);


### PR DESCRIPTION
1. Support using CREATE TABLE statement to set TTL for a table Example, TTL 10 seconds based on column ttl_col: 'CREATE TABLE tbl (...ttl_col DATETIME) ENGINE = NDB, COMMENT="NDB_TABLE=TTL=10@ttl_col;'

2. Compatible with MySQL

3. Since it's part 1 of the entire PR, I leave the debug comments in the code base to be convenient for the following development, they will be removed finally in the last PR

NOTICE:
1. Undefined behaviors if set TTL on a parent FK table

2. When a row expires, it won't trigger any deletion trigger

4. In an in-flight transaction, the rows locked by this transaction are always visible to this transaction even if they expired before the transaction is committed.

TODO:
1. Support changing TTL for a table by using ALTER TABLE statement
2. Support purging expired rows automatically
3. Maybe support setting TTL on a TIMESTAMP column
5. More and more tests