### PR TITLE
RONDB-899: Improve scaling of large data nodes

### DIFF
--- a/storage/ndb/include/kernel/ndb_limits.h
+++ b/storage/ndb/include/kernel/ndb_limits.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2024, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2024, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -51,7 +51,9 @@
 #define MAX_USED_NUM_CPUS 800
 #define MAX_QUERY_THREAD_PER_LDM 3
 #define MIN_RR_GROUP_SIZE 4
-#define MAX_RR_GROUP_SIZE 16
+#define MIN_MAX_RR_GROUP_SIZE 8
+#define DEF_MAX_RR_GROUP_SIZE 16
+#define MAX_RR_GROUP_SIZE 32
 
 /**************************************************************************
  * IT SHOULD BE (MAX_NDB_NODES - 1).

--- a/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
+++ b/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
@@ -24,8 +24,8 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
-#ifndef MGMAPI_CONFIG_PARAMTERS_H
-#define MGMAPI_CONFIG_PARAMTERS_H
+#ifndef MGMAPI_CONFIG_PARAMETERS_H
+#define MGMAPI_CONFIG_PARAMETERS_H
 
 #define CFG_SYS_NAME                  3
 #define CFG_SYS_PRIMARY_MGM_NODE      1
@@ -296,6 +296,8 @@
 
 #define CFG_DB_USE_TC_IN_RR_GROUP     700
 #define CFG_DB_MAX_RR_GROUP_SIZE      701
+#define CFG_DB_NUM_LQHKEYREQ_COUNTS   702
+#define CFG_DB_NUM_SCAN_FRAGREQ_COUNTS 703
 
 /* End RonDB only configuration parameters */
 

--- a/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
+++ b/storage/ndb/include/mgmapi/mgmapi_config_parameters.h
@@ -293,6 +293,10 @@
 #define CFG_DB_UNDO_BUFFER            697
 #define CFG_DB_TOTAL_MEMORY_CONFIG    698
 #define CFG_DB_AUTO_MEMORY_CONFIG     699
+
+#define CFG_DB_USE_TC_IN_RR_GROUP     700
+#define CFG_DB_MAX_RR_GROUP_SIZE      701
+
 /* End RonDB only configuration parameters */
 
 #define CFG_NODE_ARBIT_RANK           200

--- a/storage/ndb/include/mgmcommon/thr_config.hpp
+++ b/storage/ndb/include/mgmcommon/thr_config.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2022, 2024, Oracle and/or its affiliates.
-   Copyright (c) 2022, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2022, 2025, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -70,7 +70,8 @@ public:
                     unsigned num_cpus,
                     unsigned &num_rr_groups,
                     bool use_tc_threads,
-                    bool use_ldm_threads);
+                    bool use_ldm_threads,
+                    unsigned max_rr_group_size);
   int do_parse_thrconfig(const char * ThreadConfig,
                          unsigned realtime,
                          unsigned spintime);

--- a/storage/ndb/include/portlib/NdbHW.hpp
+++ b/storage/ndb/include/portlib/NdbHW.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2013, 2024, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -148,7 +148,7 @@ extern "C"
    * Round Robin groups of LDM groups that are contained in the same
    * virtual L3 cache groups.
    */
-  Uint32 Ndb_CreateCPUMap(Uint32 num_query_instances);
+  Uint32 Ndb_CreateCPUMap(Uint32 num_query_instances, Uint32 max_rr_group_size);
   bool Ndb_InitRRGroups(Uint32 *rr_group,
                         Uint32 num_rr_groups,
                         Uint32 num_query_instances,
@@ -156,7 +156,7 @@ extern "C"
   Uint32 Ndb_GetFirstCPUInMap(Uint32 & rr_group);
   Uint32 Ndb_GetNextCPUInMap(Uint32 cpu_id, Uint32 & rr_group);
 
-  Uint32 Ndb_GetRRGroups(Uint32 query_instances);
+  Uint32 Ndb_GetRRGroups(Uint32 query_instances, Uint32 max_rr_group_size);
 
   /**
    * Get the CPU id of all the CPUs in the CPU core of the

--- a/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
+++ b/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
@@ -613,6 +613,31 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     "true" },
 
   {
+    CFG_DB_USE_TC_IN_RR_GROUP,
+    "UseTcInRRGroup",
+    DB_TOKEN,
+    "Each recv thread will distribute connections only to tc threads "
+    "in the same RR group, false means distribute to all",
+    ConfigInfo::CI_USED,
+    false,
+    ConfigInfo::CI_BOOL,
+    "false",
+    "false",
+    "true" },
+
+  {
+    CFG_DB_MAX_RR_GROUP_SIZE,
+    "MaxRRGroupSize",
+    DB_TOKEN,
+    "Max size of a Round Robin group",
+    ConfigInfo::CI_USED,
+    false,
+    ConfigInfo::CI_INT,
+    STR_VALUE(MAX_RR_GROUPS),
+    STR_VALUE(MIN_MAX_RR_GROUPS),
+    STR_VALUE(MAX_RR_GROUPS) },
+
+  {
     CFG_DB_MAX_NUM_SCHEMA_OBJECTS,
     "MaxNoOfSchemaObjects",
     DB_TOKEN,

--- a/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
+++ b/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
@@ -626,6 +626,32 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     "true" },
 
   {
+    CFG_DB_NUM_LQHKEYREQ_COUNTS,
+    "KeyBatchSizeQueryWorker",
+    DB_TOKEN,
+    "Number of LQHKEYREQ signals sent to query worker before next"
+    " worker is used",
+    ConfigInfo::CI_USED,
+    false,
+    ConfigInfo::CI_INT,
+    STR_VALUE(NUM_LQHKEYREQ_COUNTS),
+    "1",
+    "64" },
+
+  {
+    CFG_DB_NUM_SCAN_FRAGREQ_COUNTS,
+    "ScanBatchSizeQueryWorker",
+    DB_TOKEN,
+    "Number of SCAN_FRAGREQ signals sent to query worker before next"
+    " worker is used",
+    ConfigInfo::CI_USED,
+    false,
+    ConfigInfo::CI_INT,
+    STR_VALUE(NUM_SCAN_FRAGREQ_COUNTS),
+    "1",
+    "16" },
+
+  {
     CFG_DB_MAX_RR_GROUP_SIZE,
     "MaxRRGroupSize",
     DB_TOKEN,

--- a/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
+++ b/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
@@ -449,7 +449,7 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
 
     {CFG_DB_MAX_SEND_DELAY, "MaxSendDelay", DB_TOKEN,
      "Max number of microseconds to delay sending in ndbmtd",
-     ConfigInfo::CI_DEPRECATED, false, ConfigInfo::CI_INT, "125", "0", "1000"},
+     ConfigInfo::CI_USED, false, ConfigInfo::CI_INT, "0", "0", "1000"},
 
     {CFG_DB_SCHED_SPIN_TIME, "SchedulerSpinTimer", DB_TOKEN,
      "Number of microseconds to execute in scheduler before sleeping",

--- a/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
+++ b/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
@@ -613,6 +613,30 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
     "true" },
 
   {
+    CFG_DB_USE_TC_THREADS,
+    "UseTcThreads",
+    DB_TOKEN,
+    "Use tc threads",
+    ConfigInfo::CI_USED,
+    false,
+    ConfigInfo::CI_BOOL,
+    "true",
+    "false",
+    "true" },
+
+  {
+    CFG_DB_USE_LDM_THREADS,
+    "UseLdmThreads",
+    DB_TOKEN,
+    "Use ldm threads, not using it implies only recv threads",
+    ConfigInfo::CI_USED,
+    false,
+    ConfigInfo::CI_BOOL,
+    "true",
+    "false",
+    "true" },
+
+  {
     CFG_DB_USE_TC_IN_RR_GROUP,
     "UseTcInRRGroup",
     DB_TOKEN,

--- a/storage/ndb/src/common/mgmcommon/thr_config.cpp
+++ b/storage/ndb/src/common/mgmcommon/thr_config.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2022, 2024, Oracle and/or its affiliates.
-   Copyright (c) 2020, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2020, 2025, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -524,7 +524,8 @@ THRConfig::do_parse_auto(unsigned realtime,
                          unsigned num_cpus,
                          unsigned &num_rr_groups,
                          bool use_tc_threads,
-                         bool use_ldm_threads) {
+                         bool use_ldm_threads,
+                         unsigned max_rr_group_size) {
   Uint32 tc_threads = 0;
   Uint32 ldm_threads = 0;
   Uint32 main_threads = 0;
@@ -658,12 +659,13 @@ THRConfig::do_parse_auto(unsigned realtime,
      * which L3 cache a Round Robin group belongs to.
      */
     num_rr_groups =
-      Ndb_CreateCPUMap(num_query_instances);
+      Ndb_CreateCPUMap(num_query_instances, max_rr_group_size);
     Uint32 count_ldm_threads = ldm_threads;
     Uint32 count_tc_threads = tc_threads;
     Uint32 count_main_threads = main_threads;
     Uint32 count_rep_threads = rep_threads;
     Uint32 count_recv_threads = recv_threads;
+    Uint32 count_send_threads = send_threads;
     g_eventLogger->info("Number of RR Groups = %u", num_rr_groups);
     Uint32 rr_group = 0;
     Uint32 next_cpu_id = Ndb_GetFirstCPUInMap(rr_group);
@@ -680,24 +682,19 @@ THRConfig::do_parse_auto(unsigned realtime,
     Uint32 num_only_ldms_in_group = num_rr_groups * num_only_ldm_groups;
     assert(num_only_ldms_in_group <= count_ldm_threads);
 
-    for (Uint32 i = 0; i < num_cpus; i++)
-    {
+    for (Uint32 i = 0; i < num_cpus; i++) {
       Uint32 thread_type = T_SEND; // T_SEND silences compiler
       Uint32 inx = RNIL;
       Uint32 odd = (i & 1) == 1;
-      if (i != 0)
-      {
+      if (i != 0) {
         next_cpu_id = Ndb_GetNextCPUInMap(next_cpu_id, rr_group);
       }
-      if (num_only_ldms_in_group > 0)
-      {
+      if (num_only_ldms_in_group > 0) {
         thread_type = T_LDM;
         count_ldm_threads--;
         num_only_ldms_in_group--;
         inx = count_ldm_threads;
-      }
-      else
-      {
+      } else {
         /**
          * We want to balance the CPU load on the non-LDM CPU cores and
          * similarly we want to achieve a balanced load on the Round Robin
@@ -714,64 +711,52 @@ THRConfig::do_parse_auto(unsigned realtime,
          * core and thus we should have a fairly good balance also on
          * Round Robin groups.
          */
-        if (odd)
-        {
-          if (count_main_threads > 0)
-          {
-            thread_type = T_MAIN;
-            count_main_threads--;
-            inx = count_main_threads;
-          }
-          else if (count_rep_threads > 0)
-          {
+        if (odd) {
+          if (count_tc_threads > 0) {
+            thread_type = T_TC;
+            count_tc_threads--;
+            inx = count_tc_threads;
+          } else if (count_rep_threads > 0) {
             thread_type = T_REP;
             count_rep_threads--;
             inx = count_rep_threads;
-          }
-          else if (count_tc_threads > 0)
-          {
-            thread_type = T_TC;
-            count_tc_threads--;
-            inx = count_tc_threads;
-          }
-          else if (count_recv_threads > 0)
-          {
+          } else if (count_recv_threads > 0) {
             thread_type = T_RECV;
             count_recv_threads--;
             inx = count_recv_threads;
-          }
-          else
-          {
-            /* Send thread handled in non-odd part */
-            odd = false;
+          } else {
+            require(send_threads > 0);
+            thread_type = T_SEND;
+            count_send_threads--;
+            inx = count_send_threads;
           }
         }
-        if (!odd)
-        {
-          if (count_ldm_threads > 0)
-          {
+        if (!odd) {
+          if (count_ldm_threads > 0) {
             thread_type = T_LDM;
             count_ldm_threads--;
             inx = count_ldm_threads;
-          }
-          else if (count_recv_threads > 0)
-          {
+          } else if (count_recv_threads > 0) {
             thread_type = T_RECV;
             count_recv_threads--;
             inx = count_recv_threads;
-          }
-          else if (count_tc_threads > 0)
-          {
+          } else if (count_main_threads > 0) {
+            thread_type = T_MAIN;
+            count_main_threads--;
+            inx = count_main_threads;
+          } else if (count_send_threads > 0) {
+            thread_type = T_SEND;
+            count_send_threads--;
+            inx = count_send_threads;
+          } else if (count_rep_threads > 0) {
+            thread_type = T_REP;
+            count_rep_threads--;
+            inx = count_rep_threads;
+          } else {
+            require(tc_threads > 0);
             thread_type = T_TC;
             count_tc_threads--;
             inx = count_tc_threads;
-          }
-          else
-          {
-            require(send_threads > 0);
-            thread_type = T_SEND;
-            send_threads--;
-            inx = send_threads;
           }
         }
       }
@@ -852,7 +837,7 @@ THRConfig::do_parse_auto(unsigned realtime,
       }
     }
   } else {
-    num_rr_groups = Ndb_GetRRGroups(num_query_instances);
+    num_rr_groups = Ndb_GetRRGroups(num_query_instances, max_rr_group_size);
   }
   return 0;
 }

--- a/storage/ndb/src/common/portlib/NdbHW.cpp
+++ b/storage/ndb/src/common/portlib/NdbHW.cpp
@@ -237,8 +237,9 @@ void Ndb_GetCoreCPUIds(Uint32 cpu_id, Uint32 *cpu_ids, Uint32 &num_cpus) {
   return;
 }
 
-Uint32 Ndb_GetRRGroups(Uint32 num_query_instances) {
-  return (num_query_instances + MAX_RR_GROUP_SIZE) / MAX_RR_GROUP_SIZE;
+Uint32 Ndb_GetRRGroups(Uint32 num_query_instances, Uint32 max_rr_group_size) {
+  return (num_query_instances + max_rr_group_size) /
+          max_rr_group_size;
 }
 
 Uint32 Ndb_GetFirstCPUInMap(Uint32 &rr_group) {
@@ -974,7 +975,8 @@ create_virt_l3_cache_list(struct ndb_hwinfo *hwinfo,
   return 0;
 }
 
-Uint32 Ndb_CreateCPUMap(Uint32 num_query_instances) {
+Uint32 Ndb_CreateCPUMap(Uint32 num_query_instances,
+                        Uint32 max_rr_group_size) {
   struct ndb_hwinfo *hwinfo = g_ndb_hwinfo;
   /**
    * We have set up HW information and now we need to set up the CPU map
@@ -991,7 +993,7 @@ Uint32 Ndb_CreateCPUMap(Uint32 num_query_instances) {
    */
   g_create_cpu_map = true;
   num_query_instances = (num_query_instances == 0) ? 1 : num_query_instances;
-  Uint32 optimal_group_size = MAX_RR_GROUP_SIZE;
+  Uint32 optimal_group_size = max_rr_group_size;
   Uint32 min_group_size = MIN(MIN_RR_GROUP_SIZE, num_query_instances);
   Uint32 max_num_groups =
     (num_query_instances + (min_group_size - 1)) / min_group_size;
@@ -3113,6 +3115,7 @@ test_create_cpumap()
   expected_res[24] = 2;
   expected_res[25] = 4;
   struct test_cpumap_data test_map;
+  Uint32 max_rr_group_size = 16;
   for (Uint32 i = 0; i < NUM_TESTS; i++) {
     printf("Start test %u\n", i + 1);
     test_create(&test_map, i);
@@ -3120,7 +3123,7 @@ test_create_cpumap()
     create_hwinfo_test_cpu_map(&test_map);
     printf("Create CPUMap for test %u\n", i + 1);
     Uint32 num_rr_groups =
-      Ndb_CreateCPUMap(test_map.num_query_instances);
+      Ndb_CreateCPUMap(test_map.num_query_instances, max_rr_group_size);
     for (Uint32 id = 0; id < g_ndb_hwinfo->cpu_cnt_max; id++)
     {
       Uint32 cpu_ids[MAX_USED_NUM_CPUS];

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcProxy.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcProxy.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2011, 2024, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2024, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -185,34 +185,125 @@ void DbtcProxy::execTCSEIZEREQ(Signal *signal) {
     return;
   }
 
-  if (globalData.ndbMtTcThreads == 0)
-  {
-    jam();
-    BlockReference sender_ref = signal->senderBlockRef();
-    NodeId node_id = refToNode(sender_ref);
-    Uint32 instance;
-    if (node_id == getOwnNodeId())
-    {
-      instance = 0; /* Handle Startup */
-    }
-    else
-    {
-      instance = map_api_node_to_recv_instance(node_id);
-      ndbrequire(instance != RNIL);
-      ndbrequire(instance < globalData.ndbMtReceiveThreads);
-    }
-    signal->theData[2] = (1 + instance);
-    sendSignal(workerRef(instance), GSN_TCSEIZEREQ, signal,
-               signal->getLength(), JBB);
-  }
-  else
+  if (globalData.ndbMtTcThreads > 0 &&
+      !globalData.theUseTcInSameRRGroup)
   {
     jam();
     signal->theData[2] = 1 + m_tc_seize_req_instance;
+    m_tc_seize_req_instance = (m_tc_seize_req_instance + 1) % c_workers;
     sendSignal(workerRef(m_tc_seize_req_instance), GSN_TCSEIZEREQ, signal,
                signal->getLength(), JBB);
-    m_tc_seize_req_instance = (m_tc_seize_req_instance + 1) % c_workers;
+    return;
   }
+  jam();
+  BlockReference sender_ref = signal->senderBlockRef();
+  NodeId node_id = refToNode(sender_ref);
+  Uint32 instance;
+  if (node_id == getOwnNodeId()) {
+    instance = 0; /* Handle Startup */
+    signal->theData[2] = (1 + instance);
+    sendSignal(workerRef(instance), GSN_TCSEIZEREQ, signal,
+                         signal->getLength(), JBB);
+    return;
+  } else {
+    instance = map_api_node_to_recv_instance(node_id);
+    ndbrequire(instance != RNIL);
+    ndbrequire(instance < globalData.ndbMtReceiveThreads);
+  }
+  if (globalData.ndbMtTcThreads > 0) {
+    /**
+     * Coming here means that theUseTcInSameRRGroup is true and we should
+     * distribute only to a subset of the tc threads from each
+     * recv thread. The idea is that this will decrease the amount
+     * of wakeups that need to happen from recv threads to tc
+     * threads. We only use tc threads in the same Round Robin group to
+     * increase chance of using the same CPU cache lines. In case there
+     * isn't enough tc threads in the same RR group we will select another.
+     *
+     * The best case here is that we have the number of tc threads
+     * divisible by the number of recv threads, normally twice as
+     * many. Otherwise certain imbalance might happen, but this
+     * should be handled by the scheduler for reads that will
+     * distribute more load to the less active tc threads.
+     *
+     * So normally setting TcThreadPerRecv to 2 or 4 would be the
+     * normal setting that should give best result.
+     *
+     * As an example if we have 16 tc threads and we have TcThreadPerRecv
+     * set to 4 with 8 recv threads. In 
+     */
+    Uint32 first_tc_instance = globalData.ndbMtLqhThreads;
+    Uint32 first_recv_instance = first_tc_instance +
+                                 globalData.ndbMtTcThreads;
+    Uint32 recv_instance = first_recv_instance + instance;
+    Uint32 recv_rr_group = m_rr_group[recv_instance];
+    Uint32 found_tc_instances = 0;
+    Uint32 instances_found[MAX_RR_GROUP_SIZE];
+
+    for (Uint32 i = first_tc_instance; i < first_recv_instance; i++) {
+      if (m_rr_group[i] == recv_rr_group) {
+        instances_found[found_tc_instances] = i - first_tc_instance;
+        found_tc_instances++;
+      }
+    }
+    if (found_tc_instances >= 2) {
+      /**
+       * At least 2 TC instances in this RR group, we will assume that
+       * the potential imbalance can be handled by read scheduler. Pick
+       * one of the tc instances using round robin for this recv thread.
+       */
+      Uint32 next_tc_thread = globalData.theNextTcThreadPerRecv[instance];
+      next_tc_thread++;
+      if (next_tc_thread >= found_tc_instances) {
+        next_tc_thread = 0;
+      }
+      globalData.theNextTcThreadPerRecv[instance] = next_tc_thread;
+      instance = instances_found[next_tc_thread];
+    } else if (found_tc_instances == 1) {
+      /**
+       * Only one tc thread in this RR group, we will pick this one in
+       * 2/3 of the cases, but the last 1/3 we will pick another based
+       * on the recv instance.
+       */
+      Uint32 next_tc_thread = globalData.theNextTcThreadPerRecv[instance];
+      next_tc_thread++;
+      if (next_tc_thread >= 3) {
+        next_tc_thread = 0;
+      }
+      globalData.theNextTcThreadPerRecv[instance] = next_tc_thread;
+      if (next_tc_thread < 2) {
+        instance = instances_found[0];
+      } else if (instance == instances_found[0]) {
+        /**
+         * By default we use the same tc instance number as recv, here
+         * this is the found one, so we have to use another.
+         */
+        if (instance > 0)
+          instance--;
+        else if (globalData.ndbMtTcThreads == 1)
+          instance = 0;
+        else
+          instance = 1;
+        if (instance > 0) 
+          instance--;
+      } else if (instance >= globalData.ndbMtTcThreads) {
+        instance = instances_found[0];
+      } else {
+        /* Here we will simply use the same tc instance number is recv */
+      }
+    } else {
+      /**
+       * The number of tc threads is very limited, simply use normal
+       * round robin approach.
+       */
+       
+      m_tc_seize_req_instance = (m_tc_seize_req_instance + 1) % c_workers;
+      instance = m_tc_seize_req_instance;
+    }
+  }
+  signal->theData[2] = (1 + instance);
+  sendSignal(workerRef(instance), GSN_TCSEIZEREQ, signal,
+             signal->getLength(), JBB);
 }
 
 // GSN_SET_DOMAIN_ID_REQ

--- a/storage/ndb/src/kernel/vm/Configuration.cpp
+++ b/storage/ndb/src/kernel/vm/Configuration.cpp
@@ -270,6 +270,14 @@ void Configuration::fetch_configuration(
   iter.get(CFG_DB_MAX_SEND_DELAY, &max_send_delay);
   globalData.theMaxSendDelay = max_send_delay;
 
+  Uint32 num_lqhkeyreq_counts = NUM_LQHKEYREQ_COUNTS;
+  iter.get(CFG_DB_NUM_LQHKEYREQ_COUNTS, &num_lqhkeyreq_counts);
+  globalData.theNumLqhKeyReqCounts = num_lqhkeyreq_counts;
+
+  Uint32 num_scan_fragreq_counts = NUM_SCAN_FRAGREQ_COUNTS;
+  iter.get(CFG_DB_NUM_SCAN_FRAGREQ_COUNTS, &num_scan_fragreq_counts);
+  globalData.theNumScanFragReqCounts = num_scan_fragreq_counts;
+
   const char * pidfile_dir;
   if(iter.get(CFG_NODE_PIDFILE_DIR, &pidfile_dir) == 0)
   {

--- a/storage/ndb/src/kernel/vm/Configuration.cpp
+++ b/storage/ndb/src/kernel/vm/Configuration.cpp
@@ -266,6 +266,10 @@ void Configuration::fetch_configuration(
   iter.get(CFG_DB_MAX_RR_GROUP_SIZE, &max_rr_group_size);
   globalData.theMaxRRGroupSize = max_rr_group_size;
 
+  Uint32 max_send_delay = 0;
+  iter.get(CFG_DB_MAX_SEND_DELAY, &max_send_delay);
+  globalData.theMaxSendDelay = max_send_delay;
+
   const char * pidfile_dir;
   if(iter.get(CFG_NODE_PIDFILE_DIR, &pidfile_dir) == 0)
   {

--- a/storage/ndb/src/kernel/vm/Configuration.cpp
+++ b/storage/ndb/src/kernel/vm/Configuration.cpp
@@ -258,6 +258,14 @@ void Configuration::fetch_configuration(
   iter.get(CFG_TCP_ONLY_IPV4, &use_only_ipv4);
   globalData.theUseOnlyIPv4Flag = use_only_ipv4;
 
+  Uint32 use_tc_in_same_rr_group = 0;
+  iter.get(CFG_DB_USE_TC_IN_RR_GROUP, &use_tc_in_same_rr_group);
+  globalData.theUseTcInSameRRGroup = use_tc_in_same_rr_group;
+
+  Uint32 max_rr_group_size = DEF_MAX_RR_GROUP_SIZE;
+  iter.get(CFG_DB_MAX_RR_GROUP_SIZE, &max_rr_group_size);
+  globalData.theMaxRRGroupSize = max_rr_group_size;
+
   const char * pidfile_dir;
   if(iter.get(CFG_NODE_PIDFILE_DIR, &pidfile_dir) == 0)
   {
@@ -1700,7 +1708,8 @@ Configuration::setupConfiguration()
                                  num_cpus,
                                  globalData.ndbRRGroups,
                                  use_tc_threads,
-                                 use_ldm_threads);
+                                 use_ldm_threads,
+                                 globalData.theMaxRRGroupSize);
     }
     else
     {
@@ -1865,7 +1874,8 @@ Configuration::setupConfiguration()
        * ndbRRGroups haven't been set yet, means we didn't use
        * do_parse_auto. Calculate it here.
        */
-      globalData.ndbRRGroups = Ndb_GetRRGroups(globalData.ndbMtQueryWorkers);
+      globalData.ndbRRGroups = Ndb_GetRRGroups(globalData.ndbMtQueryWorkers,
+                                               globalData.theMaxRRGroupSize);
     }
   } while (0);
 

--- a/storage/ndb/src/kernel/vm/GlobalData.hpp
+++ b/storage/ndb/src/kernel/vm/GlobalData.hpp
@@ -124,11 +124,14 @@ struct GlobalData {
   Uint32     theMaxNoOfTables;
   Uint32     theMaxNoOfOrderedIndexes;
   Uint32     theMaxNoOfUniqueHashIndexes;
+  Uint32     theMaxRRGroupSize;
 
+  bool       theUseTcInSameRRGroup;
   bool       theGracefulShutdownFlag;
   bool       theUseOnlyIPv4Flag;
   bool       theUseContainerMemoryFlag;
 
+  Uint8      theNextTcThreadPerRecv[MAX_NDBMT_RECEIVE_THREADS];
 
   NdbMutex   *theIO_lag_mutex;
   ndb_openssl_evp::byte nodeMasterKey[MAX_NODE_MASTER_KEY_LENGTH];
@@ -157,7 +160,10 @@ struct GlobalData {
     theBufferFullMicrosSleep = 0;
     theMicrosSend = 0;
     theMicrosSpin = 0;
+    std::memset(theNextTcThreadPerRecv, 0, sizeof(theNextTcThreadPerRecv));
     std::memset(m_hb_count, 0, sizeof(m_hb_count));
+    theMaxRRGroupSize = MIN_MAX_RR_GROUP_SIZE;
+    theUseTcInSameRRGroup = false;
 #ifdef GCP_TIMER_HACK
     gcp_timer_limit = 0;
 #endif

--- a/storage/ndb/src/kernel/vm/GlobalData.hpp
+++ b/storage/ndb/src/kernel/vm/GlobalData.hpp
@@ -125,6 +125,7 @@ struct GlobalData {
   Uint32     theMaxNoOfOrderedIndexes;
   Uint32     theMaxNoOfUniqueHashIndexes;
   Uint32     theMaxRRGroupSize;
+  Uint32     theMaxSendDelay;
 
   bool       theUseTcInSameRRGroup;
   bool       theGracefulShutdownFlag;
@@ -163,6 +164,7 @@ struct GlobalData {
     std::memset(theNextTcThreadPerRecv, 0, sizeof(theNextTcThreadPerRecv));
     std::memset(m_hb_count, 0, sizeof(m_hb_count));
     theMaxRRGroupSize = MIN_MAX_RR_GROUP_SIZE;
+    theMaxSendDelay = 0;
     theUseTcInSameRRGroup = false;
 #ifdef GCP_TIMER_HACK
     gcp_timer_limit = 0;

--- a/storage/ndb/src/kernel/vm/GlobalData.hpp
+++ b/storage/ndb/src/kernel/vm/GlobalData.hpp
@@ -140,6 +140,9 @@ struct GlobalData {
   unsigned char filesystemPassword[MAX_BACKUP_ENCRYPTION_PASSWORD_LENGTH];
   Uint32 filesystemPasswordLength;
 
+  Uint32     theNumLqhKeyReqCounts;
+  Uint32     theNumScanFragReqCounts;
+
   GlobalData() {
     theSignalId = 0;
     theStartLevel = NodeState::SL_NOTHING;
@@ -165,6 +168,8 @@ struct GlobalData {
     std::memset(m_hb_count, 0, sizeof(m_hb_count));
     theMaxRRGroupSize = MIN_MAX_RR_GROUP_SIZE;
     theMaxSendDelay = 0;
+    theNumLqhKeyReqCounts = 0;
+    theNumScanFragReqCounts = 0;
     theUseTcInSameRRGroup = false;
 #ifdef GCP_TIMER_HACK
     gcp_timer_limit = 0;

--- a/storage/ndb/src/kernel/vm/SimulatedBlock.hpp
+++ b/storage/ndb/src/kernel/vm/SimulatedBlock.hpp
@@ -1994,6 +1994,8 @@ public:
     Uint32 num_rr_groups = globalData.ndbRRGroups;
     Uint32 num_distr_threads = num_query_instances;
 
+    m_num_lqhkeyreq_counts = globalData.theNumLqhKeyReqCounts;
+    m_num_scan_fragreq_counts = globalData.theNumScanFragReqCounts;
     m_num_rr_groups = num_rr_groups;
     m_num_distribution_threads = num_distr_threads;
     if (!Ndb_InitRRGroups(&m_rr_group[0],

--- a/storage/ndb/src/kernel/vm/mt.cpp
+++ b/storage/ndb/src/kernel/vm/mt.cpp
@@ -2847,7 +2847,6 @@ extend_send_delay(struct thr_send_trps &trp_state, NDB_TICKS now)
     /**
      * No need to change timer when no send delay or when all
      * changes have already been performed.
-     * changes have already been performed.
      */
     return;
   }
@@ -8706,8 +8705,10 @@ mt_setConfMaxSignalsBeforeFlushReceiver(Uint32 max_signals_before_flush_receiver
 void
 mt_setMinSendDelay(Uint32 min_send_delay)
 {
-  g_min_send_delay = min_send_delay;
-  g_min_send_delay_available = (2 * g_min_send_delay) / 3;
+  if (min_send_delay >= globalData.theMaxSendDelay) {
+    g_min_send_delay = min_send_delay;
+    g_min_send_delay_available = (2 * g_min_send_delay) / 3;
+  }
 }
 
 void
@@ -9717,6 +9718,8 @@ static
 void
 rep_init(struct thr_repository* rep, unsigned int cnt, Ndbd_mem_manager *mm)
 {
+  mt_setMinSendDelay(globalData.theMaxSendDelay);
+
   rep->m_mm = mm;
 
   rep->m_thread_count = cnt;

--- a/storage/ndb/src/ndbapi/Ndb.cpp
+++ b/storage/ndb/src/ndbapi/Ndb.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2024, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2024, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -689,6 +689,7 @@ NdbImpl::select_node(NdbTableImpl *table_impl,
     DBUG_RETURN(m_ndb_cluster_connection.select_any(this));
   }
 
+  Uint16 *node_hint_count = &m_node_hint_count[0];
   Uint32 nodeId;
   bool readBackup = table_impl->m_read_backup;
   bool fullyReplicated = table_impl->m_fully_replicated;
@@ -718,7 +719,11 @@ NdbImpl::select_node(NdbTableImpl *table_impl,
      */
     cnt = table_impl->m_fragments.size();
     nodes = table_impl->m_fragments.getBase();
-    nodeId = m_ndb_cluster_connection.select_node(this, nodes, cnt, 0);
+    nodeId = m_ndb_cluster_connection.select_node(this,
+                                                  nodes,
+                                                  cnt,
+                                                  0,
+                                                  node_hint_count);
   } else if (cnt == 0) {
     /**
      * For unhinted select, let caller select node.
@@ -732,7 +737,11 @@ NdbImpl::select_node(NdbTableImpl *table_impl,
      * Consider one fragment and any replica for readBackup
      */
     require(readBackup);
-    nodeId = m_ndb_cluster_connection.select_node(this, nodes, cnt, 0);
+    nodeId = m_ndb_cluster_connection.select_node(this,
+                                                  nodes,
+                                                  cnt,
+                                                  0,
+                                                  node_hint_count);
     DBUG_PRINT("exit",("select_node: nodeId: %u", nodeId));
   }
   DBUG_RETURN(nodeId);

--- a/storage/ndb/src/ndbapi/NdbImpl.hpp
+++ b/storage/ndb/src/ndbapi/NdbImpl.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2024, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2024, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -193,6 +193,7 @@ class NdbImpl : public trp_client {
 
   // 1 indicates to release all connections to node
   Uint32 the_release_ind[MAX_NDB_NODES];
+  Uint16 m_node_hint_count[MAX_NDB_NODES];
 
   NdbWaiter theWaiter;
 

--- a/storage/ndb/src/ndbapi/Ndbinit.cpp
+++ b/storage/ndb/src/ndbapi/Ndbinit.cpp
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2003, 2024, Oracle and/or its affiliates.
+   Copyright (c) 2025, 2025, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -235,9 +236,8 @@ NdbImpl::NdbImpl(Ndb_cluster_connection *ndb_cluster_connection, Ndb &ndb)
       customData(0),
       send_TC_COMMIT_ACK_immediate_flag(false) {
   int i;
-  for (i = 0; i < MAX_NDB_NODES; i++) {
-    the_release_ind[i] = 0;
-  }
+  memset(the_release_ind, 0, sizeof(the_release_ind));
+  memset(m_node_hint_count, 0, sizeof(m_node_hint_count));
   m_optimized_node_selection =
       m_ndb_cluster_connection.m_conn_default_optimized_node_selection;
 

--- a/storage/ndb/src/ndbapi/ndb_cluster_connection.cpp
+++ b/storage/ndb/src/ndbapi/ndb_cluster_connection.cpp
@@ -891,11 +891,6 @@ void Ndb_cluster_connection_impl::adjust_node_comm_group(Uint32 node_id,
   node.adjusted_group += adjustment;
   DBUG_PRINT("info", ("Set adjusted_group to %u for node_index: %u, node: %u",
     node.adjusted_group, inx, node_id));
-  /**
-   * Clear hint count since the node adjusted will not have a
-   * hint count in sync with its new group.
-   */
-  m_node_hint_count[inx - 1] = 0;
   DBUG_VOID_RETURN;
 }
 
@@ -1571,7 +1566,8 @@ Uint32 Ndb_cluster_connection_impl::select_any(NdbImpl *impl_ndb) {
     DBUG_RETURN(select_node(impl_ndb,
                             prospective_node_ids,
                             num_prospective_nodes,
-                            0));
+                            0,
+                            &impl_ndb->m_node_hint_count[0]));
   }
 }
 
@@ -1586,6 +1582,7 @@ Ndb_cluster_connection_impl::select_location_based(NdbImpl *impl_ndb,
                                                    Uint32 cnt,
                                                    Uint32 primary_node)
 {
+  Uint16 *node_hint_count = &impl_ndb->m_node_hint_count[0];
   Uint16 prospective_node_ids[MAX_NDB_NODES];
   Uint32 num_prospective_nodes = 0;
   Uint32 my_location_domain_id = m_my_location_domain_id;
@@ -1594,7 +1591,11 @@ Ndb_cluster_connection_impl::select_location_based(NdbImpl *impl_ndb,
              cnt, primary_node, my_location_domain_id));
 
   if (my_location_domain_id == 0) {
-    DBUG_RETURN(select_node(impl_ndb, nodes, cnt, primary_node));
+    DBUG_RETURN(select_node(impl_ndb,
+                            nodes,
+                            cnt,
+                            primary_node,
+                            node_hint_count));
   }
   for (Uint32 i = 0; i < cnt; i++) {
     DBUG_PRINT("info",("Location domain id: %u of node: %u, avail: %u",
@@ -1612,14 +1613,19 @@ Ndb_cluster_connection_impl::select_location_based(NdbImpl *impl_ndb,
     }
   }
   if (num_prospective_nodes == 0) {
-    DBUG_RETURN(select_node(impl_ndb, nodes, cnt, primary_node));
+    DBUG_RETURN(select_node(impl_ndb,
+                            nodes,
+                            cnt,
+                            primary_node,
+                            node_hint_count));
   } else if (num_prospective_nodes == 1) {
     DBUG_RETURN(prospective_node_ids[0]);
   } else {
     DBUG_RETURN(select_node(impl_ndb,
                             prospective_node_ids,
                             num_prospective_nodes,
-                            primary_node));
+                            primary_node,
+                            node_hint_count));
   }
 }
 
@@ -1627,7 +1633,8 @@ Uint32
 Ndb_cluster_connection_impl::select_node(NdbImpl *impl_ndb,
                                          const Uint16 * nodes,
                                          Uint32 cnt,
-                                         Uint32 primary_node)
+                                         Uint32 primary_node,
+                                         Uint16 *node_hint_count)
 {
   DBUG_ENTER("Ndb_cluster_connection_impl::select_node");
   DBUG_PRINT("enter",("cnt: %u, primary: %u, my_domain: %u, my_node: %u",
@@ -1638,7 +1645,12 @@ Ndb_cluster_connection_impl::select_node(NdbImpl *impl_ndb,
     DBUG_RETURN(0);
   }
 
-  Uint32 best_node = nodes[0];
+  /**
+   * The node_hint_count is now stored on the NdbImpl object, this means
+   * that we remove any concurrent access to this variable which could easily
+   * hurt scalability.
+   */
+  Uint32 best_node = 0;
   Uint32 best_idx = Uint32(~0);
   Uint32 best_usage = 0;
   Int32 best_score = MAX_PROXIMITY_GROUP; // Lower is better
@@ -1666,12 +1678,12 @@ Ndb_cluster_connection_impl::select_node(NdbImpl *impl_ndb,
       best_idx = node_index;
       best_node = candidate_node;
       best_score = node.adjusted_group;
-      best_usage = m_node_hint_count[best_idx - 1];
+      best_usage = node_hint_count[best_idx - 1];
       DBUG_PRINT("info",("1: node: %u, best_score: %u, best_usage: %u,"
                  " node_index: %u",
         candidate_node, best_score, best_usage, node_index));
     } else if (node.adjusted_group == best_score) {
-      Uint32 usage = m_node_hint_count[node_index - 1];
+      Uint32 usage = node_hint_count[node_index - 1];
       if (candidate_node == primary_node) {
         /**
          * hint_count may wrap, for this calculation it is assumed that
@@ -1685,10 +1697,13 @@ Ndb_cluster_connection_impl::select_node(NdbImpl *impl_ndb,
                    " node_index: %u",
           candidate_node, best_score, best_usage, node_index));
       } else {
-        if (best_usage - usage < HINT_COUNT_HALF &&
-            best_node != primary_node) {
+        bool best_usage_larger = best_usage > usage;
+        best_usage_larger = best_usage_larger ?
+          best_usage - usage < HINT_COUNT_HALF :
+          usage - best_usage > HINT_COUNT_HALF;
+        if (best_usage_larger && best_node != primary_node) {
           /**
-           * hint_count may wrap, for this calculation it is assummed that
+           * hint_count may wrap, for this calculation it is assumed that
            * the two counts should be near each other, and so if the
            * difference is small above, best_usage is greater than usage.
            */
@@ -1702,13 +1717,9 @@ Ndb_cluster_connection_impl::select_node(NdbImpl *impl_ndb,
       }
     }
   }
-  if (!impl_ndb->get_node_available(best_node)) {
-    DBUG_RETURN(0);
-  }
-
   if (best_idx != Uint32(~0)) {
-    m_node_hint_count[best_idx - 1] =
-      (m_node_hint_count[best_idx - 1]) & HINT_COUNT_MASK;
+    node_hint_count[best_idx - 1] =
+      (node_hint_count[best_idx - 1] + 1) & HINT_COUNT_MASK;
   }
   DBUG_RETURN(best_node);
 }

--- a/storage/ndb/src/ndbapi/ndb_cluster_connection_impl.hpp
+++ b/storage/ndb/src/ndbapi/ndb_cluster_connection_impl.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2004, 2024, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2023, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -119,7 +119,6 @@ class Ndb_cluster_connection_impl : public Ndb_cluster_connection {
   NdbMutex *m_nodes_comm_group_mutex;
   Vector<Node> m_nodes_comm_group;
   Uint16 m_node_index[MAX_NDB_NODES];
-  Uint32 m_node_hint_count[MAX_NDB_NODES];
   Uint16 m_location_domain_id[MAX_NODES];
   int init_nodes_vector(Uint32 nodeid, const ndb_mgm_configuration *config);
   int configure(Uint32 nodeid, const ndb_mgm_configuration *config);
@@ -139,7 +138,8 @@ class Ndb_cluster_connection_impl : public Ndb_cluster_connection {
   Uint32 select_node(NdbImpl *impl_ndb,
                      const Uint16* nodes,
                      Uint32 cnt,
-                     Uint32 primary);
+                     Uint32 primary,
+                     Uint16 *node_hint_count);
   /**
    * Select primary or if primary in other location domain
    * choose a node in the same location domain


### PR DESCRIPTION
As nodes goes larger the receive threads have to split sending to many more tc threads. This includes a lot of wakeups and synchronization and mutex handling.

In this patch we provide a configuration variable that decides whether we should only distribute within the Round Robin Group of the receive thread. This has two advantages, first a receive thread will no longer need to send signals to a great number of tc threads, instead it will focus on sending to 2-4 tc threads normally. We also introduce a variable that sets the optimal round robin group size. Both of these new configuration variables enables us to experiment in benchmarks the efficiency of this approach.

The second benefit comes from the fact that the Round Robin Group shares normally at least a L3 CPU cache. This means that communication to the selected tc threads should be more efficient as well.

There is likely still some scaling issues remaining since there is a large number of LDM threads still for the tc threads to communicate with.