### PR TITLE
NdbScanOperation::scanImpl(): call handleInterpreterOptions(options) only when options not null

### DIFF
--- a/storage/ndb/src/ndbapi/NdbScanOperation.cpp
+++ b/storage/ndb/src/ndbapi/NdbScanOperation.cpp
@@ -517,8 +517,10 @@ inline int NdbScanOperation::scanImpl(
    * since the interpreter depends on input parameters being added before
    * packed read instructions.
    */
-  if (handleInterpreterOptions(options) != 0) {
-    return -1;
+  if (options != nullptr) {
+    if (handleInterpreterOptions(options) != 0) {
+      return -1;
+    }
   }
 
   /* Add AttrInfos for packed read of cols in result_record */


### PR DESCRIPTION
similar to the call to handleScanOptions(options) a bit further down in scanImpl().

This caused an unhandled memory fault when doing a scan without ScanOptions.