### PR TITLE
Bugfix: Incorrect BUSY State Set on Extra Disk Page

### DIFF
--- a/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/Dbtup.hpp
@@ -985,6 +985,7 @@ struct Operationrec {
     m_any_value(0),
     op_type(ZREAD),
     trans_state(Uint32(TRANS_DISCONNECTED)),
+    get_disk_page_flags(RNIL),
     original_op_type(ZREAD),
     ttl_ignore(0),
     ttl_only_expired(0)
@@ -1137,6 +1138,14 @@ struct Operationrec {
       Uint32 op_bit_fields;
     };
     OpStruct op_struct;
+
+    /*
+     * Temporary variable to cache the flags for retrieving the original disk page.
+     * This prevents issues in case of real-time break, where the callback
+     * function might lose the flags' value and pass incorrect values when retrieving
+     * the next extra disk page.
+     */
+    Uint32 get_disk_page_flags;
 
     /*
      * When refreshing a row, there are four scenarios


### PR DESCRIPTION
Description:

1. In the load_diskpage function, the REF_REQ flag is added to increment the reference count when loading the original disk page. If an extra disk page is detected, the same flag is used to load the extra page. This causes the reference count for the extra disk page to increase without being decremented, which ultimately prevents the Local Checkpoint (LCP) process from completing.
2. If a real-time interruption occurs while loading the original disk page, the callback function may lose the previous flag value, leading to further issues.

Solution:

1. Avoid using the REF_REQ flag when loading the extra disk page.
2. Cache the flag in Dbtup::Operationrec and restore it if a real-time interruption occurs.