### PR TITLE
Backport, bugfix: MySQL does not properly handle connection failure t…

### DIFF
--- a/storage/ndb/plugin/ha_ndbcluster_connection.cc
+++ b/storage/ndb/plugin/ha_ndbcluster_connection.cc
@@ -275,7 +275,20 @@ int ndbcluster_connect(ulong wait_connected,  // Timeout in seconds
 
   while ((res = g_ndb_cluster_connection->connect(0, 0, 0)) == 1) {
     const NDB_TICKS now = NdbTick_getCurrentTicks();
-    if (NdbTick_Elapsed(start, now).seconds() > wait_connected) break;
+    if (NdbTick_Elapsed(start, now).seconds() > wait_connected) {
+      if (g_ndb_cluster_connection->get_latest_error() ==
+          1101 /*NDB_MGM_ALLOCID_ERROR*/) {
+        std::string error_msg(g_ndb_cluster_connection->get_latest_error_msg());
+        if (error_msg.find("No free node id") != std::string::npos) {
+          ndb_log_error("Connection to ndb_mgmd failed "
+                        "repeatedly due to %u(%s). Terminating mysqld",
+                        g_ndb_cluster_connection->get_latest_error(),
+                        g_ndb_cluster_connection->get_latest_error_msg());
+          return -1;
+        }
+      }
+      break;
+    }
     ndb_retry_sleep(100);
     if (connection_events_loop_aborted()) return -1;
   }

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
@@ -5065,6 +5065,12 @@ MgmtSrvr::alloc_node_id_impl(NodeId& nodeid,
       {
         const char *alias, *str = nullptr;
         alias = ndb_mgm_get_node_type_alias_string(type, &str);
+        /*
+         * WARNING:
+         * MySQL server uses this specific error message to determine
+         * whether it should terminate during startup.
+         * DO NOT modify or remove this error message.
+         */
         error_string.appfmt("No free node id found for %s(%s).",
                             alias,
                             str);


### PR DESCRIPTION
…o ndb_mgmd (#683)

Description:
  On MySQL startup, if it fails to connect to ndb_mgmd — typically due
  to no free slot in the Hopsworks production environment — it would
  silently skip the error and continue starting up. This results in a
  running MySQL server with an unavailable storage backend, which can
  mislead users.
Solution:
  If the connection retry limit is exceeded, force MySQL to shut
  down.
Notice:
  The previous design was intended to terminate mysqld after a timeout when
  encountering errno 1101. However, errno 1101 is also used for other
  errors related to slot ID allocation on the management node.
  What we really need here is to terminate mysqld only for the specific
  case of "No free node id found for ...". This patch filters out the
  other errors that share the same error number.