### PR TITLE
Bugfix: ndb_restore cause mysqld stuck on restart

### DIFF
--- a/storage/ndb/tools/restore/restore_main.cpp
+++ b/storage/ndb/tools/restore/restore_main.cpp
@@ -2015,14 +2015,26 @@ int do_restore(RestoreThreadData *thrdata) {
     }
   }
 
-  restoreLogger.log_debug("Handling index stat tables");
-  for (i = 0; i < g_consumers.size(); i++) {
-    if (!g_consumers[i]->handle_index_stat_tables()) {
-      restoreLogger.log_error(
-          "Restore: Failed to handle index stat tables ... Exiting ");
-      return NdbToolsProgramExitCode::FAILED;
-    }
-  }
+  /*
+   * NOTE:
+   *
+   * There’s a bug here: the restore tool doesn’t create the related
+   * event for the index_stat table — it only creates the table itself.
+   * This causes mysqld to get stuck when it fails to retrieve the event
+   * on restart after data has been restored on data nodes.
+   * So, here we skip creating the index_stat table and leave it to
+   * mysqld to handle instead.
+   *
+   * restoreLogger.log_debug("Handling index stat tables");
+   * for (i = 0; i < g_consumers.size(); i++) {
+   *   if (!g_consumers[i]->handle_index_stat_tables()) {
+   *     restoreLogger.log_error(
+   *         "Restore: Failed to handle index stat tables ... Exiting ");
+   *     return NdbToolsProgramExitCode::FAILED;
+   *   }
+   * }
+   *
+   */
 
   Vector<OutputStream *> table_output(metaData.getNoOfTables());
   restoreLogger.log_debug("Restoring tables");


### PR DESCRIPTION
Description:
After restoring, the system table mysql.ndb_index_stat_head is restored on the data node. When mysqld starts up, it first checks if this table exists:
 If it doesn’t exist, it creates the table and sets up the related event.
 If it does exist, it skips those steps.
In this case, the table mysql.ndb_index_stat_head does exist, so MySQL skips step 2.
As a result, the event needed by ndb_index_stat_thread is not created, and the thread never finishes setting up - causing mysqld to keep waiting until it times out.