### PR TITLE
Add status variable Ndb_is_db_nodes_all_alive to indicate the health …

### DIFF
--- a/storage/ndb/include/ndbapi/ndb_cluster_connection.hpp
+++ b/storage/ndb/include/ndbapi/ndb_cluster_connection.hpp
@@ -453,6 +453,7 @@ class Ndb_cluster_connection {
    * @return #nodes connected, or -1 on error
    */
   int wait_until_ready(const int *nodes, int cnt, int timeout);
+  int db_nodes_all_alive();
 #endif
 
  private:

--- a/storage/ndb/plugin/ha_ndbcluster.cc
+++ b/storage/ndb/plugin/ha_ndbcluster.cc
@@ -484,6 +484,7 @@ struct st_ndb_status {
   long long api_client_stats[Ndb::NumClientStatistics];
   const char *system_name;
   long fetch_table_stats;
+  long db_nodes_all_alive;
 };
 
 /* Status variables shown with 'show status like 'Ndb%' */
@@ -510,6 +511,7 @@ static int update_status_variables(Thd_ndb *thd_ndb, st_ndb_status *ns,
   ns->connect_count = c->get_connect_count();
   ns->system_name = c->get_system_name();
   ns->last_commit_epoch_server = ndb_get_latest_trans_gci();
+  ns->db_nodes_all_alive = c->db_nodes_all_alive();
   if (thd_ndb) {
     ns->execute_count = thd_ndb->m_execute_count;
     ns->trans_hint_count = thd_ndb->hinted_trans_count();
@@ -644,6 +646,8 @@ static SHOW_VAR ndb_status_vars_dynamic[] = {
      SHOW_SCOPE_GLOBAL},
     {"fetch_table_stats", (char *)&g_ndb_status.fetch_table_stats, SHOW_LONG,
      SHOW_SCOPE_GLOBAL},
+    {"is_db_nodes_all_alive", (char *)&g_ndb_status.db_nodes_all_alive,
+     SHOW_LONG, SHOW_SCOPE_GLOBAL},
     {NullS, NullS, SHOW_LONG, SHOW_SCOPE_GLOBAL}};
 
 // Global instance of stats for the default replication channel, populated

--- a/storage/ndb/src/ndbapi/ClusterMgr.cpp
+++ b/storage/ndb/src/ndbapi/ClusterMgr.cpp
@@ -1938,6 +1938,27 @@ void ClusterMgr::print_nodes(const char *where, NdbOut &out) {
   out << "<<" << endl;
 }
 
+int ClusterMgr::db_nodes_all_alive() {
+  int all_alive = 1;
+  TransporterRegistry *tr = theFacade.get_registry();
+  for (NodeId n = 1; n < MAX_NODES; n++) {
+    const trp_node node = getNodeInfo(n);
+    if (!node.defined) continue;
+    /*
+     * Note:
+     * We don’t use node.m_node_active to determine whether the node is
+     * activated or deactivated, because the node info in ClusterMgr
+     * may be outdated.
+     */
+    if (node.m_info.getType() == NODE_TYPE_DB
+        && tr->get_active_node(n) &&!node.m_alive) {
+      all_alive = 0;
+      break;
+    }
+  }
+  return all_alive;
+}
+
 void ClusterMgr::setProcessInfoUri(const char *scheme,
                                    const char *address_string, int port,
                                    const char *path) {

--- a/storage/ndb/src/ndbapi/ClusterMgr.hpp
+++ b/storage/ndb/src/ndbapi/ClusterMgr.hpp
@@ -279,6 +279,7 @@ public:
   Uint32 get_node_change_count();
   void lock_node_state();
   void unlock_node_state();
+  int db_nodes_all_alive();
 };
 
 inline const trp_node &ClusterMgr::getNodeInfo(NodeId nodeId) const {

--- a/storage/ndb/src/ndbapi/TransporterFacade.hpp
+++ b/storage/ndb/src/ndbapi/TransporterFacade.hpp
@@ -681,6 +681,12 @@ inline unsigned Ndb_cluster_connection_impl::get_connect_count() const {
   return 0;
 }
 
+inline int Ndb_cluster_connection_impl::db_nodes_all_alive() {
+  if (m_transporter_facade->theClusterMgr)
+    return m_transporter_facade->theClusterMgr->db_nodes_all_alive();
+  return false;
+}
+
 inline unsigned Ndb_cluster_connection_impl::get_min_db_version() const {
   return m_transporter_facade->getMinDbNodeVersion();
 }

--- a/storage/ndb/src/ndbapi/ndb_cluster_connection.cpp
+++ b/storage/ndb/src/ndbapi/ndb_cluster_connection.cpp
@@ -312,6 +312,10 @@ unsigned Ndb_cluster_connection::no_db_nodes() {
   return m_impl.m_nodes_comm_group.size();
 }
 
+int Ndb_cluster_connection::db_nodes_all_alive() {
+  return m_impl.db_nodes_all_alive();
+}
+
 Uint32 Ndb_cluster_connection::max_api_nodeid() const {
   return m_impl.m_max_api_nodeid;
 }

--- a/storage/ndb/src/ndbapi/ndb_cluster_connection_impl.hpp
+++ b/storage/ndb/src/ndbapi/ndb_cluster_connection_impl.hpp
@@ -85,6 +85,7 @@ class Ndb_cluster_connection_impl : public Ndb_cluster_connection {
  public:
   inline Uint64 *get_latest_trans_gci() { return &m_latest_trans_gci; }
   int set_location_domain_id(Uint32 nodeId, Uint32 location_domain_id);
+  int db_nodes_all_alive();
 
  private:
   friend class Ndb;


### PR DESCRIPTION
…state of activated DB nodes.

The variable returns an integer value:
  1: All activated nodes are alive
  0: At least one of the activated nodes is not alive