### PR TITLE
RONDB-880: ALTER TABLE with copying and BLOBs uses too large transact…

### DIFF
--- a/mysql-test/suite/ndb/r/ndb_alter_table_copy_blob.result
+++ b/mysql-test/suite/ndb/r/ndb_alter_table_copy_blob.result
@@ -1,0 +1,14 @@
+create table t1 (a int NOT NULL PRIMARY KEY, b int, c text) engine=ndb;
+show variables like '%ndb_use%';
+Variable_name	Value
+ndb_use_copying_alter_table	OFF
+ndb_use_exact_count	OFF
+ndb_use_transactions	ON
+set ndb_use_transactions=OFF;
+show variables like '%ndb_use%';
+Variable_name	Value
+ndb_use_copying_alter_table	OFF
+ndb_use_exact_count	OFF
+ndb_use_transactions	OFF
+alter table t1 modify column b bigint NOT NULL;
+drop table t1;

--- a/mysql-test/suite/ndb/t/ndb_alter_table_copy_blob.test
+++ b/mysql-test/suite/ndb/t/ndb_alter_table_copy_blob.test
@@ -1,0 +1,15 @@
+-- source include/have_ndb.inc
+create table t1 (a int NOT NULL PRIMARY KEY, b int, c text) engine=ndb;
+show variables like '%ndb_use%';
+set ndb_use_transactions=OFF;
+show variables like '%ndb_use%';
+let $1=25001;
+disable_query_log;
+while ($1)
+{
+ eval insert into t1 values($1, 1, 'abc');
+ dec $1;
+}
+enable_query_log;
+alter table t1 modify column b bigint NOT NULL;
+drop table t1;

--- a/storage/ndb/plugin/ha_ndbcluster.cc
+++ b/storage/ndb/plugin/ha_ndbcluster.cc
@@ -3190,6 +3190,9 @@ inline int ha_ndbcluster::fetch_next(NdbScanOperation *cursor) {
     if (m_thd_ndb->m_unsent_blob_ops) {
       if (execute_no_commit(m_thd_ndb, trans, m_ignore_no_key) != 0)
         return ndb_err(trans);
+      if (m_thd_ndb->check_trans_option(Thd_ndb::TRANS_TRANSACTIONS_OFF)) {
+        m_thd_ndb->m_unsent_bytes = 12;
+      }
     }
 
     /* Should be no unexamined completed operations

--- a/storage/ndb/rest-server/data-access-rondb/src/db-operations/pk/pkr-response.cpp
+++ b/storage/ndb/rest-server/data-access-rondb/src/db-operations/pk/pkr-response.cpp
@@ -181,6 +181,7 @@ RS_Status PKRResponse::SetColumnLength(Uint32 colNumber, Uint32 len) {
   int indexWritten = (start + (colNumber * COL_HEADERS_COUNT * ADDRESS_SIZE)) / ADDRESS_SIZE;
 
   b[indexWritten + 4] = len;  // data len
+  return RS_OK;
 }
 
 Uint32 PKRResponse::GetCurrentColNumber() {


### PR DESCRIPTION
…ions

The code in fetch_next calls execute_no_commit for every row and this resets the variables m_unsent_blob_ops and m_unsent_bytes. This leads to that no call to flush_bulk_insert is made when using BLOBs. Since flush_bulk_insert is responsible to commit every now and then, this will create very large transactions and effectively turn the ALTER TABLE into a single transaction.