### PR TITLE
RONDB-820: sendPoolShrink can cause a crash with uninitialised Signal…

### DIFF
--- a/storage/ndb/src/kernel/vm/SimulatedBlock.hpp
+++ b/storage/ndb/src/kernel/vm/SimulatedBlock.hpp
@@ -2896,7 +2896,7 @@ SimulatedBlock::prepareRETURN_DIRECT(Uint32 gsn,
   signal->header.theVerId_signalNumber = gsn;
 }
 
-// Do a consictency check before reusing a signal.
+// Do a consistency check before reusing a signal.
 inline void 
 SimulatedBlock::check_sections(Signal25* signal,
                                Uint32 oldSecCount, 

--- a/storage/ndb/src/kernel/vm/VMSignal.hpp
+++ b/storage/ndb/src/kernel/vm/VMSignal.hpp
@@ -76,6 +76,9 @@ struct NodeReceiverGroup {
 
 template <unsigned T> struct SignalT
 {
+  SignalT() {
+    memset(&header, 0, sizeof(SignalHeader));
+  }
   Uint32 m_sectionPtrI[3];
   SignalHeader header;
   union {


### PR DESCRIPTION
…Header, fixed by initialiser