### PR TITLE
RONDB-753 TTL feature [Patch 3 - optimization]

### DIFF
--- a/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/Dblqh.hpp
@@ -3862,6 +3862,9 @@ private:
                       Uint64 &inserts,
                       Uint64 &deletes,
                       Uint64& max_redo_percentage);
+  const Dbtux* get_c_tux() const {
+    return c_tux;
+  }
 
 private:
   bool validate_filter(Signal*);

--- a/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
@@ -2710,6 +2710,9 @@ private:
                KeyReqStruct *req_struct,
                bool* has_error,
                int* err_no);
+
+  void PrepareAccLockReq4RAL(void* scan_rec,
+                             Signal* signal);
 // *****************************************************************
 // Setting up the environment for reads, inserts, updates and deletes.
 // *****************************************************************

--- a/storage/ndb/src/kernel/blocks/dbtux/Dbtux.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/Dbtux.hpp
@@ -688,6 +688,11 @@ private:
    */
   void execTUX_MAINT_REQ(Signal *signal);
 
+  /*
+   * DbtuxScan.cpp
+   */
+  void PrepareAccLockReq4RAL(void* scan_rec_ptr,
+                             Signal* signal);
  private:
   /*
    * DbtuxNode.cpp


### PR DESCRIPTION
For read-committed scan operation, do the READ-AFTER-LOCKING checking only on expired rows.