### PR TITLE
RONDB-854: Metrics updater for RDRS2

### DIFF
--- a/storage/ndb/rest-server2/server/src/batch_feature_store_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/batch_feature_store_ctrl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hopsworks AB
+ * Copyright (C) 2024, 2025 Hopsworks AB
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -78,7 +78,7 @@ void BatchFeatureStoreCtrl::batch_featureStore(
    */
 
   drogon::HttpResponsePtr resp = drogon::HttpResponse::newHttpResponse();
-  rdrs_metrics::EndPointMetricsUpdater metricsUpdater(BATCH_FEATURE_STORE, POST, resp);
+  BatchFsReadEndPointMetricsUpdater metricsUpdater(resp);
 
   size_t currentThreadIndex = drogon::app().getCurrentThreadIndex();
   if (unlikely(currentThreadIndex >= globalConfigs.rest.numThreads)) {
@@ -245,6 +245,7 @@ void BatchFeatureStoreCtrl::batch_featureStore(
       Uint32 *length_ptr_casted = reinterpret_cast<Uint32*>(length_ptr);
       reqBuffs[i].size = *length_ptr_casted;
     }
+    metricsUpdater.set_key_requests(noOps);
     // pk_batch_read
     status = pk_batch_read((void*)&amalloc,
                            noOps,

--- a/storage/ndb/rest-server2/server/src/batch_pk_read_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/batch_pk_read_ctrl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2024 Hopsworks AB
+ * Copyright (C) 2023, 2025 Hopsworks AB
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -52,7 +52,7 @@ void BatchPKReadCtrl::batchPKRead(
   std::function<void(const drogon::HttpResponsePtr &)> &&callback) {
 
   drogon::HttpResponsePtr resp = drogon::HttpResponse::newHttpResponse();
-  rdrs_metrics::EndPointMetricsUpdater metricsUpdater(BATCH, POST, resp);
+  BatchPkReadEndPointMetricsUpdater metricsUpdater(resp);
 
   size_t currentThreadIndex = drogon::app().getCurrentThreadIndex();
   if (unlikely(currentThreadIndex >= globalConfigs.rest.numThreads)) {
@@ -226,6 +226,8 @@ void BatchPKReadCtrl::batchPKRead(
       Uint32 *length_ptr_casted = reinterpret_cast<Uint32*>(length_ptr);
       reqBuffs[i].size = *length_ptr_casted;
     }
+
+    metricsUpdater.set_key_requests(noOps);
 
     // pk_batch_read
     status = pk_batch_read(&amalloc,

--- a/storage/ndb/rest-server2/server/src/feature_store_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/feature_store_ctrl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hopsworks AB
+ * Copyright (C) 2024, 2025 Hopsworks AB
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -568,7 +568,7 @@ void FeatureStoreCtrl::featureStore(
    */
 
   drogon::HttpResponsePtr resp = drogon::HttpResponse::newHttpResponse();
-  rdrs_metrics::EndPointMetricsUpdater metricsUpdater(FEATURE_STORE, POST, resp);
+  FsReadEndPointMetricsUpdater metricsUpdater(resp);
 
   size_t currentThreadIndex = drogon::app().getCurrentThreadIndex();
   if (unlikely(currentThreadIndex >= globalConfigs.rest.numThreads)) {

--- a/storage/ndb/rest-server2/server/src/health_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/health_ctrl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2024 Hopsworks AB
+ * Copyright (C) 2024, 2025 Hopsworks AB
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -25,6 +25,7 @@
 #include "config_structs.hpp"
 #include "constants.hpp"
 #include <rdrs_dal.h>
+#include <metrics.hpp>
 
 #include <cstring>
 #include <drogon/HttpTypes.h>
@@ -50,6 +51,7 @@ void HealthCtrl::health(
     const drogon::HttpResponsePtr &)> &&callback) {
 
   auto resp = drogon::HttpResponse::newHttpResponse();
+  HealthEndPointMetricsUpdater metricsUpdater;
 
   // Store it to the first string buffer
   size_t length = req->getBody().length();

--- a/storage/ndb/rest-server2/server/src/metrics.cpp
+++ b/storage/ndb/rest-server2/server/src/metrics.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hopsworks AB
+ * Copyright (C) 2024, 2025 Hopsworks AB
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,40 +26,631 @@
 #include <prometheus/counter.h>
 #include <prometheus/summary.h>
 #include <prometheus/family.h>
+#include <prometheus/histogram.h>
 #include <prometheus/info.h>
 #include <prometheus/registry.h>
 #include <string>
+#include <vector>
 #include <my_compiler.h>  // for likely and unlikely
+#include <metrics.hpp>
 
 using namespace prometheus;
+
+std::atomic<Uint64> m_key_request_counter;
+std::atomic<Uint64> m_ping_request_counter;
+std::atomic<Uint64> m_health_request_counter;
+std::atomic<Uint64> m_metrics_request_counter;
+std::atomic<Uint64> pk_read_histogram[64];
+std::atomic<Uint64> batch_pk_read_histogram[64];
+std::atomic<Uint64> fs_histogram[64];
+std::atomic<Uint64> batch_fs_histogram[64];
+std::atomic<Uint64> ronsql_histogram[64];
+
+Uint32 pk_histogram_boundaries[61];
+Uint32 batch_pk_histogram_boundaries[61];
+Uint32 fs_histogram_boundaries[61];
+Uint32 batch_fs_histogram_boundaries[61];
+Uint32 ronsql_histogram_boundaries[61];
+
+static void
+init_hist_boundaries() {
+  m_key_request_counter = 0;
+  m_ping_request_counter = 0;
+  m_health_request_counter = 0;
+  for (Uint32 i = 0; i < 64; i++) {
+    pk_read_histogram[i] = 0;
+  }
+  for (Uint32 i = 0; i < 64; i++) {
+    batch_pk_read_histogram[i] = 0;
+  }
+  for (Uint32 i = 0; i < 64; i++) {
+    fs_histogram[i] = 0;
+  }
+  for (Uint32 i = 0; i < 64; i++) {
+    batch_fs_histogram[i] = 0;
+  }
+  for (Uint32 i = 0; i < 64; i++) {
+    ronsql_histogram[i] = 0;
+  }
+
+  for (Uint32 i = 0; i < 10; i++) {
+    pk_histogram_boundaries[i] = 40 * (i + 1);
+  }
+  for (Uint32 i = 0; i < 10; i++) {
+    pk_histogram_boundaries[10 + i] = 400 + 100 * (i + 1);
+  }
+  for (Uint32 i = 0; i < 10; i++) {
+    pk_histogram_boundaries[20 + i] = 1400 + 200 * (i + 1);
+  }
+  for (Uint32 i = 0; i < 10; i++) {
+    pk_histogram_boundaries[30 + i] = 3400 + 260 * (i + 1);
+  }
+  Uint32 pk_boundary = 7500;
+  for (Uint32 i = 0; i < 21; i++) {
+    pk_histogram_boundaries[40 + i] = pk_boundary;
+    pk_boundary = (pk_boundary / 2) * 3;
+  }
+
+  for (Uint32 i = 0; i < 20; i++) {
+    batch_pk_histogram_boundaries[i] = 200 * (i + 1);
+  }
+  for (Uint32 i = 0; i < 20; i++) {
+    batch_pk_histogram_boundaries[20 + i] = 4000 + 500 * (i + 1);
+  }
+  Uint32 batch_pk_boundary = 21000;
+  for (Uint32 i = 0; i < 21; i++) {
+    batch_pk_histogram_boundaries[40 + i] = batch_pk_boundary;
+    batch_pk_boundary = (batch_pk_boundary / 2) * 3;
+  }
+
+  for (Uint32 i = 0; i < 10; i++) {
+    fs_histogram_boundaries[i] = 50 * (i + 1);
+  }
+  for (Uint32 i = 0; i < 10; i++) {
+    fs_histogram_boundaries[10 + i] = 500 + 100 * (i + 1);
+  }
+  for (Uint32 i = 0; i < 10; i++) {
+    fs_histogram_boundaries[20 + i] = 1500 + 200 * (i + 1);
+  }
+  for (Uint32 i = 0; i < 10; i++) {
+    fs_histogram_boundaries[30 + i] = 3500 + 300 * (i + 1);
+  }
+  Uint32 fs_boundary = 9750;
+  for (Uint32 i = 0; i < 21; i++) {
+    fs_histogram_boundaries[40 + i] = fs_boundary;
+    fs_boundary = (fs_boundary / 2) * 3;
+  }
+
+  for (Uint32 i = 0; i < 20; i++) {
+    batch_fs_histogram_boundaries[i] = 250 * (i + 1);
+  }
+  for (Uint32 i = 0; i < 20; i++) {
+    batch_fs_histogram_boundaries[20 + i] = 5000 + 600 * (i + 1);
+  }
+  Uint32 batch_fs_boundary = 25500;
+  for (Uint32 i = 0; i < 21; i++) {
+    batch_fs_histogram_boundaries[40 + i] = batch_fs_boundary;
+    batch_fs_boundary = (batch_fs_boundary / 2) * 3;
+  }
+
+  for (Uint32 i = 0; i < 10; i++) {
+    ronsql_histogram_boundaries[i] = 100 * (i + 1);
+  }
+  for (Uint32 i = 0; i < 10; i++) {
+    ronsql_histogram_boundaries[10 + i] = 1000 + 200 * (i + 1);
+  }
+  for (Uint32 i = 0; i < 10; i++) {
+    ronsql_histogram_boundaries[20 + i] = 3000 + 500 * (i + 1);
+  }
+  for (Uint32 i = 0; i < 10; i++) {
+    ronsql_histogram_boundaries[30 + i] = 8000 + 2000 * (i + 1);
+  }
+  Uint32 ronsql_boundary = 72000;
+  for (Uint32 i = 0; i < 21; i++) {
+    ronsql_histogram_boundaries[40 + i] = ronsql_boundary;
+    ronsql_boundary = (ronsql_boundary / 2) * 3;
+  }
+}
+
+static Uint32 calculate_pk_index(Uint64 micros) {
+  if (micros < Uint64(400)) {
+    return micros / Uint64(40);
+  } else if (micros < Uint64(1400)) {
+    return ((micros - Uint64(400)) / Uint64(100)) + 10;
+  } else if (micros < Uint64(3400)) {
+    return ((micros - Uint64(1400)) / Uint64(200)) + 20;
+  } else if (micros < Uint64(6000)) {
+    return ((micros - Uint64(3400)) / Uint64(260)) + 30;
+  } else {
+    for (Uint32 i = 40; i < 60; i++) {
+      if (micros < pk_histogram_boundaries[i]) return i;
+    }
+    return Uint32(60);
+  }
+}
+
+static Uint32 calculate_batch_pk_index(Uint64 micros) {
+  if (micros < Uint64(4000)) {
+    return micros / Uint64(200);
+  } else if (micros < Uint64(14000)) {
+    return ((micros - Uint64(4000)) / Uint64(500)) + 20;
+  } else {
+    for (Uint32 i = 40; i < 60; i++) {
+      if (micros < batch_pk_histogram_boundaries[i]) return i;
+    }
+    return Uint32(60);
+  }
+}
+
+static Uint32 calculate_fs_index(Uint64 micros) {
+  if (micros < Uint64(500)) {
+    return micros / Uint64(50);
+  } else if (micros < Uint64(1500)) {
+    return ((micros - Uint64(500)) / Uint64(100)) + 10;
+  } else if (micros < Uint64(3500)) {
+    return ((micros - Uint64(1500)) / Uint64(200)) + 20;
+  } else if (micros < Uint64(6500)) {
+    return ((micros - Uint64(3500)) / Uint64(300)) + 30;
+  } else {
+    for (Uint32 i = 40; i < 60; i++) {
+      if (micros < fs_histogram_boundaries[i]) return i;
+    }
+    return Uint32(60);
+  }
+}
+
+static Uint32 calculate_batch_fs_index(Uint64 micros) {
+  if (micros < Uint64(5000)) {
+    return micros / Uint64(250);
+  } else if (micros < Uint64(17000)) {
+    return ((micros - Uint64(5000)) / Uint64(600)) + 20;
+  } else {
+    for (Uint32 i = 40; i < 60; i++) {
+      if (micros < batch_fs_histogram_boundaries[i]) return i;
+    }
+    return Uint32(60);
+  }
+}
+
+static Uint32 calculate_ronsql_index(Uint64 micros) {
+  if (micros < Uint64(1000)) {
+    return micros / Uint64(100);
+  } else if (micros < Uint64(3000)) {
+    return ((micros - Uint64(1000)) / Uint64(200)) + 10;
+  } else if (micros < Uint64(8000)) {
+    return ((micros - Uint64(3000)) / Uint64(500)) + 20;
+  } else if (micros < Uint64(48000)) {
+    return ((micros - Uint64(8000)) / Uint64(2000)) + 30;
+  } else {
+    for (Uint32 i = 40; i < 60; i++) {
+      if (micros < ronsql_histogram_boundaries[i]) return i;
+    }
+    return Uint32(60);
+  }
+}
+
+PkReadEndPointMetricsUpdater::PkReadEndPointMetricsUpdater(
+  drogon::HttpResponsePtr response) {
+  m_start_time = NdbTick_getCurrentTicks();
+  m_response = response;
+}
+
+PkReadEndPointMetricsUpdater::~PkReadEndPointMetricsUpdater() {
+  NDB_TICKS now = NdbTick_getCurrentTicks();
+  Uint64 elapsed_us = NdbTick_Elapsed(m_start_time, now).microSec();
+  auto status = m_response->getStatusCode();
+  Uint32 hist;
+  if (status == drogon::HttpStatusCode::k200OK) {
+    hist = calculate_pk_index(elapsed_us);
+  } else if (status == drogon::HttpStatusCode::k400BadRequest) {
+    hist = 61;
+  } else if (status == drogon::HttpStatusCode::k500InternalServerError) {
+    hist = 62;
+  } else {
+    hist = 63; // Other error
+  }
+  pk_read_histogram[hist].fetch_add(1, std::memory_order_relaxed);
+}
+
+BatchPkReadEndPointMetricsUpdater::BatchPkReadEndPointMetricsUpdater(
+  drogon::HttpResponsePtr response) {
+  m_start_time = NdbTick_getCurrentTicks();
+  m_response = response;
+  m_key_requests = 1;
+}
+
+void
+BatchPkReadEndPointMetricsUpdater::set_key_requests(Uint32 key_requests) {
+  m_key_requests = key_requests;
+}
+
+BatchPkReadEndPointMetricsUpdater::~BatchPkReadEndPointMetricsUpdater() {
+  NDB_TICKS now = NdbTick_getCurrentTicks();
+  Uint64 elapsed_us = NdbTick_Elapsed(m_start_time, now).microSec();
+  auto status = m_response->getStatusCode();
+  Uint32 hist;
+  Uint32 key_requests = 0;
+  if (status == drogon::HttpStatusCode::k200OK) {
+    hist = calculate_batch_pk_index(elapsed_us);
+    key_requests = m_key_requests - 1;
+  } else if (status == drogon::HttpStatusCode::k400BadRequest) {
+    hist = 61;
+  } else if (status == drogon::HttpStatusCode::k500InternalServerError) {
+    hist = 62;
+  } else {
+    hist = 63; // Other error
+  }
+  batch_pk_read_histogram[hist].fetch_add(1, std::memory_order_relaxed);
+  m_key_request_counter.fetch_add(key_requests, std::memory_order_relaxed);
+}
+
+
+FsReadEndPointMetricsUpdater::FsReadEndPointMetricsUpdater(
+  drogon::HttpResponsePtr response) {
+  m_start_time = NdbTick_getCurrentTicks();
+  m_response = response;
+}
+
+FsReadEndPointMetricsUpdater::~FsReadEndPointMetricsUpdater() {
+  NDB_TICKS now = NdbTick_getCurrentTicks();
+  Uint64 elapsed_us = NdbTick_Elapsed(m_start_time, now).microSec();
+  auto status = m_response->getStatusCode();
+  Uint32 hist;
+  if (status == drogon::HttpStatusCode::k200OK) {
+    hist = calculate_fs_index(elapsed_us);
+  } else if (status == drogon::HttpStatusCode::k400BadRequest) {
+    hist = 61;
+  } else if (status == drogon::HttpStatusCode::k500InternalServerError) {
+    hist = 62;
+  } else {
+    hist = 63; // Other error
+  }
+  fs_histogram[hist].fetch_add(1, std::memory_order_relaxed);
+}
+
+BatchFsReadEndPointMetricsUpdater::BatchFsReadEndPointMetricsUpdater(
+  drogon::HttpResponsePtr response) {
+  m_start_time = NdbTick_getCurrentTicks();
+  m_response = response;
+  m_key_requests = 1;
+}
+
+void
+BatchFsReadEndPointMetricsUpdater::set_key_requests(Uint32 key_requests) {
+  m_key_requests = key_requests;
+}
+
+BatchFsReadEndPointMetricsUpdater::~BatchFsReadEndPointMetricsUpdater() {
+  NDB_TICKS now = NdbTick_getCurrentTicks();
+  Uint64 elapsed_us = NdbTick_Elapsed(m_start_time, now).microSec();
+  auto status = m_response->getStatusCode();
+  Uint32 hist;
+  Uint32 key_requests = 0;
+  if (status == drogon::HttpStatusCode::k200OK) {
+    hist = calculate_batch_fs_index(elapsed_us);
+    key_requests = m_key_requests - 1;
+  } else if (status == drogon::HttpStatusCode::k400BadRequest) {
+    hist = 61;
+  } else if (status == drogon::HttpStatusCode::k500InternalServerError) {
+    hist = 62;
+  } else {
+    hist = 63; // Other error
+  }
+  batch_fs_histogram[hist].fetch_add(1, std::memory_order_relaxed);
+  m_key_request_counter.fetch_add(key_requests, std::memory_order_relaxed);
+}
+
+RonSQLEndPointMetricsUpdater::RonSQLEndPointMetricsUpdater(
+  drogon::HttpResponsePtr response) {
+  m_start_time = NdbTick_getCurrentTicks();
+  m_response = response;
+}
+
+RonSQLEndPointMetricsUpdater::~RonSQLEndPointMetricsUpdater() {
+  NDB_TICKS now = NdbTick_getCurrentTicks();
+  Uint64 elapsed_us = NdbTick_Elapsed(m_start_time, now).microSec();
+  auto status = m_response->getStatusCode();
+  Uint32 hist;
+  if (status == drogon::HttpStatusCode::k200OK) {
+    hist = calculate_ronsql_index(elapsed_us);
+  } else if (status == drogon::HttpStatusCode::k400BadRequest) {
+    hist = 61;
+  } else if (status == drogon::HttpStatusCode::k500InternalServerError) {
+    hist = 62;
+  } else {
+    hist = 63; // Other error
+  }
+  ronsql_histogram[hist].fetch_add(1, std::memory_order_relaxed);
+}
+
+PingEndPointMetricsUpdater::PingEndPointMetricsUpdater() {
+  m_ping_request_counter.fetch_add(1, std::memory_order_relaxed);
+}
+
+PingEndPointMetricsUpdater::~PingEndPointMetricsUpdater() {
+}
+
+HealthEndPointMetricsUpdater::HealthEndPointMetricsUpdater() {
+  m_health_request_counter.fetch_add(1, std::memory_order_relaxed);
+}
+
+HealthEndPointMetricsUpdater::~HealthEndPointMetricsUpdater() {
+}
 
 namespace rdrs_metrics {
 
 namespace {
-std::shared_ptr<Registry> registry                      = std::make_shared<Registry>();
+
+std::shared_ptr<Registry> registry = std::make_shared<Registry>();
 prometheus::Family<prometheus::Counter> *requestCounter = nullptr;
-prometheus::Family<prometheus::Summary> *summary_family = nullptr;
+
+prometheus::Counter *keyRequestCounter = nullptr;
+prometheus::Counter *pingCounter = nullptr;
+prometheus::Counter *healthCounter = nullptr;
+prometheus::Counter *metricsCounter = nullptr;
+
+prometheus::Counter *pkReadCounter = nullptr;
+prometheus::Counter *pkReadCounter400 = nullptr;
+prometheus::Counter *pkReadCounter500 = nullptr;
+prometheus::Counter *pkReadCounterOther = nullptr;
+
+prometheus::Counter *batchPkReadCounter = nullptr;
+prometheus::Counter *batchPkReadCounter400 = nullptr;
+prometheus::Counter *batchPkReadCounter500 = nullptr;
+prometheus::Counter *batchPkReadCounterOther = nullptr;
+
+prometheus::Counter *fsReadCounter = nullptr;
+prometheus::Counter *fsReadCounter400 = nullptr;
+prometheus::Counter *fsReadCounter500 = nullptr;
+prometheus::Counter *fsReadCounterOther = nullptr;
+
+prometheus::Counter *batchFsReadCounter = nullptr;
+prometheus::Counter *batchFsReadCounter400 = nullptr;
+prometheus::Counter *batchFsReadCounter500 = nullptr;
+prometheus::Counter *batchFsReadCounterOther = nullptr;
+
+prometheus::Counter *ronSQLReadCounter = nullptr;
+prometheus::Counter *ronSQLReadCounter400 = nullptr;
+prometheus::Counter *ronSQLReadCounter500 = nullptr;
+prometheus::Counter *ronSQLReadCounterOther = nullptr;
+
+prometheus::Histogram *pkReadHistogram = nullptr;
+prometheus::Histogram *batchPkReadHistogram = nullptr;
+prometheus::Histogram *fsReadHistogram = nullptr;
+prometheus::Histogram *batchFsReadHistogram = nullptr;
+prometheus::Histogram *ronSQLReadHistogram = nullptr;
+
 prometheus::Gauge *ronDBConnectionStateGauge            = nullptr;
 prometheus::Gauge *ndbObjectsTotalCountGauge            = nullptr;
-prometheus::Summary::Quantiles objectives               = {
-    {0.5, 0.05},   // 50th percentile with 5% error margin
-    {0.9, 0.01},   // 90th percentile with 1% error margin
-    {0.95, 0.01},  // 95th percentile with 1% error margin
-    {0.99, 0.001}  // 99th percentile with 0.1% error margin
-};
 }  // namespace
 
 void initMetrics() {
+  init_hist_boundaries();
+  /* RDRS Endpoint Request Counters */
   requestCounter = &BuildCounter()
                         .Name("rdrs_endpoints_response_status_count")
                         .Help("Number of response status returned by REST API")
                         .Register(*registry);
 
-  summary_family =
-      &prometheus::BuildSummary()
-           .Name("rdrs_endpoints_response_time_summary")
-           .Help("Summary for response time handled by REST API handler. Time is in nanoseconds")
-           .Register(*registry);
+  /* RDRS pk_read Request Counters */
+  pkReadCounter =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", PKREAD},
+                          {"method", POST},
+                          {"status", "200"}});
+
+  pkReadCounter400 =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", PKREAD},
+                          {"method", POST},
+                          {"status", "400"}});
+
+  pkReadCounter500 =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", PKREAD},
+                          {"method", POST},
+                          {"status", "500"}});
+
+  pkReadCounterOther =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", PKREAD},
+                          {"method", POST},
+                          {"status", "300"}});
+
+
+  /* RDRS batch Request Counters */
+  batchPkReadCounter =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", BATCH},
+                          {"method", POST},
+                          {"status", "200"}});
+
+  batchPkReadCounter400 =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", BATCH},
+                          {"method", POST},
+                          {"status", "400"}});
+
+  batchPkReadCounter500 =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", BATCH},
+                          {"method", POST},
+                          {"status", "500"}});
+
+  batchPkReadCounterOther =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", BATCH},
+                          {"method", POST},
+                          {"status", "300"}});
+
+
+  /* RDRS batch_feature_store Request Counters */
+  batchFsReadCounter =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", BATCH_FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "200"}});
+
+  batchFsReadCounter400 =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", BATCH_FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "400"}});
+
+  batchFsReadCounter500 =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", BATCH_FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "500"}});
+
+  batchFsReadCounterOther =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", BATCH_FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "300"}});
+
+
+  /* RDRS feature_store Request Counters */
+  fsReadCounter =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "200"}});
+
+  fsReadCounter400 =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "400"}});
+
+  fsReadCounter500 =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "500"}});
+
+  fsReadCounterOther =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "300"}});
+
+
+  /* RDRS ronsql Request Counters */
+  ronSQLReadCounter =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "200"}});
+
+  ronSQLReadCounter400 =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "400"}});
+
+  ronSQLReadCounter500 =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "500"}});
+
+  ronSQLReadCounterOther =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", FEATURE_STORE},
+                          {"method", POST},
+                          {"status", "300"}});
+
+  /* RDRS ping Request Counters */
+  keyRequestCounter =
+    &requestCounter->Add({{"api_type", "NDB"},
+                          {"end_point", "key"}});
+
+  pingCounter =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", PING},
+                          {"method", POST},
+                          {"status", "200"}});
+
+  /* RDRS health Request Counters */
+  healthCounter =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", HEALTH},
+                          {"method", POST},
+                          {"status", "200"}});
+
+  /* RDRS metrics Request Counters */
+  metricsCounter =
+    &requestCounter->Add({{"api_type", "REST"},
+                          {"end_point", METRICS},
+                          {"method", POST},
+                          {"status", "200"}});
+
+  prometheus::Family<prometheus::Histogram>& request_duration =
+    prometheus::BuildHistogram()
+      .Name("http_request_duration_seconds")
+      .Help("Histogram of response times")
+      .Register(*registry);
+  {
+    std::vector<double> hist_boundaries(61);
+    for (Uint32 i = 0; i < 61; i++) {
+      double hist_boundary = double(1);
+      hist_boundary *= (double)pk_histogram_boundaries[i];
+      hist_boundary /= (double)1000000;
+      hist_boundaries[i] = hist_boundary;
+    }
+    pkReadHistogram =
+      &request_duration.Add({{"method", "POST"}, {"endpoint", PKREAD}},
+        hist_boundaries);
+  }
+  {
+    std::vector<double> hist_boundaries(61);
+    for (Uint32 i = 0; i < 61; i++) {
+      double hist_boundary = double(1);
+      hist_boundary *= (double)batch_pk_histogram_boundaries[i];
+      hist_boundary /= (double)1000000;
+      hist_boundaries[i] = hist_boundary;
+    }
+    batchPkReadHistogram =
+      &request_duration.Add({{"method", "POST"}, {"endpoint", BATCH}},
+        hist_boundaries);
+  }
+  {
+    std::vector<double> hist_boundaries(61);
+    for (Uint32 i = 0; i < 61; i++) {
+      double hist_boundary = double(1);
+      hist_boundary *= (double)fs_histogram_boundaries[i];
+      hist_boundary /= (double)1000000;
+      hist_boundaries[i] = hist_boundary;
+    }
+    fsReadHistogram =
+      &request_duration.Add({{"method", "POST"}, {"endpoint", FEATURE_STORE}},
+        hist_boundaries);
+  }
+  {
+    std::vector<double> hist_boundaries(61);
+    for (Uint32 i = 0; i < 61; i++) {
+      double hist_boundary = double(1);
+      hist_boundary *= (double)batch_fs_histogram_boundaries[i];
+      hist_boundary /= (double)1000000;
+      hist_boundaries[i] = hist_boundary;
+    }
+    batchFsReadHistogram =
+      &request_duration.Add({{"method", "POST"}, {"endpoint", BATCH_FEATURE_STORE}},
+        hist_boundaries);
+  }
+  {
+    std::vector<double> hist_boundaries(61);
+    for (Uint32 i = 0; i < 61; i++) {
+      double hist_boundary = double(1);
+      hist_boundary *= (double)ronsql_histogram_boundaries[i];
+      hist_boundary /= (double)1000000;
+      hist_boundaries[i] = hist_boundary;
+    }
+    ronSQLReadHistogram =
+      &request_duration.Add({{"method", "POST"}, {"endpoint", RONSQL}},
+        hist_boundaries);
+  }
 
   ronDBConnectionStateGauge = &prometheus::BuildGauge()
                                    .Name("rdrs_rondb_connection_state")
@@ -86,26 +677,182 @@ void setRonDBStats() {
   }
 }
 
-void incrementEndpointAccessCount(const char *endPointLabel, const char *methodType,
-                                  Uint32 status) {
-
-  std::string statusStr = std::to_string(status);
-  // create a new counter or return an already existing one
-  prometheus::Counter *pkCounter = &requestCounter->Add({{"api_type", "REST"},
-                                                         {"end_point", endPointLabel},
-                                                         {"method", methodType},
-                                                         {"status", statusStr}});
-  pkCounter->Increment();
-}
-
-void observeEndpointLatency(const char *endPointLabel, const char *methodType, Uint64 latency) {
-  // create a new counter or return an already existing one
-  prometheus::Summary &response_time_summary = summary_family->Add(
-      {{"api_type", "REST"}, {"end_point", endPointLabel}, {"method", methodType}}, objectives);
-  response_time_summary.Observe(latency);
-}
-
 void writeMetrics(drogon::HttpResponsePtr resp) {
+
+  Uint64 hist_counters[64];
+  for (Uint32 i = 0; i < 64; i++) {
+    Uint64 count = pk_read_histogram[i].exchange(0, std::memory_order_relaxed);
+    hist_counters[i] = count;
+  }
+  Uint64 tot_count = 0;
+  for (Uint32 i = 0; i < 61; i++) {
+    tot_count += hist_counters[i];
+  }
+  if (tot_count > 0) {
+    pkReadCounter->Increment(tot_count);
+  }
+  if (hist_counters[61] > 0) {
+    pkReadCounter400->Increment(hist_counters[61]);
+  }
+  if (hist_counters[62] > 0) {
+    pkReadCounter500->Increment(hist_counters[62]);
+  }
+  if (hist_counters[63] > 0) {
+    pkReadCounterOther->Increment(hist_counters[63]);
+  }
+  double low_boundary = 0.0;
+  for (Uint32 i = 0; i < 61; i++) {
+    double hist_boundary = double(1);
+    hist_boundary *= (double)pk_histogram_boundaries[i];
+    hist_boundary /= (double)1000000;
+    low_boundary = hist_boundary;
+    double reported_val = low_boundary + ((hist_boundary - low_boundary) * 0.99);
+    for (Uint32 j = 0; j < hist_counters[i]; j++) {
+      pkReadHistogram->Observe(reported_val);
+    }
+  }
+
+  for (Uint32 i = 0; i < 64; i++) {
+    Uint64 count =
+      batch_pk_read_histogram[i].exchange(0, std::memory_order_relaxed);
+    hist_counters[i] = count;
+  }
+  tot_count = 0;
+  for (Uint32 i = 0; i < 61; i++) {
+    tot_count += hist_counters[i];
+  }
+  if (tot_count > 0) {
+    batchPkReadCounter->Increment(tot_count);
+  }
+  if (hist_counters[61] > 0) {
+    batchPkReadCounter400->Increment(hist_counters[61]);
+  }
+  if (hist_counters[62] > 0) {
+    batchPkReadCounter500->Increment(hist_counters[62]);
+  }
+  if (hist_counters[63] > 0) {
+    batchPkReadCounterOther->Increment(hist_counters[63]);
+  }
+  low_boundary = 0.0;
+  for (Uint32 i = 0; i < 61; i++) {
+    double hist_boundary = double(1);
+    hist_boundary *= (double)batch_pk_histogram_boundaries[i];
+    hist_boundary /= (double)1000000;
+    low_boundary = hist_boundary;
+    double reported_val = low_boundary + ((hist_boundary - low_boundary) * 0.99);
+    for (Uint32 j = 0; j < hist_counters[i]; j++) {
+      batchPkReadHistogram->Observe(reported_val);
+    }
+  }
+
+  for (Uint32 i = 0; i < 64; i++) {
+    Uint64 count = fs_histogram[i].exchange(0, std::memory_order_relaxed);
+    hist_counters[i] = count;
+  }
+  tot_count = 0;
+  for (Uint32 i = 0; i < 61; i++) {
+    tot_count += hist_counters[i];
+  }
+  if (tot_count > 0) {
+    fsReadCounter->Increment(tot_count);
+  }
+  if (hist_counters[61] > 0) {
+    fsReadCounter400->Increment(hist_counters[61]);
+  }
+  if (hist_counters[62] > 0) {
+    fsReadCounter500->Increment(hist_counters[62]);
+  }
+  if (hist_counters[63] > 0) {
+    fsReadCounterOther->Increment(hist_counters[63]);
+  }
+  low_boundary = 0.0;
+  for (Uint32 i = 0; i < 61; i++) {
+    double hist_boundary = double(1);
+    hist_boundary *= (double)fs_histogram_boundaries[i];
+    hist_boundary /= (double)1000000;
+    low_boundary = hist_boundary;
+    double reported_val = low_boundary + ((hist_boundary - low_boundary) * 0.99);
+    for (Uint32 j = 0; j < hist_counters[i]; j++) {
+      fsReadHistogram->Observe(reported_val);
+    }
+  }
+
+  for (Uint32 i = 0; i < 64; i++) {
+    Uint64 count =
+      batch_fs_histogram[i].exchange(0, std::memory_order_relaxed);
+    hist_counters[i] = count;
+  }
+  tot_count = 0;
+  for (Uint32 i = 0; i < 61; i++) {
+    tot_count += hist_counters[i];
+  }
+  if (tot_count > 0) {
+    batchFsReadCounter->Increment(tot_count);
+  }
+  if (hist_counters[61] > 0) {
+    batchFsReadCounter400->Increment(hist_counters[61]);
+  }
+  if (hist_counters[62] > 0) {
+    batchFsReadCounter500->Increment(hist_counters[62]);
+  }
+  if (hist_counters[63] > 0) {
+    batchFsReadCounterOther->Increment(hist_counters[63]);
+  }
+  low_boundary = 0.0;
+  for (Uint32 i = 0; i < 61; i++) {
+    double hist_boundary = double(1);
+    hist_boundary *= (double)batch_fs_histogram_boundaries[i];
+    hist_boundary /= (double)1000000;
+    low_boundary = hist_boundary;
+    double reported_val = low_boundary + ((hist_boundary - low_boundary) * 0.99);
+    for (Uint32 j = 0; j < hist_counters[i]; j++) {
+      batchFsReadHistogram->Observe(reported_val);
+    }
+  }
+
+  for (Uint32 i = 0; i < 64; i++) {
+    Uint64 count = ronsql_histogram[i].exchange(0, std::memory_order_relaxed);
+    hist_counters[i] = count;
+  }
+  tot_count = 0;
+  for (Uint32 i = 0; i < 61; i++) {
+    tot_count += hist_counters[i];
+  }
+  if (tot_count > 0) {
+    ronSQLReadCounter->Increment(tot_count);
+  }
+  if (hist_counters[61] > 0) {
+    ronSQLReadCounter400->Increment(hist_counters[61]);
+  }
+  if (hist_counters[62] > 0) {
+    ronSQLReadCounter500->Increment(hist_counters[62]);
+  }
+  if (hist_counters[63] > 0) {
+    ronSQLReadCounterOther->Increment(hist_counters[63]);
+  }
+  low_boundary = 0.0;
+  for (Uint32 i = 0; i < 61; i++) {
+    double hist_boundary = double(1);
+    hist_boundary *= (double)ronsql_histogram_boundaries[i];
+    hist_boundary /= (double)1000000;
+    low_boundary = hist_boundary;
+    double reported_val = low_boundary + ((hist_boundary - low_boundary) * 0.99);
+    for (Uint32 j = 0; j < hist_counters[i]; j++) {
+      ronSQLReadHistogram->Observe(reported_val);
+    }
+  }
+
+  Uint64 count = m_key_request_counter.exchange(0, std::memory_order_relaxed);
+  keyRequestCounter->Increment(count);
+
+  count = m_ping_request_counter.exchange(0, std::memory_order_relaxed);
+  pingCounter->Increment(count);
+
+  count = m_health_request_counter.exchange(0, std::memory_order_relaxed);
+  healthCounter->Increment(count);
+
+  count = m_metrics_request_counter;
+  metricsCounter->Increment(count);
 
   // Update RonDB Metrics
   setRonDBStats();

--- a/storage/ndb/rest-server2/server/src/metrics.hpp
+++ b/storage/ndb/rest-server2/server/src/metrics.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hopsworks AB
+ * Copyright (C) 2024, 2025 Hopsworks AB
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -25,43 +25,88 @@
 #include <drogon/drogon.h>
 #include <drogon/HttpSimpleController.h>
 #include <ndb_types.h>
+#include <NdbTick.h>
+
+// Classes for Updating the endpoints stats
+class PkReadEndPointMetricsUpdater {
+ private:
+  drogon::HttpResponsePtr m_response;
+  NDB_TICKS m_start_time;
+
+ public:
+  PkReadEndPointMetricsUpdater(drogon::HttpResponsePtr response);
+
+  ~PkReadEndPointMetricsUpdater();
+};
+
+class FsReadEndPointMetricsUpdater {
+ private:
+  drogon::HttpResponsePtr m_response;
+  NDB_TICKS m_start_time;
+
+ public:
+  FsReadEndPointMetricsUpdater(drogon::HttpResponsePtr response);
+
+  ~FsReadEndPointMetricsUpdater();
+};
+
+class BatchPkReadEndPointMetricsUpdater {
+ private:
+  drogon::HttpResponsePtr m_response;
+  NDB_TICKS m_start_time;
+  Uint32 m_key_requests;
+
+ public:
+  BatchPkReadEndPointMetricsUpdater(drogon::HttpResponsePtr response);
+  void set_key_requests(Uint32 key_requests);
+
+  ~BatchPkReadEndPointMetricsUpdater();
+};
+
+class BatchFsReadEndPointMetricsUpdater {
+ private:
+  drogon::HttpResponsePtr m_response;
+  NDB_TICKS m_start_time;
+  Uint32 m_key_requests;
+
+ public:
+  BatchFsReadEndPointMetricsUpdater(drogon::HttpResponsePtr response);
+  void set_key_requests(Uint32 key_requests);
+
+  ~BatchFsReadEndPointMetricsUpdater();
+};
+
+class RonSQLEndPointMetricsUpdater {
+ private:
+  drogon::HttpResponsePtr m_response;
+  NDB_TICKS m_start_time;
+
+ public:
+  RonSQLEndPointMetricsUpdater(drogon::HttpResponsePtr response);
+
+  ~RonSQLEndPointMetricsUpdater();
+};
+
+class PingEndPointMetricsUpdater {
+ public:
+  PingEndPointMetricsUpdater();
+
+  ~PingEndPointMetricsUpdater();
+};
+
+class HealthEndPointMetricsUpdater {
+ public:
+  HealthEndPointMetricsUpdater();
+
+  ~HealthEndPointMetricsUpdater();
+};
+
 
 namespace rdrs_metrics {
 
 void initMetrics();
 void writeMetrics(drogon::HttpResponsePtr resp);
-void incrementEndpointAccessCount(const char *endPointLabel, const char *methodType, Uint32 status);
-void observeEndpointLatency(const char *endPointLabel, const char *methodType, Uint64 latency);
 void setRonDBStats();
-
-// Class for Updating the endpoints stats
-class EndPointMetricsUpdater {
- private:
-  EndPointMetricsUpdater()                                          = delete;
-  EndPointMetricsUpdater(const EndPointMetricsUpdater &)            = delete;
-  EndPointMetricsUpdater &operator=(const EndPointMetricsUpdater &) = delete;
-  EndPointMetricsUpdater(EndPointMetricsUpdater &&)                 = delete;
-  EndPointMetricsUpdater &operator=(EndPointMetricsUpdater &&)      = delete;
-
-  const char *endPointLabel;
-  const char *endPointVerb;
-  drogon::HttpResponsePtr response;
-  std::chrono::high_resolution_clock::time_point start;
-
- public:
-  EndPointMetricsUpdater(const char *endPointLabel, const char *endPointVerb,
-                         drogon::HttpResponsePtr response)
-      : endPointLabel(endPointLabel), endPointVerb(endPointVerb), response(std::move(response)),
-        start(std::chrono::high_resolution_clock::now()) {
-  }
-
-  ~EndPointMetricsUpdater() {
-    std::chrono::high_resolution_clock::time_point end = std::chrono::high_resolution_clock::now();
-    Uint64 elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
-    observeEndpointLatency(endPointLabel, endPointVerb, elapsed_ns);
-    incrementEndpointAccessCount(endPointLabel, endPointVerb, response->getStatusCode());
-  }
-};
 
 }  // namespace rdrs_metrics
 

--- a/storage/ndb/rest-server2/server/src/ping_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/ping_ctrl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024, 2024 Hopsworks AB
+ * Copyright (C) 2024, 2025 Hopsworks AB
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,6 +24,7 @@
 #include "api_key.hpp"
 #include "config_structs.hpp"
 #include "constants.hpp"
+#include <metrics.hpp>
 
 #include <cstring>
 #include <drogon/HttpTypes.h>
@@ -47,6 +48,7 @@ void PingCtrl::ping(const drogon::HttpRequestPtr &req,
                     std::function<void(
                       const drogon::HttpResponsePtr &)> &&callback) {
   auto resp = drogon::HttpResponse::newHttpResponse();
+  PingEndPointMetricsUpdater metricsUpdater;
 
   // Store it to the first string buffer
   size_t length = req->getBody().length();

--- a/storage/ndb/rest-server2/server/src/pk_read_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/pk_read_ctrl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023, 2024 Hopsworks AB
+ * Copyright (C) 2023, 2025 Hopsworks AB
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -53,7 +53,7 @@ void PKReadCtrl::pkRead(const drogon::HttpRequestPtr &req,
                         const std::string_view &db,
                         const std::string_view &table) {
   drogon::HttpResponsePtr resp = drogon::HttpResponse::newHttpResponse();
-  rdrs_metrics::EndPointMetricsUpdater metricsUpdater(PKREAD, POST, resp);
+  PkReadEndPointMetricsUpdater metricsUpdater(resp);
 
   size_t currentThreadIndex = drogon::app().getCurrentThreadIndex();
   if (unlikely(currentThreadIndex >= globalConfigs.rest.numThreads)) {

--- a/storage/ndb/rest-server2/server/src/ronsql_ctrl.cpp
+++ b/storage/ndb/rest-server2/server/src/ronsql_ctrl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2024, Hopsworks and/or its affiliates.
+ * Copyright (c) 2024, 2025, Hopsworks and/or its affiliates.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,6 +24,7 @@
 #include <drogon/HttpTypes.h>
 #include "storage/ndb/src/ronsql/RonSQLPreparer.hpp"
 #include "api_key.hpp"
+#include <metrics.hpp>
 
 #if (defined(VM_TRACE) || defined(ERROR_INSERT))
 //#define DEBUG_SQL_CTRL 1
@@ -49,8 +50,9 @@ void RonSQLCtrl::ronsql(
   const drogon::HttpRequestPtr &req,
   std::function<void(const drogon::HttpResponsePtr &)> &&callback) {
 
-  size_t currentThreadIndex = drogon::app().getCurrentThreadIndex();
   auto resp = drogon::HttpResponse::newHttpResponse();
+  RonSQLEndPointMetricsUpdater metricsUpdater(resp);
+  size_t currentThreadIndex = drogon::app().getCurrentThreadIndex();
   if (currentThreadIndex >= globalConfigs.rest.numThreads) {
     resp->setBody("Too many threads");
     resp->setStatusCode(drogon::HttpStatusCode::k500InternalServerError);

--- a/storage/ndb/rest-server2/server/test_go/internal/integrationtests/pkread/performance_test.go
+++ b/storage/ndb/rest-server2/server/test_go/internal/integrationtests/pkread/performance_test.go
@@ -94,7 +94,7 @@ func BenchmarkSimple(b *testing.B) {
 			pkRESTTestWithClient(b, httpClient, testInfo, false, false)
 			latenciesChannel <- time.Since(requestStartTime)
 			count := ops.Add(1)
-			if count%4000000 == 0 {
+			if count%400000 == 0 {
 				tempTotalPkLookups := 400000
 				tempPkLookupsPerSecond := float64(tempTotalPkLookups) / time.Since(last).Seconds()
 				b.Logf("Throughput:                 %f pk lookups/second", tempPkLookupsPerSecond)


### PR DESCRIPTION
To implement Request statistics we use prometheus-cpp library. However it is not a good idea to call this library on each request. This will kill performance.

To handle this prometheus-cpp offers a possibility to report histograms instead of reporting every response time. In this implementation we have reported 61 entries in the histogram plus 3 for error codes.

This means that request counters can be had by summing all of those histogram counters together.

In addition we keep a counter of number of primary key lookups that RDRS2 is doing towards RonDB. This uses a separate counter.

Also ping and health have separate counters and no response time handling.

Since prometheus end point will likely be called every 10 seconds it means that we report 323 values every 10 seconds. This should also ensure that we don't overload the memory of the prometheus server. Reporting each response time would create hundreds of thousands of rows in prometheus and not likely to be handled well by the prometheus server.

The histogram reports static increments for short response times, for long response times the times are increasing logarithmically instead. This gives good accuracy for common, short response times while still providing some level of accuracy to long response times.