### PR TITLE
Copy mysqlpump from 22.10

### DIFF
--- a/build_scripts/release_scripts/create_rondb_tarball.sh
+++ b/build_scripts/release_scripts/create_rondb_tarball.sh
@@ -12,6 +12,19 @@ cd $TEMP_BUILD_DIR_ABS
 rm -rf $TARBALL_NAME
 mv rondb_bin_use $TARBALL_NAME
 
+# Copy the mysqlpump binary from 22.10
+if [[ "$TARBALL_NAME" == *"x86_64"* ]]; then
+  wget -O mysqlpump https://repo.hops.works/master/mysqlpump_rondb_22.10.11/mysqlpump_x86_64
+  chmod +x mysqlpump
+  mv mysqlpump $TARBALL_NAME/bin/
+elif [[ "$TARBALL_NAME" == *"arm64"* ]]; then
+  wget -O mysqlpump https://repo.hops.works/master/mysqlpump_rondb_22.10.11/mysqlpump_arm
+  chmod +x mysqlpump
+  mv mysqlpump $TARBALL_NAME/bin/
+else
+  echo "Unknown architecture $TARBALL_NAME for downloading the mysqlpump"
+fi
+
 set +e
 which pigz >/dev/null
 if [[ "$?" -ne "0" ]]; then


### PR DESCRIPTION
mysqlpump was removed by MySQL starting with 8.0.34, but Hopsworks still requires it. So, during the build of 24.10, we need to copy the binary from the 22.10 tarball.