### PR TITLE
Backport, Add status variable Ndb_is_db_nodes_all_alive to indicate t…

### DIFF
--- a/mysql-test/suite/ndb/r/ndb_basic.result
+++ b/mysql-test/suite/ndb/r/ndb_basic.result
@@ -121,6 +121,7 @@ Ndb_index_stat_cache_clean	#
 Ndb_index_stat_cache_query	#
 Ndb_index_stat_event_count	#
 Ndb_index_stat_status	#
+Ndb_is_db_nodes_all_alive	#
 Ndb_last_commit_epoch_server	#
 Ndb_last_commit_epoch_session	#
 Ndb_metadata_detected_count	#

--- a/mysql-test/suite/ndb/r/ndb_basic_3rpl.result
+++ b/mysql-test/suite/ndb/r/ndb_basic_3rpl.result
@@ -121,6 +121,7 @@ Ndb_index_stat_cache_clean	#
 Ndb_index_stat_cache_query	#
 Ndb_index_stat_event_count	#
 Ndb_index_stat_status	#
+Ndb_is_db_nodes_all_alive	#
 Ndb_last_commit_epoch_server	#
 Ndb_last_commit_epoch_session	#
 Ndb_metadata_detected_count	#

--- a/mysql-test/suite/ndb/r/ndb_basic_3rpl_2ng.result
+++ b/mysql-test/suite/ndb/r/ndb_basic_3rpl_2ng.result
@@ -121,6 +121,7 @@ Ndb_index_stat_cache_clean	#
 Ndb_index_stat_cache_query	#
 Ndb_index_stat_event_count	#
 Ndb_index_stat_status	#
+Ndb_is_db_nodes_all_alive      #
 Ndb_last_commit_epoch_server	#
 Ndb_last_commit_epoch_session	#
 Ndb_metadata_detected_count	#

--- a/mysql-test/suite/ndb/r/ndb_basic_4rpl.result
+++ b/mysql-test/suite/ndb/r/ndb_basic_4rpl.result
@@ -121,6 +121,7 @@ Ndb_index_stat_cache_clean	#
 Ndb_index_stat_cache_query	#
 Ndb_index_stat_event_count	#
 Ndb_index_stat_status	#
+Ndb_is_db_nodes_all_alive	#
 Ndb_last_commit_epoch_server	#
 Ndb_last_commit_epoch_session	#
 Ndb_metadata_detected_count	#

--- a/mysql-test/suite/ndb/r/ndb_basic_mix_numcpus.result
+++ b/mysql-test/suite/ndb/r/ndb_basic_mix_numcpus.result
@@ -121,6 +121,7 @@ Ndb_index_stat_cache_clean	#
 Ndb_index_stat_cache_query	#
 Ndb_index_stat_event_count	#
 Ndb_index_stat_status	#
+Ndb_is_db_nodes_all_alive	#
 Ndb_last_commit_epoch_server	#
 Ndb_last_commit_epoch_session	#
 Ndb_metadata_detected_count	#

--- a/storage/ndb/include/ndbapi/ndb_cluster_connection.hpp
+++ b/storage/ndb/include/ndbapi/ndb_cluster_connection.hpp
@@ -334,6 +334,7 @@ public:
    * @return #nodes connected, or -1 on error
    */
   int wait_until_ready(const int * nodes, int cnt, int timeout);
+  int db_nodes_all_alive();
 #endif
 
 private:

--- a/storage/ndb/plugin/ha_ndbcluster.cc
+++ b/storage/ndb/plugin/ha_ndbcluster.cc
@@ -474,6 +474,7 @@ struct st_ndb_status {
   long long api_client_stats[Ndb::NumClientStatistics];
   const char *system_name;
   long fetch_table_stats;
+  long db_nodes_all_alive;
 };
 
 /* Status variables shown with 'show status like 'Ndb%' */
@@ -500,6 +501,7 @@ static int update_status_variables(Thd_ndb *thd_ndb, st_ndb_status *ns,
   ns->connect_count = c->get_connect_count();
   ns->system_name = c->get_system_name();
   ns->last_commit_epoch_server = ndb_get_latest_trans_gci();
+  ns->db_nodes_all_alive = c->db_nodes_all_alive();
   if (thd_ndb) {
     ns->execute_count = thd_ndb->m_execute_count;
     ns->trans_hint_count = thd_ndb->hinted_trans_count();
@@ -634,6 +636,8 @@ static SHOW_VAR ndb_status_vars_dynamic[] = {
      SHOW_SCOPE_GLOBAL},
     {"fetch_table_stats", (char *)&g_ndb_status.fetch_table_stats, SHOW_LONG,
      SHOW_SCOPE_GLOBAL},
+    {"is_db_nodes_all_alive", (char *)&g_ndb_status.db_nodes_all_alive,
+     SHOW_LONG, SHOW_SCOPE_GLOBAL},
     {NullS, NullS, SHOW_LONG, SHOW_SCOPE_GLOBAL}};
 
 // Global instance of stats for the default replication channel, populated

--- a/storage/ndb/src/ndbapi/ClusterMgr.cpp
+++ b/storage/ndb/src/ndbapi/ClusterMgr.cpp
@@ -2094,6 +2094,27 @@ ClusterMgr::print_nodes(const char* where, NdbOut& out)
   out << "<<" << endl;
 }
 
+int ClusterMgr::db_nodes_all_alive() {
+  int all_alive = 1;
+  TransporterRegistry *tr = theFacade.get_registry();
+  for (NodeId n = 1; n < MAX_NODES; n++) {
+    const trp_node node = getNodeInfo(n);
+    if (!node.defined) continue;
+    /*
+     * Note:
+     * We don’t use node.m_node_active to determine whether the node is
+     * activated or deactivated, because the node info in ClusterMgr
+     * may be outdated.
+     */
+    if (node.m_info.getType() == NODE_TYPE_DB
+        && tr->get_active_node(n) &&!node.m_alive) {
+      all_alive = 0;
+      break;
+    }
+  }
+  return all_alive;
+}
+
 void
 ClusterMgr::setProcessInfoUri(const char * scheme, const char * address_string,
                               int port, const char * path)

--- a/storage/ndb/src/ndbapi/ClusterMgr.hpp
+++ b/storage/ndb/src/ndbapi/ClusterMgr.hpp
@@ -277,6 +277,7 @@ public:
   Uint32 get_node_change_count();
   void lock_node_state();
   void unlock_node_state();
+  int db_nodes_all_alive();
 };
 
 inline

--- a/storage/ndb/src/ndbapi/TransporterFacade.hpp
+++ b/storage/ndb/src/ndbapi/TransporterFacade.hpp
@@ -674,6 +674,12 @@ unsigned Ndb_cluster_connection_impl::get_connect_count() const
   return 0;
 }
 
+inline int Ndb_cluster_connection_impl::db_nodes_all_alive() {
+  if (m_transporter_facade->theClusterMgr)
+    return m_transporter_facade->theClusterMgr->db_nodes_all_alive();
+  return false;
+}
+
 inline
 unsigned Ndb_cluster_connection_impl::get_min_db_version() const
 {

--- a/storage/ndb/src/ndbapi/ndb_cluster_connection.cpp
+++ b/storage/ndb/src/ndbapi/ndb_cluster_connection.cpp
@@ -324,6 +324,10 @@ Ndb_cluster_connection::no_db_nodes()
   return m_impl.m_nodes_proximity.size();
 }
 
+int Ndb_cluster_connection::db_nodes_all_alive() {
+  return m_impl.db_nodes_all_alive();
+}
+
 Uint32
 Ndb_cluster_connection::max_api_nodeid() const
 {

--- a/storage/ndb/src/ndbapi/ndb_cluster_connection_impl.hpp
+++ b/storage/ndb/src/ndbapi/ndb_cluster_connection_impl.hpp
@@ -87,6 +87,7 @@ class Ndb_cluster_connection_impl : public Ndb_cluster_connection
 public:
   inline Uint64 *get_latest_trans_gci() { return &m_latest_trans_gci; }
   int set_location_domain_id(Uint32 nodeId, Uint32 location_domain_id);
+  int db_nodes_all_alive();
 
 private:
   friend class Ndb;


### PR DESCRIPTION
…he health state of activated DB nodes. (#703)

The variable returns an integer value:
  1: All activated nodes are alive
  0: At least one of the activated nodes is not alive