### PR TITLE
RONDB-916: Distribute cluster connections from one location domain id…

### DIFF
--- a/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
+++ b/storage/ndb/src/common/mgmcommon/ConfigInfo.cpp
@@ -1259,7 +1259,7 @@ const ConfigInfo::ParamInfo ConfigInfo::m_ParamInfo[] = {
 
     {CFG_LOCATION_DOMAIN_ID, "LocationDomainId", DB_TOKEN,
      "LocationDomainId for node", ConfigInfo::CI_USED, false,
-     ConfigInfo::CI_INT, nullptr, "0", STR_VALUE(MAX_SIGNED_INT)},
+     ConfigInfo::CI_INT, nullptr, "0", "16"},
 
     {CFG_DB_NODEGROUP, "Nodegroup", DB_TOKEN,
      "Nodegroup for node, only used during initial cluster start",

--- a/storage/ndb/src/kernel/vm/Configuration.cpp
+++ b/storage/ndb/src/kernel/vm/Configuration.cpp
@@ -366,6 +366,42 @@ Configuration::get_total_memory(const ndb_mgm_configuration_iterator *p,
 }
 
 void
+Configuration::set_location_domain_id() {
+  const char * msg = "Invalid configuration fetched";
+  char buf[255];
+  ndb_mgm_configuration_iterator * p = m_clusterConfigIter;
+  g_eventLogger->info("Set LocationDomainId's");
+
+  Uint32 max_location_domain_id = 0;
+  for (ndb_mgm_first(p); ndb_mgm_valid(p); ndb_mgm_next(p)) {
+    Uint32 nodeId;
+    Uint32 location_domain_id = 0;
+    if (ndb_mgm_get_int_parameter(p, CFG_NODE_ID, &nodeId)) {
+      ERROR_SET(fatal, NDBD_EXIT_INVALID_CONFIG, msg,
+                "Node data (Id) missing");
+    }
+    if(nodeId > MAX_NODES || nodeId == 0) {
+      BaseString::snprintf(buf, sizeof(buf),
+	       "Invalid node id: %d", nodeId);
+      ERROR_SET(fatal, NDBD_EXIT_INVALID_CONFIG, msg, buf);
+    }
+    if (ndb_mgm_get_int_parameter(p,
+                                  CFG_LOCATION_DOMAIN_ID,
+                                  &location_domain_id)) {
+      location_domain_id = 0;
+    }
+    if (location_domain_id > 16) {
+      ERROR_SET(fatal, NDBD_EXIT_INVALID_CONFIG, msg,
+                "LocationDomainId > 16");
+    }
+    globalData.theLocationDomainId[nodeId] = location_domain_id;
+    max_location_domain_id =
+      std::max(max_location_domain_id, location_domain_id);
+  }
+  globalData.theMaxLocationDomainId = max_location_domain_id;
+}
+
+void
 Configuration::set_not_active_nodes()
 {
   const char * msg = "Invalid configuration fetched";
@@ -1894,6 +1930,7 @@ Configuration::setupConfiguration()
 
   calcSizeAlt(cf);
   set_not_active_nodes();
+  set_location_domain_id();
   DBUG_VOID_RETURN;
 }
 

--- a/storage/ndb/src/kernel/vm/Configuration.hpp
+++ b/storage/ndb/src/kernel/vm/Configuration.hpp
@@ -232,6 +232,7 @@ class Configuration {
   static Uint64 get_and_set_shared_global_memory(
            const ndb_mgm_configuration_iterator *p);
   void set_not_active_nodes();
+  void set_location_domain_id();
 public:
   static Uint64 get_send_buffer(const ndb_mgm_configuration_iterator *p);
   void get_num_nodes(Uint32 & noOfNodes,

--- a/storage/ndb/src/kernel/vm/GlobalData.hpp
+++ b/storage/ndb/src/kernel/vm/GlobalData.hpp
@@ -131,8 +131,10 @@ struct GlobalData {
   bool       theGracefulShutdownFlag;
   bool       theUseOnlyIPv4Flag;
   bool       theUseContainerMemoryFlag;
+  Uint8      theMaxLocationDomainId;
 
   Uint8      theNextTcThreadPerRecv[MAX_NDBMT_RECEIVE_THREADS];
+  Uint8      theLocationDomainId[MAX_NODES];
 
   NdbMutex   *theIO_lag_mutex;
   ndb_openssl_evp::byte nodeMasterKey[MAX_NODE_MASTER_KEY_LENGTH];
@@ -165,6 +167,8 @@ struct GlobalData {
     theMicrosSend = 0;
     theMicrosSpin = 0;
     std::memset(theNextTcThreadPerRecv, 0, sizeof(theNextTcThreadPerRecv));
+    theMaxLocationDomainId = 0;
+    std::memset(theLocationDomainId, 0, sizeof(theLocationDomainId));
     std::memset(m_hb_count, 0, sizeof(m_hb_count));
     theMaxRRGroupSize = MIN_MAX_RR_GROUP_SIZE;
     theMaxSendDelay = 0;

--- a/storage/ndb/src/kernel/vm/mt.cpp
+++ b/storage/ndb/src/kernel/vm/mt.cpp
@@ -9991,6 +9991,7 @@ assign_receiver_threads(void)
   Uint32 num_recv_threads = globalData.ndbMtReceiveThreads;
   Uint32 recv_thread_idx = 0;
   Uint32 recv_thread_idx_shm = 0;
+  Uint32 max_trp_id = 0;
   for (Uint32 i = 0; i < MAX_NODES; i++)
   {
     g_api_node_to_recv_instance_map[i] = RNIL;
@@ -9999,37 +10000,60 @@ assign_receiver_threads(void)
   {
     Transporter *trp =
       globalTransporterRegistry.get_transporter(trp_id);
+    if (trp) {
+      max_trp_id = std::max(max_trp_id, trp_id);
+    }
+  }
+  /**
+   * We sort the assignment after LocationDomainId. This ensures that we
+   * are well distributed on the receive threads for each of the location
+   * domains. In particular this is important for the API nodes that resides
+   * in the same location domain id as us.
+   *
+   * We implement by first assigning all transporters belonging to location
+   * domain id 0, next to 1 and so forth. In this manner we distribute the
+   * connections over all receive threads.
+   *
+   * Shared memory transporters are by definition local and distributed
+   * separately, we handle this by handling shared memory transporters in
+   * the first loop with location domain id equal to 0.
+   */
+  for (Uint32 ld_id = 0; ld_id <= globalData.theMaxLocationDomainId; ld_id++) {
+    for (Uint32 trp_id = 1; trp_id <= max_trp_id; trp_id++) {
 
     /**
      * Ensure that shared memory transporters are well distributed
      * over all receive threads, so distribute those independent of
      * rest of transporters.
      */
-    if (trp)
-    {
-      Uint32 node_id =
-        globalTransporterRegistry.get_transporter_node_id(trp_id);
-      if (globalTransporterRegistry.is_shm_transporter(trp_id))
-      {
-        g_trp_to_recv_thr_map[trp_id] = recv_thread_idx_shm;
-        g_api_node_to_recv_instance_map[node_id] = recv_thread_idx_shm;
-        globalTransporterRegistry.set_recv_thread_idx(trp,recv_thread_idx_shm);
-        DEB_MULTI_TRP(("SHM trp %u uses recv_thread_idx: %u",
-                       trp_id, recv_thread_idx_shm));
-        recv_thread_idx_shm++;
-        if (recv_thread_idx_shm == num_recv_threads) recv_thread_idx_shm = 0;
+      Transporter *trp =
+        globalTransporterRegistry.get_transporter(trp_id);
+      if (trp) {
+        Uint32 node_id =
+          globalTransporterRegistry.get_transporter_node_id(trp_id);
+        if (globalTransporterRegistry.is_shm_transporter(trp_id)) {
+          if (ld_id != 0) continue;
+          g_trp_to_recv_thr_map[trp_id] = recv_thread_idx_shm;
+          g_api_node_to_recv_instance_map[node_id] = recv_thread_idx_shm;
+          globalTransporterRegistry.set_recv_thread_idx(trp,recv_thread_idx_shm);
+          DEB_MULTI_TRP(("SHM trp %u uses recv_thread_idx: %u",
+                         trp_id, recv_thread_idx_shm));
+          recv_thread_idx_shm++;
+          if (recv_thread_idx_shm == num_recv_threads) recv_thread_idx_shm = 0;
+        } else {
+          if (globalData.theLocationDomainId[node_id] != ld_id) continue;
+          g_trp_to_recv_thr_map[trp_id] = recv_thread_idx;
+          g_api_node_to_recv_instance_map[node_id] = recv_thread_idx;
+          DEB_MULTI_TRP(("TCP trp %u uses recv_thread_idx: %u",
+                         trp_id, recv_thread_idx));
+          globalTransporterRegistry.set_recv_thread_idx(trp,recv_thread_idx);
+          recv_thread_idx++;
+          if (recv_thread_idx == num_recv_threads) recv_thread_idx = 0;
+         }
       } else {
-        g_trp_to_recv_thr_map[trp_id] = recv_thread_idx;
-        g_api_node_to_recv_instance_map[node_id] = recv_thread_idx;
-        DEB_MULTI_TRP(("TCP trp %u uses recv_thread_idx: %u",
-                       trp_id, recv_thread_idx));
-        globalTransporterRegistry.set_recv_thread_idx(trp,recv_thread_idx);
-        recv_thread_idx++;
-        if (recv_thread_idx == num_recv_threads) recv_thread_idx = 0;
+        /* Flag for no transporter */
+        g_trp_to_recv_thr_map[trp_id] = MAX_NTRANSPORTERS;
       }
-    } else {
-      /* Flag for no transporter */
-      g_trp_to_recv_thr_map[trp_id] = MAX_NTRANSPORTERS;
     }
   }
   return;


### PR DESCRIPTION
… over all receive threads

Previously cluster connections was distributed over the receive threads without taking location domain id into account. Since reads can be very local this could lead to that not all receive threads are used for receiving since they only handle cluster connections to other location domain ids which are not heavily used.

The solution here assigns still round robin, but handles all cluster connections from location domain id 0 first, next 1 and so forth.

This leads to a major improvement in throughput when reading a lot locally in the same location domain id and multiple location domain ids are used.