### PR TITLE
Fix boost download

### DIFF
--- a/Dockerfile.oraclelinux7
+++ b/Dockerfile.oraclelinux7
@@ -65,8 +65,9 @@ ENV BOOST_V_UNDERSCORE=${BOOST_VERSION_MAJOR}_${BOOST_VERSION_MINOR}_${BOOST_VER
 ENV BOOST_LABEL="boost_${BOOST_V_UNDERSCORE}"
 ENV BOOST_TARBALL="${BOOST_LABEL}.tar.gz"
 RUN --mount=type=cache,target=$DOWNLOADS_CACHE_DIR \
+    rm -f $DOWNLOADS_CACHE_DIR/${BOOST_TARBALL} && \
     wget -N --progress=bar:force -P $DOWNLOADS_CACHE_DIR \
-        https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/${BOOST_TARBALL} \
+        https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_TARBALL} \
     && tar xzf $DOWNLOADS_CACHE_DIR/${BOOST_TARBALL} -C .
 # Important env variable for RonDB compilation
 ENV BOOST_ROOT="/${BOOST_LABEL}"

--- a/Dockerfile.oraclelinux9
+++ b/Dockerfile.oraclelinux9
@@ -66,8 +66,9 @@ ENV BOOST_V_UNDERSCORE=${BOOST_VERSION_MAJOR}_${BOOST_VERSION_MINOR}_${BOOST_VER
 ENV BOOST_LABEL="boost_${BOOST_V_UNDERSCORE}"
 ENV BOOST_TARBALL="${BOOST_LABEL}.tar.gz"
 RUN --mount=type=cache,target=$DOWNLOADS_CACHE_DIR \
+    rm -f $DOWNLOADS_CACHE_DIR/${BOOST_TARBALL} && \
     wget -N --progress=bar:force -P $DOWNLOADS_CACHE_DIR \
-        https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/${BOOST_TARBALL} \
+        https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_TARBALL} \
     && tar xzf $DOWNLOADS_CACHE_DIR/${BOOST_TARBALL} -C .
 # Important env variable for RonDB compilation
 ENV BOOST_ROOT="/${BOOST_LABEL}"

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -50,8 +50,9 @@ ENV BOOST_V_UNDERSCORE=${BOOST_VERSION_MAJOR}_${BOOST_VERSION_MINOR}_${BOOST_VER
 ENV BOOST_LABEL="boost_${BOOST_V_UNDERSCORE}"
 ENV BOOST_TARBALL="${BOOST_LABEL}.tar.gz"
 RUN --mount=type=cache,target=$DOWNLOADS_CACHE_DIR \
+    rm -f $DOWNLOADS_CACHE_DIR/${BOOST_TARBALL} && \
     wget -N --progress=bar:force -P $DOWNLOADS_CACHE_DIR \
-        https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/${BOOST_TARBALL} \
+        https://archives.boost.io/release/${BOOST_VERSION}/source/${BOOST_TARBALL} \
     && tar xzf $DOWNLOADS_CACHE_DIR/${BOOST_TARBALL} -C .
 # Important env variable for RonDB compilation
 ENV BOOST_ROOT="/${BOOST_LABEL}"

--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -41,7 +41,7 @@
 SET(BOOST_PACKAGE_NAME "boost_1_77_0")
 SET(BOOST_TARBALL "${BOOST_PACKAGE_NAME}.tar.bz2")
 SET(BOOST_DOWNLOAD_URL
-  "https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/${BOOST_TARBALL}"
+  "https://archives.boost.io/release/1.77.0/source/${BOOST_TARBALL}"
   )
 
 SET(OLD_PACKAGE_NAMES


### PR DESCRIPTION
Commit `c3a4a8245e1 fixed docker file` fixed the boost download in Dockerfile.oraclelinux8.

Apply the same fix to Dockerfile.oraclelinux7, Dockerfile.oraclelinux9 and Dockerfile.ubuntu22. Also fix boost download in cmake.