### PR TITLE
[RONDB-892] Fix file system password handling bugs

### DIFF
--- a/storage/ndb/src/kernel/ndbd.cpp
+++ b/storage/ndb/src/kernel/ndbd.cpp
@@ -1156,6 +1156,12 @@ ndbd_run(bool foreground, int report_fd,
           "empty password not allowed");
       ndbd_exit(-1);
     }
+    if (pwd_size > MAX_BACKUP_ENCRYPTION_PASSWORD_LENGTH) {
+      g_eventLogger->info(
+          "Invalid filesystem password, "
+          "too long");
+      ndbd_exit(-1);
+    }
 
     memcpy(globalData.filesystemPassword, pwd, pwd_size);
     globalData.filesystemPassword[pwd_size] = '\0';


### PR DESCRIPTION
- Do not use uninitialized memory to generate encryption key, as that could lead to unrecoverable data.
- Check that password is not too long, as that would lead to memory corruption.