### PR TITLE
RONDB-822: Pushdown Aggregation Patch - version

### DIFF
--- a/storage/ndb/include/ndbapi/NdbAggregationCommon.hpp
+++ b/storage/ndb/include/ndbapi/NdbAggregationCommon.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2024, Hopsworks and/or its affiliates.
+ * Copyright (c) 2024, 2025, Hopsworks and/or its affiliates.
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License, version 2.0,
  * as published by the Free Software Foundation.
@@ -38,6 +38,8 @@
 #define MAX_AGG_N_GROUPBY_COLS 128
 #define MAX_AGG_N_RESULTS 256
 #define MAX_AGG_PROGRAM_WORD_SIZE 1024
+
+#define PUSHDOWN_AGGREGATION_VERSION 1
 enum InterpreterOp {
   kOpUnknown = 0,
   kOpPlus,

--- a/storage/ndb/src/kernel/blocks/dbtup/AggInterpreter.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/AggInterpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2024, Hopsworks and/or its affiliates.
+ * Copyright (c) 2024, 2025, Hopsworks and/or its affiliates.
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License, version 2.0,
  * as published by the Free Software Foundation.
@@ -57,6 +57,22 @@ bool AggInterpreter::Init() {
   value = prog_[cur_pos_++];
   n_gb_cols_ = (value >> 16) & 0xFFFF;
   n_agg_results_ = value & 0xFFFF;
+
+  Uint32 version = prog_[cur_pos_++];
+  if (version > PUSHDOWN_AGGREGATION_VERSION) {
+    g_eventLogger->warning("Pushdown aggregation program version(%u) is "
+                           "not compatible with "
+                           "the version (%u) on data node",
+                           version, PUSHDOWN_AGGREGATION_VERSION);
+    /*
+     * Return with inited_ = false, and
+     * ProcessRec() will handle this incompatible issue.
+     */
+    return true;
+  }
+  // Skip the next 5 reserved Uint32 elements
+  assert(prog_[cur_pos_] == 0);
+  cur_pos_ += 5;
 
   /*
    * 3. Get all the group by columns id.

--- a/storage/ndb/src/ndbapi/NdbAggregator.cpp
+++ b/storage/ndb/src/ndbapi/NdbAggregator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2024, Hopsworks and/or its affiliates.
+ * Copyright (c) 2024, 2025, Hopsworks and/or its affiliates.
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License, version 2.0,
  * as published by the Free Software Foundation.
@@ -43,7 +43,7 @@
 #define DEB(...) do { } while (0)
 #endif
 
-#define PROGRAM_HEADER_SIZE 2
+#define PROGRAM_HEADER_SIZE 8
 #define RESULT_HEADER_SIZE 3
 #define RESULT_ITEM_HEADER_SIZE 1
 
@@ -739,6 +739,14 @@ bool NdbAggregator::Finalize() {
 
   buffer_[0] = (0x0721) << 16 | curr_prog_pos_;
   buffer_[1] = n_gb_cols_ << 16 | n_agg_results_;
+  buffer_[2] = PUSHDOWN_AGGREGATION_VERSION;
+
+  // Initialize the next 5 reserved Uint32 elements to 0
+  buffer_[3] = 0;
+  buffer_[4] = 0;
+  buffer_[5] = 0;
+  buffer_[6] = 0;
+  buffer_[7] = 0;
 
   if (n_gb_cols_) {
     if (n_gb_cols_ >= MAX_AGG_N_GROUPBY_COLS) {


### PR DESCRIPTION
1. Added a version field in the pushdown aggregation program header to support future upgrades.
2. Reserved 5 bytes in the program header for future improvements.