### PR TITLE
 [RONDB-903] Fix port numbers for REST and GRPC servers

### DIFF
--- a/build_scripts/release_scripts/build-docker-image/Dockerfile
+++ b/build_scripts/release_scripts/build-docker-image/Dockerfile
@@ -143,5 +143,5 @@ RUN chmod 777 -R $RONDB_DATA_DIR \
 RUN echo "PS1='${debian_chroot:+(\$debian_chroot)}\h:\w\$ '" >> /etc/bash.bashrc
 
 ENTRYPOINT ["./docker/rondb_standalone/entrypoints/main.sh"]
-EXPOSE 3306 33060 11860 1186 4406 5406
+EXPOSE 3306 33060 11860 1186 4406 5406 6379
 CMD ["mysqld"]

--- a/storage/ndb/rest-server/rest-api-server/internal/config/init_defaults.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/config/init_defaults.go
@@ -58,12 +58,12 @@ func newWithDefaults() AllConfigs {
 		GRPC: GRPC{
 			Enable:     true,
 			ServerIP:   "0.0.0.0",
-			ServerPort: 4406,
+			ServerPort: 5406,
 		},
 		REST: REST{
 			Enable:     true,
 			ServerIP:   "0.0.0.0",
-			ServerPort: 5406,
+			ServerPort: 4406,
 		},
 		RonDB: RonDB{
 			Mgmds: []Mgmd{

--- a/storage/ndb/rest-server2/server/src/config_structs_def.hpp
+++ b/storage/ndb/rest-server2/server/src/config_structs_def.hpp
@@ -176,7 +176,7 @@ CLASS
 (GRPC,
  CM(bool, enable, Enable, false, "Whether to enable the gRPC server.")
  CM(std::string, serverIP, ServerIP, "0.0.0.0", "The IP address to listen on.")
- CM(Uint16, serverPort, ServerPort, 4406, "TCP port to listen on.")
+ CM(Uint16, serverPort, ServerPort, 5406, "TCP port to listen on.")
  PROBLEM(enable, "gRPC not supported")
 )
 

--- a/storage/ndb/rest-server2/server/test_go/internal/config/init_defaults.go
+++ b/storage/ndb/rest-server2/server/test_go/internal/config/init_defaults.go
@@ -56,12 +56,12 @@ func newWithDefaults() AllConfigs {
 		GRPC: GRPC{
 			Enable:     false,
 			ServerIP:   "0.0.0.0",
-			ServerPort: 4406,
+			ServerPort: 5406,
 		},
 		REST: REST{
 			Enable:     true,
 			ServerIP:   "0.0.0.0",
-			ServerPort: 5406,
+			ServerPort: 4406,
 		},
 		RonDB: RonDB{
 			Mgmds: []Mgmd{


### PR DESCRIPTION
Commit `b96796bfa47 RONDB-903: Fix port number of REST to 4406, was
using GRPC port` changed the rdrs2 REST default port from 5406 to
4406. This is since 4406 has been used in documentation, examples and
in hopsworks. However, both rdrs and rdrs2 implementation has
defaulted to 5504 while 4404 was used for GRPC, which is inconsistent
with documentation.

This change makes port numbers across rdrs and rdrs2, documentation
and implementation, consistent:
- Change rdrs1 REST implementation default port to 4406.
- Change rdrs1 GRPC implementation default port to 5406.
- Change rdrs2 GRPC implementation default port to 5406.
- Change rdrs2 test_go REST default port to 4406.
- Change rdrs2 test_go GRPC default port to 5406.

Also, add Rondis default port to docker container exposed ports.