### PR TITLE
Postfix for commit 749558: More restrictive condition for terminating

### DIFF
--- a/storage/ndb/plugin/ha_ndbcluster_connection.cc
+++ b/storage/ndb/plugin/ha_ndbcluster_connection.cc
@@ -282,16 +282,18 @@ int ndbcluster_connect(ulong wait_connected,  // Timeout in seconds
   while ((res = g_ndb_cluster_connection->connect(0, 0, 0)) == 1) {
     const NDB_TICKS now = NdbTick_getCurrentTicks();
     if (NdbTick_Elapsed(start, now).seconds() > wait_connected) {
-      if (g_ndb_cluster_connection->get_latest_error() !=
+      if (g_ndb_cluster_connection->get_latest_error() ==
           1101 /*NDB_MGM_ALLOCID_ERROR*/) {
-        break;
-      } else {
-        ndb_log_error("Connection to ndb_mgmd failed "
-                      "repeatedly due to %u(%s). Terminating mysqld",
-                      g_ndb_cluster_connection->get_latest_error(),
-                      g_ndb_cluster_connection->get_latest_error_msg());
-        return -1;
+        std::string error_msg(g_ndb_cluster_connection->get_latest_error_msg());
+        if (error_msg.find("No free node id") != std::string::npos) {
+          ndb_log_error("Connection to ndb_mgmd failed "
+                        "repeatedly due to %u(%s). Terminating mysqld",
+                        g_ndb_cluster_connection->get_latest_error(),
+                        g_ndb_cluster_connection->get_latest_error_msg());
+          return -1;
+        }
       }
+      break;
     }
     ndb_retry_sleep(100);
     if (connection_events_loop_aborted()) return -1;

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
@@ -4656,6 +4656,12 @@ bool MgmtSrvr::alloc_node_id_impl(NodeId &nodeid, enum ndb_mgm_node_type type,
       if (error_code == 0) {
         const char *alias, *str = nullptr;
         alias = ndb_mgm_get_node_type_alias_string(type, &str);
+        /*
+         * WARNING:
+         * MySQL server uses this specific error message to determine
+         * whether it should terminate during startup.
+         * DO NOT modify or remove this error message.
+         */
         error_string.appfmt("No free node id found for %s(%s).", alias, str);
       }
     }


### PR DESCRIPTION
mysqld

The previous patch was intended to terminate mysqld after a timeout when encountering errno 1101. However, errno 1101 is also used for other errors related to slot ID allocation on the management node. What we really need here is to terminate mysqld only for the specific case of "No free node id found for ...". This patch filters out the other errors that share the same error number.