### PR TITLE
RONDB-905: Hint TC placement for REST API server

### DIFF
--- a/storage/ndb/rest-server2/server/src/config_structs_def.hpp
+++ b/storage/ndb/rest-server2/server/src/config_structs_def.hpp
@@ -18,6 +18,11 @@
  */
 
 /*
+ * NOTE:
+ * -----
+ * When updating the default setting of a config variable, ensure that you also
+ * set the same default in init_defaults.go in the test_go directory.
+ *
  * These class definitions for configuration are wrapped in macros so they can
  * be used for several things:
  * 1) Define the class

--- a/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.cpp
+++ b/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.cpp
@@ -350,51 +350,13 @@ BatchKeyOperations::init_batch_operations(ArenaMalloc *amalloc,
   return status;
 }
 
-RS_Status BatchKeyOperations::setup_transaction() {
-  if (unlikely(m_single_transaction)) {
-    KeyOperation *key_op = &m_key_ops[0];
-    key_op->m_ndbTransaction = m_ndb_object->startTransaction();
-    if (unlikely(key_op->m_ndbTransaction == nullptr)) {
-      return RS_RONDB_SERVER_ERROR(m_ndb_object->getNdbError(), 
-          std::string(rdrsErrorMessage(ERROR_TRANSACTION_START_FAILED)));
-    }
-  } else {
-    for (Uint32 i = 0; i < m_numOperations; i++) {
-      KeyOperation *key_op = &m_key_ops[i];
-      PKRRequest *req = &key_op->m_req;
-      if (req->IsInvalidOp()) {
-        continue;
-      }
-      const NdbDictionary::Table *table_dict = key_op->m_tableDict;
-      key_op->m_ndbTransaction = m_ndb_object->startTransaction(table_dict);
-      if (unlikely(key_op->m_ndbTransaction == nullptr)) {
-        return RS_RONDB_SERVER_ERROR(m_ndb_object->getNdbError(), 
-            std::string(rdrsErrorMessage(ERROR_TRANSACTION_START_FAILED)));
-      }
-    }
-  }
-  return RS_OK;
-}
-
-/**
- * Set up read operation
- *
- * @return status
- */
-RS_Status BatchKeyOperations::setup_read_operation() {
-
-  Uint32 opIdx = 0;
-start:
-  for (; opIdx < m_numOperations; opIdx++) {
+RS_Status BatchKeyOperations::setup_primary_keys() {
+  for (Uint32 opIdx = 0; opIdx < m_numOperations; opIdx++) {
     // this sub operation can not be processed
     KeyOperation *key_op = &m_key_ops[opIdx];
     PKRRequest *req = &key_op->m_req;
     if (unlikely(req->IsInvalidOp())) {
       continue;
-    }
-    NdbTransaction *trans = key_op->m_ndbTransaction;
-    if (unlikely(m_single_transaction)) {
-      trans = m_key_ops[0].m_ndbTransaction;
     }
     Uint32 numPrimaryKeys = key_op->m_num_pk_columns;
     for (Uint32 colIdx = 0; colIdx < numPrimaryKeys; colIdx++) {
@@ -409,12 +371,78 @@ start:
       if (unlikely(status.http_code != SUCCESS)) {
         if (m_isBatch) {
           req->MarkInvalidOp(status);
-          opIdx++;
-          goto start;
         } else {
           return status;
         }
       }
+    }
+  }
+  return RS_OK;
+}
+
+RS_Status BatchKeyOperations::setup_transactions() {
+  Uint32 tmp[MAX_KEY_SIZE_IN_WORDS * MAX_XFRM_MULTIPLY];
+  char *buf = (char *)&tmp[0];
+  if (unlikely(m_single_transaction)) {
+    KeyOperation *key_op = &m_key_ops[0];
+    KeyOperation *first_key_op = nullptr;
+    for (Uint32 i = 0; i < m_numOperations; i++) {
+      first_key_op = &m_key_ops[i];
+      PKRRequest *req = &first_key_op->m_req;
+      if (req->IsInvalidOp()) {
+        first_key_op = nullptr;
+        continue;
+      }
+      break;
+    }
+    /* Check that at least one operation is valid */
+    if (first_key_op != nullptr) {
+      key_op->m_ndbTransaction = m_ndb_object->startTransaction(
+        first_key_op->m_ndb_record,
+        (const char*)first_key_op->m_row,
+        buf,
+        sizeof(tmp));
+      if (unlikely(key_op->m_ndbTransaction == nullptr)) {
+        return RS_RONDB_SERVER_ERROR(m_ndb_object->getNdbError(), 
+          std::string(rdrsErrorMessage(ERROR_TRANSACTION_START_FAILED)));
+      }
+    }
+  } else {
+    for (Uint32 i = 0; i < m_numOperations; i++) {
+      KeyOperation *key_op = &m_key_ops[i];
+      PKRRequest *req = &key_op->m_req;
+      if (req->IsInvalidOp()) {
+        continue;
+      }
+      key_op->m_ndbTransaction = m_ndb_object->startTransaction(
+        key_op->m_ndb_record,
+        (const char*)key_op->m_row,
+        buf,
+        sizeof(tmp));
+      if (unlikely(key_op->m_ndbTransaction == nullptr)) {
+        return RS_RONDB_SERVER_ERROR(m_ndb_object->getNdbError(), 
+            std::string(rdrsErrorMessage(ERROR_TRANSACTION_START_FAILED)));
+      }
+    }
+  }
+  return RS_OK;
+}
+
+/**
+ * Set up read operation
+ *
+ * @return status
+ */
+RS_Status BatchKeyOperations::setup_read_operations() {
+  for (Uint32 opIdx = 0; opIdx < m_numOperations; opIdx++) {
+    KeyOperation *key_op = &m_key_ops[opIdx];
+    PKRRequest *req = &key_op->m_req;
+    if (unlikely(req->IsInvalidOp())) {
+      continue;
+    }
+    NdbTransaction *trans = key_op->m_ndbTransaction;
+    if (unlikely(m_single_transaction)) {
+      trans = m_key_ops[0].m_ndbTransaction;
     }
     DEB_NDB_BE("readTuple: read_columns[%u]: 0x%x,0x%x",
               opIdx,
@@ -474,19 +502,21 @@ start:
 }
 
 RS_Status BatchKeyOperations::execute() {
-  if (unlikely(m_single_transaction)) {
-    NdbTransaction *trans = m_key_ops[0].m_ndbTransaction;
-    if (unlikely(trans->execute(NdbTransaction::NoCommit) != 0)) {
-      return RS_RONDB_SERVER_ERROR(trans->getNdbError(),
-        std::string(rdrsErrorMessage(ERROR_TRANSACTION_EXEC_FAILED)));
-    }
-  } else {
-    if (m_ndb_object->sendPollNdb(
-        WAITFOR_RESPONSE_TIMEOUT, m_num_sent_operations) <
-          (int)m_num_sent_operations) {
-      return RS_RONDB_SERVER_ERROR(
-        m_ndb_object->getNdbError(),
-        std::string(rdrsErrorMessage(ERROR_TRANSACTION_EXEC_FAILED)));
+  if (m_num_sent_operations > 0) {
+    if (unlikely(m_single_transaction)) {
+      NdbTransaction *trans = m_key_ops[0].m_ndbTransaction;
+      if (unlikely(trans->execute(NdbTransaction::NoCommit) != 0)) {
+        return RS_RONDB_SERVER_ERROR(trans->getNdbError(),
+          std::string(rdrsErrorMessage(ERROR_TRANSACTION_EXEC_FAILED)));
+      }
+    } else {
+      if (m_ndb_object->sendPollNdb(
+          WAITFOR_RESPONSE_TIMEOUT, m_num_sent_operations) <
+            (int)m_num_sent_operations) {
+        return RS_RONDB_SERVER_ERROR(
+          m_ndb_object->getNdbError(),
+          std::string(rdrsErrorMessage(ERROR_TRANSACTION_EXEC_FAILED)));
+      }
     }
   }
   return RS_OK;
@@ -1168,14 +1198,20 @@ RS_Status BatchKeyOperations::perform_operation(
     handle_ndb_error(status);
     return status;
   }
-  DEB_NDB_BE("setup_transaction");
-  status = setup_transaction();
+  DEB_NDB_BE("setup_primary_keys");
+  status = setup_primary_keys();
   if (unlikely(status.http_code != SUCCESS)) {
     handle_ndb_error(status);
     return status;
   }
-  DEB_NDB_BE("setup_read_operation");
-  status = setup_read_operation();
+  DEB_NDB_BE("setup_transactions");
+  status = setup_transactions();
+  if (unlikely(status.http_code != SUCCESS)) {
+    handle_ndb_error(status);
+    return status;
+  }
+  DEB_NDB_BE("setup_read_operations");
+  status = setup_read_operations();
   if (unlikely(status.http_code != SUCCESS)) {
     handle_ndb_error(status);
     return status;

--- a/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.hpp
+++ b/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.hpp
@@ -78,8 +78,9 @@ class BatchKeyOperations {
                                    bool is_batch,
                                    RS_Buffer *reqBuffer,
                                    Ndb *ndb_object);
-   RS_Status setup_transaction();
-   RS_Status setup_read_operation();
+   RS_Status setup_primary_keys();
+   RS_Status setup_transactions();
+   RS_Status setup_read_operations();
    RS_Status execute();
    RS_Status create_response(RS_Buffer *respBuffer);
    RS_Status append_op_recs(Uint32);

--- a/storage/ndb/rest-server2/server/test_go/internal/config/init_defaults.go
+++ b/storage/ndb/rest-server2/server/test_go/internal/config/init_defaults.go
@@ -50,7 +50,7 @@ func newWithDefaults() AllConfigs {
 			BufferSize:          5 * 1024 * 1024,
 			GOMAXPROCS:          -1,
 			PreAllocatedBuffers: 32,
-			BatchMaxSize:        256,
+			BatchMaxSize:        1024,
 			OperationIDMaxSize:  256,
 		},
 		GRPC: GRPC{


### PR DESCRIPTION
Previously no hinting of TC placement was done in REST API Server. The REST API server uses NdbRecord variant of NDB API and there is a simple way of using NdbRecord and pointer to the row for startTransaction call. However one needed to move the setting of the row from setup_read_operation to a new method setup_primary_keys. Renamed setup_transaction and setup_read_operation to setup_transactions and setup_read_operations. Fixed problem introduced by previous patch when setting BatchMaxSize, the change needed to be in init_defaults.go as well for MTR tests to pass.

The special case where all operations in the batch were invalid was handled in a few places.