### PR TITLE
RONDB-932: Ensure releasing records in correct order to avoid long wh…

### DIFF
--- a/mysql-test/suite/ndbcrunch/my.cnf
+++ b/mysql-test/suite/ndbcrunch/my.cnf
@@ -12,7 +12,7 @@ ndbapi=,,,
 [cluster_config]
 NoOfReplicas=2
 TotalMemoryConfig=6G
-NumCPUs=4
+NumCPUs=8
 
 # Auto configure NDB to use all CPUs assigned
 AutomaticThreadConfig=1

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
@@ -17003,9 +17003,21 @@ void Dblqh::scanReleaseLocksLab(Signal *signal,
   Fragrecord::FragStatus fragstatus = fragptr.p->fragStatus;
   ndbrequire(is_scan_ok(scanPtr, fragstatus));
   check_send_scan_hb_rep(signal, scanPtr, regTcPtr);
+  if (scanPtr->readCommitted) {
+    jamDebug();
+    Uint32 release_counter = scanPtr->scanReleaseCounter;
+    Uint32 curr_rows = scanPtr->m_curr_batch_size_rows;
+    Uint32 num_releases = (curr_rows - release_counter) + 1;
+    if (release_counter >= curr_rows) {
+      num_releases = 1;
+    }
+    scanPtr->scanReleaseCounter += (num_releases - 1);
+    scanLockReleasedLab(signal, regTcPtr);
+    return;
+  }
   while (true) {
-    const Uint32 accOpPtr = scanPtr->readCommitted ?
-      get_acc_ptr_from_scan_record(scanPtr, 0, false) :
+    jamDebug();
+    const Uint32 accOpPtr =
       get_acc_ptr_from_scan_record(scanPtr,
                                    scanPtr->scanReleaseCounter-1,
                                    false);
@@ -18989,8 +19001,7 @@ void Dblqh::scanTupkeyConfLab(Signal* signal,
     } else {
       jam();
       scanPtr->scanReleaseCounter = rows + 1;
-      check_send_scan_hb_rep(signal, scanPtr, regTcPtr);
-      scanLockReleasedLab(signal, regTcPtr);
+      scanReleaseLocksLab(signal, regTcPtr);
       return;
     }
   }
@@ -19091,14 +19102,12 @@ void Dblqh::scanTupkeyRefLab(Signal* signal,
        *       WE NEED TO RELEASE ALL LOCKS CURRENTLY
        *       HELD BY THIS SCAN.
        * -------------------------------------------------------------------- */
-      scanReleaseLocksLab(signal, tcConnectptr.p);
     } else {
       jam();
       scanPtr->m_curr_batch_size_rows = rows + 1;
       scanPtr->scanReleaseCounter = rows + 1;
-      check_send_scan_hb_rep(signal, scanPtr, tcConnectptr.p);
-      scanLockReleasedLab(signal, tcConnectptr.p);
     }  // if
+    scanReleaseLocksLab(signal, tcConnectptr.p);
     return;
   }  // if
 
@@ -19137,8 +19146,7 @@ void Dblqh::scanTupkeyRefLab(Signal* signal,
      * -----------------------------------------------------------------------
      */
     scanPtr->scanReleaseCounter = rows + 1;
-    check_send_scan_hb_rep(signal, scanPtr, tcConnectptr.p);
-    scanLockReleasedLab(signal, tcConnectptr.p);
+    scanReleaseLocksLab(signal, tcConnectptr.p);
     return;
   } else {
 #ifdef DEBUG_PA

--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupScan.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupScan.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2005, 2024, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2024, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/storage/ndb/src/kernel/blocks/dbtux/Dbtux.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/Dbtux.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2024, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2024, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -773,9 +773,9 @@ private:
   bool scanCheck(ScanOp &scan, TreeEnt ent);
   bool scanVisible(ScanOp &scan, TreeEnt ent);
   void scanClose(Signal *signal, ScanOpPtr scanPtr);
-  void abortAccLockOps(Signal *signal, ScanOpPtr scanPtr);
-  void addAccLockOp(ScanOpPtr scanPtr, Uint32 accLockOp);
-  void removeAccLockOp(ScanOpPtr scanPtr, Uint32 accLockOp);
+  void abortAccLockOps(Signal *signal, ScanOp &scan);
+  void addAccLockOp(ScanOp &scan, Uint32 accLockOp);
+  void removeAccLockOp(ScanOp &scan, Uint32 accLockOp);
   void releaseScanOp(ScanOpPtr &scanPtr);
 
   /*

--- a/storage/ndb/src/kernel/blocks/dbtux/DbtuxScan.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtux/DbtuxScan.cpp
@@ -635,7 +635,7 @@ void Dbtux::execNEXT_SCANREQ(Signal *signal) {
         c_acc->execACC_LOCKREQ(signal);
         jamEntryDebug();
         ndbrequire(lockReq->returnCode == AccLockReq::Success);
-        removeAccLockOp(c_ctx.scanPtr, accOperationPtr);
+        removeAccLockOp(scan, accOperationPtr);
       }
       if (scanFlag == NextScanReq::ZSCAN_COMMIT) {
         jamDebug();
@@ -985,7 +985,7 @@ void Dbtux::continue_scan(Signal *signal, ScanOpPtr scanPtr, Frag &frag,
     if (unlikely(accLockOp != RNIL)) {
       scan.m_accLockOp = RNIL;
       // remember it until LQH unlocks it
-      addAccLockOp(scanPtr, accLockOp);
+      addAccLockOp(scan, accLockOp);
     } else {
       ndbrequire(scan.m_readCommitted);
       // operation RNIL in LQH would signal no tuple returned
@@ -1649,7 +1649,7 @@ void Dbtux::scanClose(Signal *signal, ScanOpPtr scanPtr) {
   // unlock all not unlocked by LQH
   if (!scan.m_accLockOps.isEmpty()) {
     jam();
-    abortAccLockOps(signal, scanPtr);
+    abortAccLockOps(signal, scan);
   }
   Uint32 blockNo = refToMain(scanPtr.p->m_userRef);
   if (scanPtr.p->m_errorCode == 0) {
@@ -1677,11 +1677,10 @@ void Dbtux::scanClose(Signal *signal, ScanOpPtr scanPtr) {
   }
 }
 
-void Dbtux::abortAccLockOps(Signal *signal, ScanOpPtr scanPtr) {
-  ScanOp &scan = *scanPtr.p;
+void Dbtux::abortAccLockOps(Signal *signal, ScanOp &scan) {
 #ifdef VM_TRACE
   if (debugFlags & (DebugScan | DebugLock)) {
-    tuxDebugOut << "Abort locks in scan " << scanPtr.i << " " << scan << endl;
+    tuxDebugOut << "Abort locks in scan " << scan << endl;
   }
 #endif
   Local_ScanLock_fifo list(c_scanLockPool, scan.m_accLockOps);
@@ -1701,12 +1700,11 @@ void Dbtux::abortAccLockOps(Signal *signal, ScanOpPtr scanPtr) {
   checkPoolShrinkNeed(DBTUX_SCAN_LOCK_TRANSIENT_POOL_INDEX, c_scanLockPool);
 }
 
-void Dbtux::addAccLockOp(ScanOpPtr scanPtr, Uint32 accLockOp) {
-  ScanOp &scan = *scanPtr.p;
+void Dbtux::addAccLockOp(ScanOp &scan, Uint32 accLockOp) {
 #ifdef VM_TRACE
   if (debugFlags & (DebugScan | DebugLock)) {
     tuxDebugOut << "Add lock " << hex << accLockOp << dec << " to scan "
-                << scanPtr.i << " " << scan << endl;
+                << scan << endl;
   }
 #endif
   Local_ScanLock_fifo list(c_scanLockPool, scan.m_accLockOps);
@@ -1726,12 +1724,11 @@ void Dbtux::addAccLockOp(ScanOpPtr scanPtr, Uint32 accLockOp) {
   list.addLast(lockPtr);
 }
 
-void Dbtux::removeAccLockOp(ScanOpPtr scanPtr, Uint32 accLockOp) {
-  ScanOp &scan = *scanPtr.p;
+void Dbtux::removeAccLockOp(ScanOp &scan, Uint32 accLockOp) {
 #ifdef VM_TRACE
   if (debugFlags & (DebugScan | DebugLock)) {
     tuxDebugOut << "Remove lock " << hex << accLockOp << dec << " from scan "
-                << scanPtr.i << " " << scan << endl;
+                << scan << endl;
   }
 #endif
   Local_ScanLock_fifo list(c_scanLockPool, scan.m_accLockOps);


### PR DESCRIPTION
…ile loops

Fix issues introduced in 24.10 where locked rows are not always properly released. Ensure we don't do any extra loops in removeAccLockOp. Optimisation for ReadCommitted scans.