### PR TITLE
RONDB-754: Avoid massive sizes of memory allocations.

### DIFF
--- a/storage/ndb/rest-server2/server/src/buffer_manager.hpp
+++ b/storage/ndb/rest-server2/server/src/buffer_manager.hpp
@@ -49,8 +49,8 @@ class RS_BufferArrayManager {
       throw std::runtime_error("Buffer size must be a multiple of 4");
     }
     Int64 preAllocateBuffers = globalConfigs.internal.preAllocatedBuffers;
-    reqBuffersStats            = {preAllocateBuffers, 0, preAllocateBuffers, 0};
-    respBuffersStats           = {preAllocateBuffers, 0, preAllocateBuffers, 0};
+    reqBuffersStats = {preAllocateBuffers, 0, preAllocateBuffers, 0};
+    respBuffersStats = {preAllocateBuffers, 0, preAllocateBuffers, 0};
     for (int i = 0; i < preAllocateBuffers; i++) {
       reqBufferArray.push_back(allocate_req_buffer());
       respBufferArray.push_back(allocate_resp_buffer());
@@ -81,10 +81,11 @@ class RS_BufferArrayManager {
   }
 
   static RS_Buffer allocate_req_buffer() {
-    auto reqBufferSize = globalConfigs.internal.reqBufferSize;
+    auto reqBufferSize = globalConfigs.internal.reqBufferSize * 2;
     auto buff = RS_Buffer();
     buff.buffer = new char[reqBufferSize];
     buff.size = reqBufferSize;
+    buff.next_allocated_buffer = 0;
     return buff;
   }
 
@@ -93,6 +94,7 @@ class RS_BufferArrayManager {
     auto buff = RS_Buffer();
     buff.buffer = new char[respBufferSize];
     buff.size = respBufferSize;
+    buff.next_allocated_buffer = 0;
     return buff;
   }
 

--- a/storage/ndb/rest-server2/server/src/buffer_manager.hpp
+++ b/storage/ndb/rest-server2/server/src/buffer_manager.hpp
@@ -90,7 +90,7 @@ class RS_BufferArrayManager {
   }
 
   static RS_Buffer allocate_resp_buffer() {
-    auto respBufferSize = globalConfigs.internal.respBufferSize;
+    auto respBufferSize = globalConfigs.internal.respBufferSize * 2;
     auto buff = RS_Buffer();
     buff.buffer = new char[respBufferSize];
     buff.size = respBufferSize;

--- a/storage/ndb/rest-server2/server/src/config_structs_def.hpp
+++ b/storage/ndb/rest-server2/server/src/config_structs_def.hpp
@@ -54,6 +54,7 @@
 CLASS
 (
  Internal,
+ CM(Uint32, maxReqSize,          maxReqSize,          4 * 1024 * 1024)
  CM(Uint32, reqBufferSize,       ReqBufferSize,       1024 * 1024)
  CM(Uint32, respBufferSize,      RespBufferSize,      5 * 1024 * 1024)
  CM(Uint32, preAllocatedBuffers, PreAllocatedBuffers, 32)

--- a/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.cpp
+++ b/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.cpp
@@ -103,8 +103,8 @@ BatchKeyOperations::init_batch_operations(ArenaMalloc *amalloc,
     }
     const NdbDictionary::Dictionary *dict = ndb_object->getDictionary();
     const NdbDictionary::Table *tableDict = dict->getTable(req->Table());
-    DEB_NDB_BE("Request on DB: %s, Table: %s, op: %u",
-      req->DB(), req->Table(), i);
+    DEB_NDB_BE("Request on DB: %s, Table: %s, op: %u, reqBuffer: %p",
+      req->DB(), req->Table(), i, reqBuffer[i].buffer);
     if (unlikely(tableDict == nullptr)) {
       RS_Status err = RS_CLIENT_404_WITH_MSG_ERROR(
         ERROR_011 + std::string(" Database: ") +
@@ -282,9 +282,10 @@ BatchKeyOperations::init_batch_operations(ArenaMalloc *amalloc,
     } else {
       /**
        * When we arrive here we have not received any column names from
-       * the JSON request. Since we want the use the request buffer to
-       * construct the response, we need to fill in the missing column
-       * names here.
+       * the JSON request. It is too early to fill them in here since it
+       * is possible that the schema changes between now and a retry
+       * attempt. Thus we fill in this information in create_response
+       * instead.
        */
       DEB_NDB_BE("Start reading all columns: %u", numColumns);
       bool use_blob_values = false;

--- a/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.hpp
+++ b/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.hpp
@@ -73,12 +73,11 @@ class BatchKeyOperations {
                                    Uint32,
                                    bool is_batch,
                                    RS_Buffer *reqBuffer,
-                                   RS_Buffer *respBuffer,
                                    Ndb *ndb_object);
    RS_Status setup_transaction();
    RS_Status setup_read_operation();
    RS_Status execute();
-   RS_Status create_response();
+   RS_Status create_response(RS_Buffer *respBuffer);
    RS_Status append_op_recs(Uint32);
    void close_transaction();
    RS_Status abort_request();

--- a/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_response.cpp
+++ b/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_response.cpp
@@ -47,8 +47,9 @@ RS_Status PKRResponse::SetStatus(Uint32 value, const char *message) {
   return WriteStringHeaderField(PK_RESP_OP_MESSAGE_IDX, message);
 }
 
-RS_Status PKRResponse::Close() {
+RS_Status PKRResponse::Close(Uint32 &response_length) {
   this->WriteHeaderField(PK_RESP_LENGTH_IDX, writeHeader);
+  response_length = writeHeader;
   return RS_OK;
 }
 

--- a/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_response.hpp
+++ b/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_response.hpp
@@ -49,9 +49,9 @@ class PKRResponse {
   RS_Status SetStatus(Uint32 value, const char* message);
 
   /**
-   * Close response and set the data lenght.
+   * Close response and set the data length
    */
-  RS_Status Close();
+  RS_Status Close(Uint32 &length);
 
   /**
    * Set Operation ID

--- a/storage/ndb/rest-server2/server/src/encoding.hpp
+++ b/storage/ndb/rest-server2/server/src/encoding.hpp
@@ -35,10 +35,14 @@ RS_Status process_pkread_response(ArenaMalloc*,
                                   void *,
                                   RS_Buffer *reqBuff,
                                   PKReadResponseJSON &);
-RS_Buffer getNextRS_Buffer(Uint32 &head,
-                           Uint32 request_buffer_limit,
-                           RS_Buffer &current_request_buffer,
-                           Uint32 index);
+RS_Buffer getNextReqRS_Buffer(Uint32 &head,
+                              Uint32 request_buffer_limit,
+                              RS_Buffer &current_request_buffer,
+                              Uint32 index);
+RS_Buffer getNextRespRS_Buffer(Uint32 &head,
+                               Uint32 response_buffer_limit,
+                               RS_Buffer &current_response_buffer,
+                               Uint32 index);
 void release_array_buffers(RS_Buffer *req_buffers,
                            RS_Buffer *resp_buffers,
                            Uint32 numOps);

--- a/storage/ndb/rest-server2/server/src/encoding.hpp
+++ b/storage/ndb/rest-server2/server/src/encoding.hpp
@@ -30,10 +30,17 @@
 #include <drogon/drogon.h>
 #include <iostream>
 
-RS_Status create_native_request(PKReadParams &, Uint32*);
+RS_Status create_native_request(PKReadParams &, Uint32*, Uint32&);
 RS_Status process_pkread_response(ArenaMalloc*,
                                   void *,
                                   RS_Buffer *reqBuff,
                                   PKReadResponseJSON &);
+RS_Buffer getNextRS_Buffer(Uint32 &head,
+                           Uint32 request_buffer_limit,
+                           RS_Buffer &current_request_buffer,
+                           Uint32 index);
+void release_array_buffers(RS_Buffer *req_buffers,
+                           RS_Buffer *resp_buffers,
+                           Uint32 numOps);
 
 #endif  // STORAGE_NDB_REST_SERVER2_SERVER_SRC_ENCODING_HPP_

--- a/storage/ndb/rest-server2/server/src/feature_store_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/feature_store_ctrl.cpp
@@ -581,7 +581,7 @@ void FeatureStoreCtrl::featureStore(
   const char *json_str = req->getBody().data();
   DEB_FS_CTRL("\n\n JSON REQUEST: \n %s \n", json_str);
   size_t length        = req->getBody().length();
-  if (unlikely(length > globalConfigs.internal.reqBufferSize)) {
+  if (unlikely(length > globalConfigs.internal.maxReqSize)) {
     auto resp = drogon::HttpResponse::newHttpResponse();
     resp->setBody("Request too large");
     resp->setStatusCode(drogon::HttpStatusCode::k400BadRequest);
@@ -596,7 +596,7 @@ void FeatureStoreCtrl::featureStore(
       simdjson::padded_string_view(
         jsonParser.get_buffer().get(),
         length,
-        globalConfigs.internal.reqBufferSize + simdjson::SIMDJSON_PADDING),
+        globalConfigs.internal.maxReqSize + simdjson::SIMDJSON_PADDING),
         reqStruct);
 
     if (unlikely(static_cast<drogon::HttpStatusCode>(status.http_code) !=
@@ -710,16 +710,13 @@ void FeatureStoreCtrl::featureStore(
     Uint32 request_buffer_limit = request_buffer_size / 2;
     Uint32 current_head = 0;
     RS_Buffer current_request_buffer = rsBufferArrayManager.get_req_buffer();
-    for (unsigned long i = 0; i < noOps; i++) {
-      RS_Buffer respBuff = rsBufferArrayManager.get_resp_buffer();
-
-      RS_Buffer reqBuff = getNextRS_Buffer(current_head,
-                                           request_buffer_limit,
-                                           current_request_buffer,
-                                           i);
+    respBuffs[0] = rsBufferArrayManager.get_resp_buffer();
+    for (Uint32 i = 0; i < noOps; i++) {
+      RS_Buffer reqBuff = getNextReqRS_Buffer(current_head,
+                                              request_buffer_limit,
+                                              current_request_buffer,
+                                              i);
       reqBuffs[i]  = reqBuff;
-      respBuffs[i] = respBuff;
-
       RS_Status status =
         create_native_request(readParams[i],
                               (Uint32*)reqBuff.buffer,

--- a/storage/ndb/rest-server2/server/src/json_parser.cpp
+++ b/storage/ndb/rest-server2/server/src/json_parser.cpp
@@ -179,7 +179,7 @@ JSONParser* jsonParsers = nullptr;
 
 JSONParser::JSONParser() {
   buffer = std::make_unique<char[]>(
-    globalConfigs.internal.reqBufferSize + simdjson::SIMDJSON_PADDING);
+    globalConfigs.internal.maxReqSize + simdjson::SIMDJSON_PADDING);
 }
 
 std::unique_ptr<char[]> &JSONParser::get_buffer() {

--- a/storage/ndb/rest-server2/server/src/pk_read_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/pk_read_ctrl.cpp
@@ -67,7 +67,7 @@ void PKReadCtrl::pkRead(const drogon::HttpRequestPtr &req,
   DEB_PK_CTRL("\n\n JSON REQUEST: db: %s, tab: %s\n %s \n",
               db.data(), table.data(), json_str);
   size_t length = req->getBody().length();
-  if (unlikely(length > globalConfigs.internal.reqBufferSize)) {
+  if (unlikely(length > globalConfigs.internal.maxReqSize)) {
     auto resp = drogon::HttpResponse::newHttpResponse();
     resp->setBody("Request too large");
     DEB_PK_CTRL("Error message: Request too large");
@@ -84,7 +84,7 @@ void PKReadCtrl::pkRead(const drogon::HttpRequestPtr &req,
       simdjson::padded_string_view(
         jsonParser.get_buffer().get(),
         length,
-        globalConfigs.internal.reqBufferSize + simdjson::SIMDJSON_PADDING),
+        globalConfigs.internal.maxReqSize + simdjson::SIMDJSON_PADDING),
       reqStruct);
 
   if (unlikely(static_cast<drogon::HttpStatusCode>(status.http_code) !=

--- a/storage/ndb/rest-server2/server/src/pk_read_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/pk_read_ctrl.cpp
@@ -126,14 +126,16 @@ void PKReadCtrl::pkRead(const drogon::HttpRequestPtr &req,
   {
     RS_Buffer reqBuff  = rsBufferArrayManager.get_req_buffer();
     RS_Buffer respBuff = rsBufferArrayManager.get_resp_buffer();
+    Uint32 dummy = 0;
 
-    status = create_native_request(reqStruct, (Uint32*)reqBuff.buffer);
+    status = create_native_request(reqStruct, (Uint32*)reqBuff.buffer, dummy);
     if (unlikely(static_cast<drogon::HttpStatusCode>(status.http_code) !=
           drogon::HttpStatusCode::k200OK)) {
       resp->setBody(std::string(status.message));
       DEB_PK_CTRL("Error message(4): %s", std::string(status.message).c_str());
       resp->setStatusCode(drogon::HttpStatusCode::k400BadRequest);
       callback(resp);
+      release_array_buffers(&reqBuff, &respBuff, 1);
       return;
     }
     UintPtr length_ptr = reinterpret_cast<UintPtr>(reqBuff.buffer) +
@@ -179,7 +181,6 @@ void PKReadCtrl::pkRead(const drogon::HttpRequestPtr &req,
       }
     }
     callback(resp);
-    rsBufferArrayManager.return_resp_buffer(respBuff);
-    rsBufferArrayManager.return_req_buffer(reqBuff);
+    release_array_buffers(&reqBuff, &respBuff, 1);
   }
 }

--- a/storage/ndb/rest-server2/server/src/rdrs_dal.h
+++ b/storage/ndb/rest-server2/server/src/rdrs_dal.h
@@ -70,8 +70,9 @@ typedef enum DataReturnType {
 
 // Buffer that contain request or response objects
 typedef struct RS_Buffer {
-  unsigned int size;  // Buffer size
   char *buffer;       // Buffer
+  unsigned int size;  // Buffer size
+  unsigned int next_allocated_buffer;
 } RS_Buffer;
 
 typedef RS_Buffer *pRS_Buffer;

--- a/storage/ndb/rest-server2/server/src/ronsql_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/ronsql_ctrl.cpp
@@ -59,7 +59,7 @@ void RonSQLCtrl::ronsql(
   DEB_SQL_CTRL("\n\n JSON REQUEST: \n %s \n", json_str);
 
   size_t length        = req->getBody().length();
-  if (length > globalConfigs.internal.reqBufferSize) {
+  if (length > globalConfigs.internal.maxReqSize) {
     resp->setBody("Request too large");
     resp->setStatusCode(drogon::HttpStatusCode::k400BadRequest);
     callback(resp);
@@ -73,7 +73,7 @@ void RonSQLCtrl::ronsql(
       simdjson::padded_string_view(
         jsonParser.get_buffer().get(),
         length,
-        globalConfigs.internal.reqBufferSize + simdjson::SIMDJSON_PADDING),
+        globalConfigs.internal.maxReqSize + simdjson::SIMDJSON_PADDING),
       reqStruct);
 
   if (static_cast<drogon::HttpStatusCode>(status.http_code) !=

--- a/storage/ndb/rest-server2/server/test_go/internal/integrationtests/batchpkread/utils_rest.go
+++ b/storage/ndb/rest-server2/server/test_go/internal/integrationtests/batchpkread/utils_rest.go
@@ -53,6 +53,7 @@ func sendHttpBatchRequest(
 	}
 	batch := api.BatchOpRequest{Operations: &subOps}
 	body, err := json.Marshal(batch)
+	//body, err := json.MarshalIndent(batch, "", "\t")
 	if err != nil {
 		t.Fatalf("Failed to marshall test request %v", err)
 	}

--- a/storage/ndb/rest-server2/server/test_go/internal/integrationtests/pkread/utils_rest.go
+++ b/storage/ndb/rest-server2/server/test_go/internal/integrationtests/pkread/utils_rest.go
@@ -31,6 +31,7 @@ func pkRESTTestWithClient(
 ) {
 	url := testutils.NewPKReadURL(testInfo.Db, testInfo.Table)
 	body, err := json.Marshal(testInfo.PkReq)
+	//body, err := json.MarshalIndent(testInfo.PkReq, "", "\t")
 	if err != nil {
 		t.Fatalf("Failed to marshall test request %v", err)
 	}


### PR DESCRIPTION
With this the default thread will use 10 MByte for response buffers, 2 MByte for request buffers and 2 MByte for the
JSON request. There is also a bit of memory used for other data structures used in NDB API and in response handling.
These are normally of smaller size.

A RDRS server can serve a very high request bandwidth with 16 threads. A normal set up of an RDRS server would
use about 2 threads per CPU available. The RDRS server would scale to about 10 CPUs for one cluster connection
and a bit more with multiple cluster connections. It is possible to scale with many RDRS Servers and each will be able
to handle millions of key lookups.