### PR TITLE
RONDB-822 pushdown-aggregation bugfix

### DIFF
--- a/mysql-test/suite/ronsql/disabled.def
+++ b/mysql-test/suite/ronsql/disabled.def
@@ -12,4 +12,4 @@
 #
 ##############################################################################
 
-ronsql.ronsql_emptytable : RONDB-822 Failed ndbassert during pushdown aggregation
+ronsql.ronsql_emptytable : RONDB-831 fails due to a result mismatch.

--- a/mysql-test/suite/ronsql/r/ronsql_emptytable.result
+++ b/mysql-test/suite/ronsql/r/ronsql_emptytable.result
@@ -16,12 +16,6 @@ FROM tbl1
 Number of output lines, including header: 2
 
 == Diff ==
---- mysql.out
-+++ ronsql.out
-@@ -1,2 +1,2 @@
- count(*)
--0
-+NULL
 ================================================================================
 
 
@@ -65,12 +59,6 @@ WHERE flt = 66
 Number of output lines, including header: 2
 
 == Diff ==
---- mysql.out
-+++ ronsql.out
-@@ -1,2 +1,2 @@
- count(*)
--0
-+NULL
 ================================================================================
 
 
@@ -116,12 +104,6 @@ WHERE idx >= 6 AND idx < 8
 Number of output lines, including header: 2
 
 == Diff ==
---- mysql.out
-+++ ronsql.out
-@@ -1,2 +1,2 @@
- count(*)
--0
-+NULL
 ================================================================================
 
 
@@ -167,12 +149,6 @@ WHERE idx >= 6 AND idx < 8 AND flt = 66
 Number of output lines, including header: 2
 
 == Diff ==
---- mysql.out
-+++ ronsql.out
-@@ -1,2 +1,2 @@
- count(*)
--0
-+NULL
 ================================================================================
 
 

--- a/mysql-test/suite/ronsql/r/ronsql_emptytable.result
+++ b/mysql-test/suite/ronsql/r/ronsql_emptytable.result
@@ -1,0 +1,211 @@
+Create test table with no rows
+CREATE TABLE tbl1 (
+pk INT NOT NULL,
+idx INT NULL,
+flt INT NULL,
+gr INT NULL,
+PRIMARY KEY USING HASH (pk),
+INDEX index_idx (idx)
+) ENGINE=NDB CHARSET=latin1;
+Table scan
+== Query ==
+SELECT count(*)
+FROM tbl1
+;
+
+Number of output lines, including header: 2
+
+== Diff ==
+--- mysql.out
++++ ronsql.out
+@@ -1,2 +1,2 @@
+ count(*)
+-0
++NULL
+================================================================================
+
+
+
+Table scan, group on 1 column
+== Query ==
+SELECT count(*)
+FROM tbl1
+GROUP BY gr
+;
+
+Number of output lines, including header: 0
+
+== Diff ==
+================================================================================
+
+
+
+Table scan, group on 2 columns
+== Query ==
+SELECT count(*)
+FROM tbl1
+GROUP BY gr
+, idx
+;
+
+Number of output lines, including header: 0
+
+== Diff ==
+================================================================================
+
+
+
+Table scan, eq filter
+== Query ==
+SELECT count(*)
+FROM tbl1
+WHERE flt = 66
+;
+
+Number of output lines, including header: 2
+
+== Diff ==
+--- mysql.out
++++ ronsql.out
+@@ -1,2 +1,2 @@
+ count(*)
+-0
++NULL
+================================================================================
+
+
+
+Table scan, eq filter, group on 1 column
+== Query ==
+SELECT count(*)
+FROM tbl1
+WHERE flt = 66
+GROUP BY gr
+;
+
+Number of output lines, including header: 0
+
+== Diff ==
+================================================================================
+
+
+
+Table scan, eq filter, group on 2 columns
+== Query ==
+SELECT count(*)
+FROM tbl1
+WHERE flt = 66
+GROUP BY gr
+, idx
+;
+
+Number of output lines, including header: 0
+
+== Diff ==
+================================================================================
+
+
+
+Range scan
+== Query ==
+SELECT count(*)
+FROM tbl1
+WHERE idx >= 6 AND idx < 8
+;
+
+Number of output lines, including header: 2
+
+== Diff ==
+--- mysql.out
++++ ronsql.out
+@@ -1,2 +1,2 @@
+ count(*)
+-0
++NULL
+================================================================================
+
+
+
+Range scan, group on 1 column
+== Query ==
+SELECT count(*)
+FROM tbl1
+WHERE idx >= 6 AND idx < 8
+GROUP BY gr
+;
+
+Number of output lines, including header: 0
+
+== Diff ==
+================================================================================
+
+
+
+Range scan, group on 2 columns
+== Query ==
+SELECT count(*)
+FROM tbl1
+WHERE idx >= 6 AND idx < 8
+GROUP BY gr
+, idx
+;
+
+Number of output lines, including header: 0
+
+== Diff ==
+================================================================================
+
+
+
+Range scan, eq filter
+== Query ==
+SELECT count(*)
+FROM tbl1
+WHERE idx >= 6 AND idx < 8 AND flt = 66
+;
+
+Number of output lines, including header: 2
+
+== Diff ==
+--- mysql.out
++++ ronsql.out
+@@ -1,2 +1,2 @@
+ count(*)
+-0
++NULL
+================================================================================
+
+
+
+Range scan, eq filter, group on 1 column
+== Query ==
+SELECT count(*)
+FROM tbl1
+WHERE idx >= 6 AND idx < 8 AND flt = 66
+GROUP BY gr
+;
+
+Number of output lines, including header: 0
+
+== Diff ==
+================================================================================
+
+
+
+Range scan, eq filter, group on 2 columns
+== Query ==
+SELECT count(*)
+FROM tbl1
+WHERE idx >= 6 AND idx < 8 AND flt = 66
+GROUP BY gr
+, idx
+;
+
+Number of output lines, including header: 0
+
+== Diff ==
+================================================================================
+
+
+
+DROP TABLE tbl1;

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
@@ -20392,9 +20392,14 @@ void Dblqh::sendScanFragConf(Signal *signal, Uint32 scanCompleted,
      * potential crash here? double check.
      * 1. API quits while scanning. scanPtr->scanState == WAIT_CLOSE_SCAN
      * and scanPtr->m_agg_curr_batch_size_bytes maybe 0.
++     * 2. A table-scan is done (or table-scan on an empty table, WAIT_CLOSE_SCAN)
++     * 3. An index-scan on an empty table, WAIT_ACC_SCAN);
++     *
++     * CHECK RONDB-822 for more details
      */
     ndbassert(scanPtr->m_agg_curr_batch_size_bytes ||
-           scanPtr->scanState == ScanRecord::WAIT_CLOSE_SCAN);
+           scanPtr->scanState == ScanRecord::WAIT_CLOSE_SCAN ||
+           scanPtr->scanState == ScanRecord::WAIT_ACC_SCAN);
   }
   const Uint32 completed_ops= tmp_completed_ops;
   const Uint32 total_len= tmp_total_len / sizeof(Uint32);


### PR DESCRIPTION
Description:
  it's not a bug and works fine in the release binary.
  The assertion was added to ensure everything behaves as I expected.
  Specifically, I wanted to verify that when LQH sends scanfragconf to TC,
  no aggregation results remain cached unless:

    We are scanning and aggregating an empty table.

    No rows meet the filter condition.

    It's the end of the scan.

  Under these conditions, the scanPtr->scanState should change to
  ScanRecord::WAIT_CLOSE_SCAN.

  However, this case help us catch an new exception:
  When performing an index scan on an empty table, dbtux directly
  returns ZEMPTY_FRAGMENT, skipping the state transition from
  ScanRecord::WAIT_ACC_SCAN to ScanRecord::WAIT_CLOSE_SCAN. This
  behavior causes the assertion to trigger. The root cause lies in the
  different ways dbtux and dbtup handle empty tables during
  execACC_SCANREQ.

Solution:
  Add ScanRecord::WAIT_ACC_SCAN to the assertion to account for this
  scenario.