### PR TITLE
RONDB-956: Various fixes for rate limits and quotas

### DIFF
--- a/mysql-test/suite/ndb_quota/ndb_insert.result
+++ b/mysql-test/suite/ndb_quota/ndb_insert.result
@@ -1,4 +1,13 @@
 DATABASE QUOTA SET successfully executed
+Database Quotas for test
+databaseId = 13
+databaseVersion = 13
+InMemorySize = 1 MByte
+DiskSpaceSize = 0 GByte
+RatePerSec = 1000
+MaxTransactionSize = 0
+MaxParallelTransactions = 0
+MaxParallelComplexQueries = 0
 DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (
 pk1 INT NOT NULL PRIMARY KEY,

--- a/mysql-test/suite/ndb_quota/ndb_insert.test
+++ b/mysql-test/suite/ndb_quota/ndb_insert.test
@@ -1,4 +1,5 @@
 --source include/have_ndb.inc
---exec $NDB_MGM -e "DATABASE QUOTA SET test --rate-per-sec = 1000"
+--exec $NDB_MGM -e "DATABASE QUOTA SET test --rate-per-sec = 1000 --in-memory-size=1"
+--exec $NDB_MGM -e "DATABASE QUOTA GET test"
 --source suite/ndb/t/ndb_insert.test
 --exec $NDB_MGM -e "DATABASE QUOTA DROP test"

--- a/mysql-test/suite/ndb_quota/ndb_quota_commands.result
+++ b/mysql-test/suite/ndb_quota/ndb_quota_commands.result
@@ -2,17 +2,14 @@ DATABASE QUOTA SET successfully executed
 DATABASE QUOTA SET command failed: Error:
 *  1235: Error
 *        Create Database failed
-DATABASE QUOTA SET command failed: Error:
-*  1238: Error
-*        Create Database failed
-DATABASE QUOTA SET command failed: Error:
-*  1240: Error
-*        Create Database failed
 DATABASE QUOTA SET successfully executed
+DATABASE QUOTA SET command failed: Error:
+*   721: Error
+*        Create Database failed
 Database Quotas for test
 databaseId = 13
 databaseVersion = 13
-InMemorySize = 0 MByte
+InMemorySize = 2 MByte
 DiskSpaceSize = 0 GByte
 RatePerSec = 500
 MaxTransactionSize = 4
@@ -21,7 +18,7 @@ MaxParallelComplexQueries = 0
 Database Quotas for test2
 databaseId = 14
 databaseVersion = 14
-InMemorySize = 0 MByte
+InMemorySize = 10 MByte
 DiskSpaceSize = 0 GByte
 RatePerSec = 500
 MaxTransactionSize = 0
@@ -40,7 +37,7 @@ DATABASE QUOTA ALTER successfully executed
 Database Quotas for test2
 databaseId = 14
 databaseVersion = 14
-InMemorySize = 0 MByte
+InMemorySize = 12 MByte
 DiskSpaceSize = 0 GByte
 RatePerSec = 1500
 MaxTransactionSize = 0
@@ -49,7 +46,7 @@ MaxParallelComplexQueries = 0
 Database Quotas for test
   databaseId = 13
   databaseVersion = 13
-  InMemorySize = 0 MByte
+  InMemorySize = 2 MByte
   DiskSpaceSize = 0 GByte
   RatePerSec = 500
   MaxTransactionSize = 4
@@ -59,7 +56,7 @@ Database Quotas for test
 Database Quotas for test2
   databaseId = 14
   databaseVersion = 14
-  InMemorySize = 0 MByte
+  InMemorySize = 12 MByte
   DiskSpaceSize = 0 GByte
   RatePerSec = 1500
   MaxTransactionSize = 0
@@ -67,13 +64,107 @@ Database Quotas for test2
   MaxParallelComplexQueries = 0
 
 Database Quota List command completed
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (
+pk1 INT NOT NULL PRIMARY KEY,
+b1 CHAR(255),
+b2 CHAR(255),
+b3 CHAR(255),
+b4 CHAR(255),
+b5 CHAR(255) NULL,
+b6 CHAR(255) NULL,
+b7 CHAR(255) NULL,
+b8 CHAR(255) NULL,
+b9 CHAR(255) NULL,
+b10 CHAR(255) NULL,
+b11 CHAR(255) NULL,
+b12 CHAR(255) NULL,
+b13 CHAR(255) NULL,
+b14 CHAR(255) NULL,
+b15 CHAR(255) NULL,
+b16 CHAR(255) NULL,
+b17 CHAR(255) NULL,
+b18 CHAR(255) NULL,
+b19 CHAR(255) NULL,
+b20 CHAR(255) NULL,
+b21 CHAR(255) NULL,
+b22 CHAR(255) NULL,
+b23 CHAR(255) NULL,
+b24 CHAR(255) NULL,
+b25 CHAR(255) NULL,
+b26 CHAR(255) NULL,
+b27 CHAR(255) NULL,
+b28 VARCHAR(20000) NULL
+) engine ndb character set latin1;
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (0, '0', '0', '0', '0',REPEAT('a', 19000)),(30,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (1, '0', '0', '0', '0',REPEAT('a', 19000)),(31,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (2, '0', '0', '0', '0',REPEAT('a', 19000)),(32,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (3, '0', '0', '0', '0',REPEAT('a', 19000)),(33,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (4, '0', '0', '0', '0',REPEAT('a', 19000)),(34,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (5, '0', '0', '0', '0',REPEAT('a', 19000)),(35,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (6, '0', '0', '0', '0',REPEAT('a', 19000)),(36,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (7, '0', '0', '0', '0',REPEAT('a', 19000)),(37,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (8, '0', '0', '0', '0',REPEAT('a', 19000)),(38,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (9, '0', '0', '0', '0',REPEAT('a', 19000)),(39,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (10, '0', '0', '0', '0',REPEAT('a', 19000)),(40,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (11, '0', '0', '0', '0',REPEAT('a', 19000)),(41,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (12, '0', '0', '0', '0',REPEAT('a', 19000)),(42,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (13, '0', '0', '0', '0',REPEAT('a', 19000)),(43,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (14, '0', '0', '0', '0',REPEAT('a', 19000)),(44,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (15, '0', '0', '0', '0',REPEAT('a', 19000)),(45,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (16, '0', '0', '0', '0',REPEAT('a', 19000)),(46,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (17, '0', '0', '0', '0',REPEAT('a', 19000)),(47,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (18, '0', '0', '0', '0',REPEAT('a', 19000)),(48,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (19, '0', '0', '0', '0',REPEAT('a', 19000)),(49,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (20, '0', '0', '0', '0',REPEAT('a', 19000)),(50,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (21, '0', '0', '0', '0',REPEAT('a', 19000)),(51,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (22, '0', '0', '0', '0',REPEAT('a', 19000)),(52,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (23, '0', '0', '0', '0',REPEAT('a', 19000)),(53,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (24, '0', '0', '0', '0',REPEAT('a', 19000)),(54,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (25, '0', '0', '0', '0',REPEAT('a', 19000)),(55,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (26, '0', '0', '0', '0',REPEAT('a', 19000)),(56,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (27, '0', '0', '0', '0',REPEAT('a', 19000)),(57,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (28, '0', '0', '0', '0',REPEAT('a', 19000)),(58,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (29, '0', '0', '0', '0',REPEAT('a', 19000)),(59,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (60, '0', '0', '0', '0',REPEAT('a', 19000)),(61,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (62, '0', '0', '0', '0',REPEAT('a', 19000)),(63,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (64, '0', '0', '0', '0',REPEAT('a', 19000)),(65,'30', '0', '0', '0', '0');
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+ERROR HY000: Got temporary error 239 'Memory quota reached for database, delete data before write again' from NDBCLUSTER
+DELETE from t1 WHERE pk1 = 47;
+DELETE from t1 WHERE pk1 = 46;
+DELETE from t1 WHERE pk1 = 45;
+DELETE from t1 WHERE pk1 = 44;
+DELETE from t1 WHERE pk1 = 43;
+DELETE from t1 WHERE pk1 = 42;
+DELETE from t1 WHERE pk1 = 41;
+DELETE from t1 WHERE pk1 = 40;
+DELETE from t1 WHERE pk1 = 39;
+DELETE from t1 WHERE pk1 = 38;
+DELETE from t1 WHERE pk1 = 37;
+DELETE from t1 WHERE pk1 = 36;
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 35;
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 34;
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 33;
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 32;
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 31;
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 30;
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DROP TABLE t1;
 Database Quota Backup command completed
 DATABASE QUOTA DROP successfully executed
 DATABASE QUOTA DROP successfully executed
-Execute DATABASE QUOTA SET test --in-memory-size = 0M --on-disk-size = 0G --rate-per-sec = 500 --max-transaction-size = 4 --max-parallel-transactions = 4 --max-parallel-complex-queries = 0
+Execute DATABASE QUOTA SET test --in-memory-size = 2 --on-disk-size = 0 --rate-per-sec = 500 --max-transaction-size = 4 --max-parallel-transactions = 4 --max-parallel-complex-queries = 0
 DATABASE QUOTA SET successfully executed
 DATABASE QUOTA SET command succeeded for RESTORE
-Execute DATABASE QUOTA SET test2 --in-memory-size = 0M --on-disk-size = 0G --rate-per-sec = 1500 --max-transaction-size = 0 --max-parallel-transactions = 0 --max-parallel-complex-queries = 0
+Execute DATABASE QUOTA SET test2 --in-memory-size = 12 --on-disk-size = 0 --rate-per-sec = 1500 --max-transaction-size = 0 --max-parallel-transactions = 0 --max-parallel-complex-queries = 0
 DATABASE QUOTA SET successfully executed
 DATABASE QUOTA SET command succeeded for RESTORE
 DATABASE QUOTA DROP successfully executed

--- a/mysql-test/suite/ndb_quota/ndb_quota_commands.test
+++ b/mysql-test/suite/ndb_quota/ndb_quota_commands.test
@@ -1,12 +1,10 @@
 --source include/have_ndb.inc
---exec $NDB_MGM -e "DATABASE QUOTA SET test --rate-per-sec = 500 --max-transaction-size=4 --max-parallel-transactions=4"
+--exec $NDB_MGM -e "DATABASE QUOTA SET test --rate-per-sec = 500 --in-memory-size=2 --max-transaction-size=4 --max-parallel-transactions=4"
 --error 255,65280
 --exec $NDB_MGM -e "DATABASE QUOTA SET test2 --rate-per-sec = 50000000 --in-memory-size=100 --on-disk-size=0"
+--exec $NDB_MGM -e "DATABASE QUOTA SET test2 --rate-per-sec = 500 --in-memory-size=10 --on-disk-size=0"
 --error 255,65280
---exec $NDB_MGM -e "DATABASE QUOTA SET test2 --rate-per-sec = 500 --in-memory-size=100 --on-disk-size=0"
---error 255,65280
---exec $NDB_MGM -e "DATABASE QUOTA SET test2 --rate-per-sec = 500 --in-memory-size=10 --on-disk-size=10"
---exec $NDB_MGM -e "DATABASE QUOTA SET test2 --rate-per-sec = 500 --in-memory-size=10"
+--exec $NDB_MGM -e "DATABASE QUOTA SET test2 --rate-per-sec = 500 --in-memory-size=11 --on-disk-size=0"
 --exec $NDB_MGM -e "DATABASE QUOTA GET test"
 --exec $NDB_MGM -e "DATABASE QUOTA GET test2"
 --error 255,65280
@@ -14,10 +12,121 @@
 --error 255,65280
 --exec $NDB_MGM -e "DATABASE QUOTA ALTER test2 --rate-per-sec = 1500 --in-memory-size=100 --on-disk-size=10"
 --error 255,65280
---exec $NDB_MGM -e "DATABASE QUOTA ALTER test2 --rate-per-sec = 1500 --in-memory-size=11 --on-disk-size=10"
---exec $NDB_MGM -e "DATABASE QUOTA ALTER test2 --rate-per-sec = 1500 --in-memory-size=11"
+--exec $NDB_MGM -e "DATABASE QUOTA ALTER test2 --rate-per-sec = 1500 --in-memory-size=12 --on-disk-size=10"
+--exec $NDB_MGM -e "DATABASE QUOTA ALTER test2 --rate-per-sec = 1500 --in-memory-size=12"
 --exec $NDB_MGM -e "DATABASE QUOTA GET test2"
 --exec $NDB_MGM -e "DATABASE QUOTA LIST"
+--disable_warnings
+DROP TABLE IF EXISTS t1;
+--enable_warnings
+
+CREATE TABLE t1 (
+  pk1 INT NOT NULL PRIMARY KEY,
+  b1 CHAR(255),
+  b2 CHAR(255),
+  b3 CHAR(255),
+  b4 CHAR(255),
+  b5 CHAR(255) NULL,
+  b6 CHAR(255) NULL,
+  b7 CHAR(255) NULL,
+  b8 CHAR(255) NULL,
+  b9 CHAR(255) NULL,
+  b10 CHAR(255) NULL,
+  b11 CHAR(255) NULL,
+  b12 CHAR(255) NULL,
+  b13 CHAR(255) NULL,
+  b14 CHAR(255) NULL,
+  b15 CHAR(255) NULL,
+  b16 CHAR(255) NULL,
+  b17 CHAR(255) NULL,
+  b18 CHAR(255) NULL,
+  b19 CHAR(255) NULL,
+  b20 CHAR(255) NULL,
+  b21 CHAR(255) NULL,
+  b22 CHAR(255) NULL,
+  b23 CHAR(255) NULL,
+  b24 CHAR(255) NULL,
+  b25 CHAR(255) NULL,
+  b26 CHAR(255) NULL,
+  b27 CHAR(255) NULL,
+  b28 VARCHAR(20000) NULL
+) engine ndb character set latin1;
+
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (0, '0', '0', '0', '0',REPEAT('a', 19000)),(30,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (1, '0', '0', '0', '0',REPEAT('a', 19000)),(31,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (2, '0', '0', '0', '0',REPEAT('a', 19000)),(32,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (3, '0', '0', '0', '0',REPEAT('a', 19000)),(33,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (4, '0', '0', '0', '0',REPEAT('a', 19000)),(34,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (5, '0', '0', '0', '0',REPEAT('a', 19000)),(35,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (6, '0', '0', '0', '0',REPEAT('a', 19000)),(36,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (7, '0', '0', '0', '0',REPEAT('a', 19000)),(37,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (8, '0', '0', '0', '0',REPEAT('a', 19000)),(38,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (9, '0', '0', '0', '0',REPEAT('a', 19000)),(39,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (10, '0', '0', '0', '0',REPEAT('a', 19000)),(40,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (11, '0', '0', '0', '0',REPEAT('a', 19000)),(41,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (12, '0', '0', '0', '0',REPEAT('a', 19000)),(42,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (13, '0', '0', '0', '0',REPEAT('a', 19000)),(43,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (14, '0', '0', '0', '0',REPEAT('a', 19000)),(44,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (15, '0', '0', '0', '0',REPEAT('a', 19000)),(45,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (16, '0', '0', '0', '0',REPEAT('a', 19000)),(46,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (17, '0', '0', '0', '0',REPEAT('a', 19000)),(47,'30', '0', '0', '0',REPEAT('a', 19000));
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (18, '0', '0', '0', '0',REPEAT('a', 19000)),(48,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (19, '0', '0', '0', '0',REPEAT('a', 19000)),(49,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (20, '0', '0', '0', '0',REPEAT('a', 19000)),(50,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (21, '0', '0', '0', '0',REPEAT('a', 19000)),(51,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (22, '0', '0', '0', '0',REPEAT('a', 19000)),(52,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (23, '0', '0', '0', '0',REPEAT('a', 19000)),(53,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (24, '0', '0', '0', '0',REPEAT('a', 19000)),(54,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (25, '0', '0', '0', '0',REPEAT('a', 19000)),(55,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (26, '0', '0', '0', '0',REPEAT('a', 19000)),(56,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (27, '0', '0', '0', '0',REPEAT('a', 19000)),(57,'30', '0', '0', '0', '0');
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (28, '0', '0', '0', '0',REPEAT('a', 19000)),(58,'30', '0', '0', '0', '0');
+--error 0, 1297
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (29, '0', '0', '0', '0',REPEAT('a', 19000)),(59,'30', '0', '0', '0', '0');
+--error 0, 1297
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (60, '0', '0', '0', '0',REPEAT('a', 19000)),(61,'30', '0', '0', '0', '0');
+--error 0, 1297
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (62, '0', '0', '0', '0',REPEAT('a', 19000)),(63,'30', '0', '0', '0', '0');
+--error 0, 1297
+INSERT INTO t1 (pk1,b1,b2,b3,b4,b28) VALUES (64, '0', '0', '0', '0',REPEAT('a', 19000)),(65,'30', '0', '0', '0', '0');
+--error 1297
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 47;
+DELETE from t1 WHERE pk1 = 46;
+DELETE from t1 WHERE pk1 = 45;
+DELETE from t1 WHERE pk1 = 44;
+DELETE from t1 WHERE pk1 = 43;
+DELETE from t1 WHERE pk1 = 42;
+DELETE from t1 WHERE pk1 = 41;
+DELETE from t1 WHERE pk1 = 40;
+DELETE from t1 WHERE pk1 = 39;
+DELETE from t1 WHERE pk1 = 38;
+DELETE from t1 WHERE pk1 = 37;
+DELETE from t1 WHERE pk1 = 36;
+--error 0, 1297
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 35;
+--error 0, 1297
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 34;
+--error 0, 1297
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 33;
+--error 0, 1297
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 32;
+--error 0, 1297
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+--error 0, 1297
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 31;
+--error 0, 1297
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+DELETE from t1 WHERE pk1 = 30;
+UPDATE t1 SET b28 = REPEAT('b', 19000) WHERE pk1 = 48;
+
+DROP TABLE t1;
+
 --disable_query_log
 if (!$NDB_BACKUP_DIR)
 {

--- a/mysql-test/suite/ndb_quota/ndb_update.test
+++ b/mysql-test/suite/ndb_quota/ndb_update.test
@@ -1,4 +1,4 @@
 --source include/have_ndb.inc
---exec $NDB_MGM -e "DATABASE QUOTA SET test --rate-per-sec = 500"
+--exec $NDB_MGM -e "DATABASE QUOTA SET test --rate-per-sec = 500 --in-memory-size=1"
 --source suite/ndb/t/ndb_update.test
 --exec $NDB_MGM -e "DATABASE QUOTA DROP test"

--- a/storage/ndb/src/kernel/blocks/dbdict/Dbdict.cpp
+++ b/storage/ndb/src/kernel/blocks/dbdict/Dbdict.cpp
@@ -139,7 +139,7 @@
 //#define DO_TRANSIENT_POOL_STAT 1
 //#define DEBUG_HASH 1
 //#define DEBUG_QUOTAS_EXTRA 1
-//#define DEBUG_QUOTAS 1
+#define DEBUG_QUOTAS 1
 //#define DEBUG_RESTART 1
 #endif
 
@@ -2483,7 +2483,7 @@ void Dbdict::initCommonData() {
 
   m_current_allocated_rate = 0;
   m_current_allocated_memory_quota_mb = 0;
-  m_current_allocated_disk_quota_gb = 0;
+  m_current_allocated_disk_quota_mb = 0;
 
   Uint32 num_threads = getNumThreads() + getNumSendThreads();
   Uint32 tot_rates = num_threads * 1000000;
@@ -2494,7 +2494,9 @@ void Dbdict::initCommonData() {
   Uint32 max_dm_mb = (Uint32(tot_dm_mb) / 10) * 8;
   m_allocated_memory_quota_limit = max_dm_mb;
 
-  m_allocated_disk_quota_limit_gb = 0;
+  DEB_QUOTAS(("m_allocated_memory_quota_limit init:ed to %u MBytes",
+    m_allocated_memory_quota_limit));
+  m_allocated_disk_quota_limit_mb = 0;
   m_allocated_disk_quota_limit = 0;
 
   c_outstanding_sub_startstop = 0;
@@ -22878,11 +22880,11 @@ void Dbdict::createFile_fromLocal(Signal *signal, Uint32 op_key, Uint32 ret) {
     CreateFileImplReq *impl_req = &createFilePtr.p->m_request;
     ndbrequire(find_object(f_ptr, impl_req->file_id));
     m_allocated_disk_quota_limit += f_ptr.p->m_file_size;
-    Uint64 allocated_disk_quota_gb =
-      m_allocated_disk_quota_limit / (1024 * 1024 * 1024);
-    allocated_disk_quota_gb *= 8;
-    allocated_disk_quota_gb /= 10;
-    m_allocated_disk_quota_limit_gb = Uint32(allocated_disk_quota_gb);
+    Uint64 allocated_disk_quota_mb =
+      m_allocated_disk_quota_limit / (1024 * 1024);
+    allocated_disk_quota_mb *= 8;
+    allocated_disk_quota_mb /= 10;
+    m_allocated_disk_quota_limit_mb = Uint32(allocated_disk_quota_mb);
 
     sendTransConf(signal, op_ptr);
   } else {
@@ -23541,7 +23543,7 @@ void Dbdict::dropFile_parse(Signal *signal, bool master, SchemaOpPtr op_ptr,
   getOpRec(op_ptr, dropFileRecPtr);
   DropFileImplReq *impl_req = &dropFileRecPtr.p->m_request;
 
-  if (m_current_allocated_disk_quota_gb > 0) {
+  if (m_current_allocated_disk_quota_mb > 0) {
     jam();
     setError(error, CreateTableRef::NotAllowedToDropFileWithQuotas, __LINE__);
     return;
@@ -32527,14 +32529,19 @@ Dbdict::createDatabase_parse(Signal* signal, bool master,
                           "will not fail since it is a restart");
     } else {
       jam();
+      DEB_QUOTAS(("Create Database Mem failed: Requested: %llu, curr: %u,"
+                  " avail: %u",
+        db.InMemorySize,
+        m_current_allocated_memory_quota_mb,
+        m_allocated_memory_quota_limit));
       setError(error, CreateTableRef::CreateDbNoAvailableMemoryQuota, __LINE__);
       return;
     }
   }
   Uint32 available_disk_quota_limit =
-    m_allocated_disk_quota_limit_gb - m_current_allocated_disk_quota_gb;
+    m_allocated_disk_quota_limit_mb - m_current_allocated_disk_quota_mb;
   if (db.DiskSpaceSize > 0 &&
-      (m_allocated_disk_quota_limit_gb < m_current_allocated_disk_quota_gb ||
+      (m_allocated_disk_quota_limit_mb < m_current_allocated_disk_quota_mb ||
        db.DiskSpaceSize > available_disk_quota_limit)) {
     if (op_ptr.p->m_restart) {
       jam();
@@ -32542,6 +32549,11 @@ Dbdict::createDatabase_parse(Signal* signal, bool master,
                           "will not fail since it is a restart");
     } else {
       jam();
+      DEB_QUOTAS(("Create Database Disk failed: Requested: %llu, curr: %u,"
+                  " avail: %u",
+        db.InMemorySize,
+        m_current_allocated_memory_quota_mb,
+        m_allocated_disk_quota_limit_mb));
       setError(error, CreateTableRef::CreateDbNoAvailableDiskQuota, __LINE__);
       return;
     }
@@ -32809,11 +32821,8 @@ Dbdict::createDb_local(Signal* signal,
   req->databaseId = db_ptr.p->key;
   req->databaseVersion = db_ptr.p->m_version;
   req->requestType = 0;
-  req->inMemorySizeMB = (Uint32)
-    (db_ptr.p->m_in_memory_size / (Uint64(1024) * Uint64(1024)));
-  req->diskSpaceSizeGB = (Uint32)
-    (db_ptr.p->m_disk_space_size /
-    (Uint64(1024) * Uint64(1024) * Uint64(1024)));
+  req->inMemorySizeMB = (Uint32)(db_ptr.p->m_in_memory_size);
+  req->diskSpaceSizeGB = (Uint32)(db_ptr.p->m_disk_space_size);
   req->ratePerSec = db_ptr.p->m_rate_per_sec;
   sendSignal(DBLQH_REF, GSN_CREATE_DB_REQ, signal,
              CreateDbReq::SignalLengthLQH, JBB);
@@ -32847,11 +32856,8 @@ Dbdict::execCREATE_DB_CONF(Signal *signal) {
     req->databaseId = db_ptr.p->key;
     req->databaseVersion = db_ptr.p->m_version;
     req->requestType = 0;
-    req->inMemorySizeMB = (Uint32)
-      (db_ptr.p->m_in_memory_size / (Uint64(1024) * Uint64(1024)));
-    req->diskSpaceSizeGB = (Uint32)
-      (db_ptr.p->m_disk_space_size /
-      (Uint64(1024) * Uint64(1024) * Uint64(1024)));
+    req->inMemorySizeMB = (Uint32)(db_ptr.p->m_in_memory_size);
+    req->diskSpaceSizeGB = (Uint32)(db_ptr.p->m_disk_space_size);
     req->ratePerSec = db_ptr.p->m_rate_per_sec;
     req->maxTransactionSize = db_ptr.p->m_max_transaction_size;
     req->maxParallelTransactions =
@@ -33216,11 +33222,15 @@ void Dbdict::execCOMMIT_DB_CONF(Signal *signal) {
                m_allocated_memory_quota_limit) ||
              op_ptr.p->m_restart);
 
-  m_current_allocated_disk_quota_gb += db_ptr.p->m_disk_space_size;
-  ndbrequire((m_current_allocated_disk_quota_gb <=
-               m_allocated_disk_quota_limit_gb) ||
+  m_current_allocated_disk_quota_mb += db_ptr.p->m_disk_space_size;
+  ndbrequire((m_current_allocated_disk_quota_mb <=
+               m_allocated_disk_quota_limit_mb) ||
              op_ptr.p->m_restart);
 
+  DEB_QUOTAS(("New m_current_allocated_memory_quota_mb = %u MBytes"
+              ", m_current_allocated_disk_quota_mb = %u MBytes",
+    m_current_allocated_memory_quota_mb,
+    m_current_allocated_disk_quota_mb));
   /* Finished commit phase of create database */
   execute(signal, createDbPtr.p->m_callback, db_ptr.p->key);
 }
@@ -33792,9 +33802,13 @@ void Dbdict::dropDatabase_complete(Signal* signal, SchemaOpPtr op_ptr) {
   ndbrequire(m_current_allocated_memory_quota_mb >= db_ptr.p->m_in_memory_size);
   m_current_allocated_memory_quota_mb -= db_ptr.p->m_in_memory_size;
 
-  ndbrequire(m_current_allocated_disk_quota_gb >= db_ptr.p->m_disk_space_size);
-  m_current_allocated_disk_quota_gb -= db_ptr.p->m_disk_space_size;
+  ndbrequire(m_current_allocated_disk_quota_mb >= db_ptr.p->m_disk_space_size);
+  m_current_allocated_disk_quota_mb -= db_ptr.p->m_disk_space_size;
 
+  DEB_QUOTAS(("New after drop m_current_allocated_memory_quota_mb = %u MBytes"
+              ", m_current_allocated_disk_quota_mb = %u MBytes",
+    m_current_allocated_memory_quota_mb,
+    m_current_allocated_disk_quota_mb));
   c_database_pool.release(db_ptr);
   sendTransConf(signal, op_ptr);
 }
@@ -34037,6 +34051,11 @@ Dbdict::alterDatabase_parse(Signal* signal, bool master,
             (m_current_allocated_memory_quota_mb >
               m_allocated_memory_quota_limit)) {
         jam();
+        DEB_QUOTAS(("Alter Database Mem failed: Requested: %u, curr: %u,"
+                    " avail: %u",
+          increase_memory_quota_mb,
+          m_current_allocated_memory_quota_mb,
+          m_allocated_memory_quota_limit));
         setError(error,
                  CreateTableRef::AlterDbNoAvailableMemoryQuota,
                  __LINE__);
@@ -34045,15 +34064,20 @@ Dbdict::alterDatabase_parse(Signal* signal, bool master,
     }
     if (db.DiskSpaceSize != RNIL &&
         db_ptr.p->m_disk_space_size < db.DiskSpaceSize) {
-      Uint32 increase_disk_quota_gb =
+      Uint32 increase_disk_quota_mb =
         db.DiskSpaceSize - db_ptr.p->m_disk_space_size;
-      Uint32 available_disk_quota_limit_gb =
-        m_allocated_disk_quota_limit_gb - m_current_allocated_disk_quota_gb;
-      if (increase_disk_quota_gb > available_disk_quota_limit_gb ||
-            (m_current_allocated_disk_quota_gb >
-              m_allocated_disk_quota_limit_gb)) {
+      Uint32 available_disk_quota_limit_mb =
+        m_allocated_disk_quota_limit_mb - m_current_allocated_disk_quota_mb;
+      if (increase_disk_quota_mb > available_disk_quota_limit_mb ||
+            (m_current_allocated_disk_quota_mb >
+              m_allocated_disk_quota_limit_mb)) {
         jam();
-        setError(error,
+        DEB_QUOTAS(("Create Database Disk failed: Requested: %u, curr: %u,"
+                    " avail: %u",
+          increase_disk_quota_mb,
+          m_current_allocated_disk_quota_mb,
+          m_allocated_disk_quota_limit_mb));
+          setError(error,
                  CreateTableRef::AlterDbNoAvailableDiskQuota,
                  __LINE__);
         return;
@@ -34235,11 +34259,8 @@ Dbdict::alterDatabase_commit(Signal* signal, SchemaOpPtr op_ptr)
   req->databaseId = alter_db_ptr.p->key;
   req->databaseVersion = alter_db_ptr.p->m_version;
   req->requestType = 0;
-  req->inMemorySizeMB = (Uint32)
-    (alter_db_ptr.p->m_in_memory_size / (Uint64(1024) * Uint64(1024)));
-  req->diskSpaceSizeGB = (Uint32)
-    (alter_db_ptr.p->m_disk_space_size /
-    (Uint64(1024) * Uint64(1024) * Uint64(1024)));
+  req->inMemorySizeMB = (Uint32)(alter_db_ptr.p->m_in_memory_size);
+  req->diskSpaceSizeGB = (Uint32)(alter_db_ptr.p->m_disk_space_size);
   req->ratePerSec = alter_db_ptr.p->m_rate_per_sec;
   req->maxTransactionSize = alter_db_ptr.p->m_max_transaction_size;
   req->maxParallelTransactions =
@@ -34279,11 +34300,8 @@ Dbdict::execALTER_DB_CONF(Signal *signal)
     req->databaseId = alter_db_ptr.p->key;
     req->databaseVersion = alter_db_ptr.p->m_version;
     req->requestType = 0;
-    req->inMemorySizeMB = (Uint32)
-      (alter_db_ptr.p->m_in_memory_size / (Uint64(1024) * Uint64(1024)));
-    req->diskSpaceSizeGB = (Uint32)
-      (alter_db_ptr.p->m_disk_space_size /
-      (Uint64(1024) * Uint64(1024) * Uint64(1024)));
+    req->inMemorySizeMB = (Uint32)(alter_db_ptr.p->m_in_memory_size);
+    req->diskSpaceSizeGB = (Uint32)(alter_db_ptr.p->m_disk_space_size);
     req->ratePerSec = alter_db_ptr.p->m_rate_per_sec;
     sendSignal(DBLQH_REF, GSN_ALTER_DB_REQ, signal,
                AlterDbReq::SignalLengthLQH, JBB);
@@ -34302,12 +34320,12 @@ Dbdict::execALTER_DB_CONF(Signal *signal)
   ndbrequire(m_current_allocated_memory_quota_mb <=
              m_allocated_memory_quota_limit);
 
-  ndbrequire(m_current_allocated_disk_quota_gb >=
+  ndbrequire(m_current_allocated_disk_quota_mb >=
              db_ptr.p->m_disk_space_size);
-  m_current_allocated_disk_quota_gb -= db_ptr.p->m_disk_space_size;
-  m_current_allocated_disk_quota_gb += alter_db_ptr.p->m_disk_space_size;
-  ndbrequire(m_current_allocated_disk_quota_gb <=
-             m_allocated_disk_quota_limit_gb);
+  m_current_allocated_disk_quota_mb -= db_ptr.p->m_disk_space_size;
+  m_current_allocated_disk_quota_mb += alter_db_ptr.p->m_disk_space_size;
+  ndbrequire(m_current_allocated_disk_quota_mb <=
+             m_allocated_disk_quota_limit_mb);
 
   db_ptr.p->m_in_memory_size = alter_db_ptr.p->m_in_memory_size;
   db_ptr.p->m_disk_space_size = alter_db_ptr.p->m_disk_space_size;
@@ -34502,11 +34520,8 @@ void Dbdict::execGET_DATABASE_REQ(Signal *signal) {
   conf->clientData = req->senderData;
   conf->databaseId = db_ptr.p->key;
   conf->databaseVersion = db_ptr.p->m_version;
-  conf->InMemorySizeMB = (Uint32)
-    (db_ptr.p->m_in_memory_size / (Uint64(1024) * Uint64(1024)));
-  conf->DiskSpaceSizeGB = (Uint32)
-    (db_ptr.p->m_disk_space_size /
-    (Uint64(1024) * Uint64(1024) * Uint64(1024)));
+  conf->InMemorySizeMB = (Uint32)(db_ptr.p->m_in_memory_size);
+  conf->DiskSpaceSizeGB = (Uint32)(db_ptr.p->m_disk_space_size);
   conf->RatePerSec = db_ptr.p->m_rate_per_sec;
   conf->MaxTransactionSize =
     db_ptr.p->m_max_transaction_size;
@@ -34567,11 +34582,8 @@ void Dbdict::execLIST_DATABASE_REQ(Signal *signal) {
   conf->clientData = req->senderData;
   conf->databaseId = db_ptr.p->key;
   conf->databaseVersion = db_ptr.p->m_version;
-  conf->InMemorySizeMB = (Uint32)
-    (db_ptr.p->m_in_memory_size / (Uint64(1024) * Uint64(1024)));
-  conf->DiskSpaceSizeGB = (Uint32)
-    (db_ptr.p->m_disk_space_size /
-    (Uint64(1024) * Uint64(1024) * Uint64(1024)));
+  conf->InMemorySizeMB = (Uint32)(db_ptr.p->m_in_memory_size);
+  conf->DiskSpaceSizeGB = (Uint32)(db_ptr.p->m_disk_space_size);
   conf->RatePerSec = db_ptr.p->m_rate_per_sec;
   conf->MaxTransactionSize =
     db_ptr.p->m_max_transaction_size;

--- a/storage/ndb/src/kernel/blocks/dbdict/Dbdict.hpp
+++ b/storage/ndb/src/kernel/blocks/dbdict/Dbdict.hpp
@@ -726,8 +726,8 @@ class Dbdict : public SimulatedBlock {
   Uint32 m_current_allocated_memory_quota_mb;
   Uint32 m_allocated_memory_quota_limit;
 
-  Uint32 m_current_allocated_disk_quota_gb;
-  Uint32 m_allocated_disk_quota_limit_gb;
+  Uint32 m_current_allocated_disk_quota_mb;
+  Uint32 m_allocated_disk_quota_limit_mb;
   Uint64 m_allocated_disk_quota_limit;
 
 

--- a/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dblqh/DblqhMain.cpp
@@ -5846,8 +5846,12 @@ void Dblqh::execSEND_PACKED(Signal *signal) {
   /* Send buffered DATABASE_QUOTA_REP signals */
   Uint32 num_tc_threads = globalData.ndbMtTcWorkers;
   Uint32 num_send_database_quota_rep = m_num_send_database_quota_rep;
-  DEB_RATE_SEND(("(%u) Send %u DATABASE_QUOTA_REP signals",
-    instance(), num_send_database_quota_rep));
+#ifdef DEBUG_RATE_SEND
+  if (num_send_database_quota_rep > 0) {
+    DEB_RATE_SEND(("(%u) Send %u DATABASE_QUOTA_REP signals",
+      instance(), num_send_database_quota_rep));
+  }
+#endif
   for (Uint32 i = 0; i < num_send_database_quota_rep; i++) {
     jam();
     DatabaseQuotaRep *rep = (DatabaseQuotaRep*)signal->getDataPtrSend();
@@ -9727,6 +9731,8 @@ void Dblqh::execLQHKEYREQ(Signal *signal) {
       ndbrequire(m_databaseRecordPool.getPtr(dbPtr));
       if (unlikely(dbPtr.p->m_is_memory_quota_exceeded))
       {
+        DEB_QUOTAS(("(%u) Transaction aborted due to quota exceeded",
+          instance()));
         LQHKEY_abort(signal, 7, tcConnectptr);
         return;
       }
@@ -14551,12 +14557,13 @@ void Dblqh::execABORT(Signal *signal) {
 //THE TRANSACTION MIGHT NEVER HAVE ARRIVED HERE.
 /* ------------------------------------------------------------------------- */
     DEB_ABORT_TRANS(("(%u)ABORTED not here: trans(H'%.8x,H'%.8x), tcOprec: %u"
-                     ", tcRef: %x",
+                     ", tcRef: %x, tcPtrI: %u",
                      instance(),
                      transid1,
                      transid2,
                      tcOprec,
-                     tcBlockref));
+                     tcBlockref,
+                     tcConnectptr.i));
     if (refToNode(tcBlockref) != getOwnNodeId())
     {
       signal->m_send_wakeups++;
@@ -14607,20 +14614,29 @@ void Dblqh::execABORT(Signal *signal) {
     abo->transid2 = regTcPtr->transid[1];
     signal->m_send_wakeups++;
     sendSignal(TLqhRef, GSN_ABORT, signal, Abort::SignalLength, JBB);
+    DEB_ABORT_TRANS(("(%u) LDM: Send ABORT to nextReplica node: %u, "
+                     "trans(H'%.8x',H'%.8x), tcOprec: %u, tcPtrI: %u",
+      instance(),
+      Tnode,
+      transid1,
+      transid2,
+      tcOprec,
+      tcConnectptr.i));
   }//if
   regTcPtr->abortState = TcConnectionrec::ABORT_FROM_TC;
 
   remove_commit_marker(regTcPtr);
   TRACE_OP(regTcPtr, "ABORT");
 
-  DEB_ABORT_TRANS(("(%u)Start ABORT handling: trans(H'%.8x',H'%.8x),"
-                   " tcOprec: %u, tcRef: %x, tcPtrIAcc: %u",
+  DEB_ABORT_TRANS(("(%u)LDM: Start ABORT handling: trans(H'%.8x',H'%.8x),"
+                   " tcOprec: %u, tcRef: %x, tcPtrIAcc: %u, tcPtrI: %u",
                    instance(),
                    transid1,
                    transid2,
                    tcOprec,
                    tcBlockref,
-                   tcConnectptr.p->accConnectrec));
+                   tcConnectptr.p->accConnectrec,
+                   tcConnectptr.i));
   abortStateHandlerLab(signal, tcConnectptr);
 }
 
@@ -14828,6 +14844,8 @@ void Dblqh::abortStateHandlerLab(Signal* signal,
                                  const TcConnectionrecPtr tcConnectptr)
 {
   TcConnectionrec * const regTcPtr = tcConnectptr.p;
+  DEB_ABORT_TRANS(("(%u) tcPtrI: %u, state: %u",
+    instance(), tcConnectptr.i, regTcPtr->transactionState));
   switch (regTcPtr->transactionState) {
     case TcConnectionrec::PREPARED:
       jam();
@@ -34225,7 +34243,7 @@ void Dblqh::sendAborted(Signal *signal, const TcConnectionrecPtr tcConnectptr) {
   conf->transid2 = tcConnectptr.p->transid[1];
   conf->nodeId = cownNodeid;
   conf->lastLqhIndicator = TlastInd;
-  DEB_ABORT_TRANS(("(%u)ABORTED: trans(H'%.8x,H'%.8x), tcOprec: %u"
+  DEB_ABORT_TRANS(("(%u)LDM: ABORTED: trans(H'%.8x,H'%.8x), tcOprec: %u"
                    ", tcRef: %x, tcPtrIAcc: %u",
                    instance(),
                    tcConnectptr.p->transid[0],
@@ -38780,7 +38798,7 @@ Dblqh::send_database_quota_rep(DatabaseRecordPtr dbPtr,
   dbPtr.p->m_rate_usage = 0;
 
   {
-    DEB_RATE(("(%u)(%u) db: %u, Added rate_usage: %u us",
+    DEB_RATE(("(%u)(%u) db: %u, Added rate_usage: %llu us",
               m_is_query_block,
               instance(),
               dbPtr.p->m_database_id,

--- a/storage/ndb/src/kernel/blocks/dbtc/Dbtc.hpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/Dbtc.hpp
@@ -192,12 +192,9 @@
 #define ZTOO_MANY_OPERATIONS_IN_TRANSACTION_ERROR 247
 #define ZTOO_MANY_CONCURRENT_TRANSACTIONS_ERRROR 248
 #define ZDISK_QUOTA_OVERFLOW_ERROR 239
-#define ZSCAN_NODE_ERROR 250
 #define ZNO_FRAG_LOCATION_RECORD_ERROR 251
 #define ZTRANS_STATUS_ERROR 253
 #define ZTIME_OUT_ERROR 266
-#define ZSIMPLE_READ_WITHOUT_AI 271
-#define ZNO_AI_WITH_UPDATE 272
 #define ZSEIZE_API_COPY_ERROR 275
 #define ZSCANINPROGRESS 276
 #define ZABORT_ERROR 277
@@ -239,7 +236,6 @@
 
 #define ZINVALID_KEY 290
 #define ZUNLOCKED_IVAL_TOO_HIGH 294
-#define ZUNLOCKED_OP_HAS_BAD_STATE 295
 #define ZBAD_DIST_KEY 298
 #define ZTRANS_TOO_BIG 261
 #define ZLQH_NO_SUCH_FRAGMENT_ID 1235
@@ -1300,6 +1296,7 @@ class Dbtc : public SimulatedBlock {
      * one transaction at a time.
      */
     Uint32 m_num_queued;
+    Uint32 m_num_queued_outstanding;
     Uint64 m_queuedDatabasePtrI;
     Uint64 m_parallel_transactions_db;
     QueueRecord *m_first_queued_req;
@@ -3114,7 +3111,8 @@ class Dbtc : public SimulatedBlock {
     }
     Uint32 startNewOperation(ApiConnectRecord *regApiPtr,
                              bool is_disk_based,
-                             Uint32 op_type);
+                             Uint32 op_type,
+                             Uint32 instance);
 
     void closeAllowedTransaction() {
       NdbMutex_Lock(theDatabaseConcurrentTransactionMutex);

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
@@ -142,6 +142,8 @@
 //#define DEBUG_RATE_QUEUE_SET 1
 //#define DEBUG_QUOTAS 1
 //#define DEBUG_RATE_QUEUE_DROP 1
+//#define DEBUG_QUOTA_ABORT 1
+//#define DEBUG_TRACK_EXEC_FLAG 1
 //#define DEBUG_SCAN_MANY 1
 #endif
 
@@ -158,6 +160,18 @@
 #define DEBUG(x) ndbout << "DBTC: " << x << endl;
 #else
 #define DEBUG(x)
+#endif
+
+#ifdef DEBUG_TRACK_EXEC_FLAG
+#define DEB_TRACK_EXEC_FLAG(arglist) do { g_eventLogger->info arglist ; } while (0)
+#else
+#define DEB_TRACK_EXEC_FLAG(arglist) do { } while (0)
+#endif
+
+#ifdef DEBUG_QUOTA_ABORT
+#define DEB_QUOTA_ABORT(arglist) do { g_eventLogger->info arglist ; } while (0)
+#else
+#define DEB_QUOTA_ABORT(arglist) do { } while (0)
 #endif
 
 #ifdef DEBUG_RATE_QUEUE_DROP
@@ -774,6 +788,8 @@ void Dbtc::execCONTINUEB(Signal *signal) {
       check_tc_hbrep(signal, apiConnectptr);
       apiConnectptr.p->counter--;
       tcConnectptr.i = Tdata1;
+      DEB_RATE_QUEUE(("(%u) apiPtrI: %u, ZABORT_BREAK, counter = %u",
+        instance(), apiConnectptr.i, apiConnectptr.p->counter));
       abort015Lab(signal, apiConnectptr);
       return;
     }
@@ -2580,11 +2596,6 @@ Dbtc::TCKEY_abort(Signal* signal, int place, ApiConnectRecordPtr const apiConnec
     terrorCode = ZERO_KEYLEN_ERROR;
     releaseAtErrorLab(signal, apiConnectptr);
     return;
-  case 5:
-    jam();
-    terrorCode = ZNO_AI_WITH_UPDATE;
-    releaseAtErrorLab(signal, apiConnectptr);
-    return;
   case 7:
     jam();
     /* Table out of range */
@@ -2603,107 +2614,10 @@ Dbtc::TCKEY_abort(Signal* signal, int place, ApiConnectRecordPtr const apiConnec
       releaseAtErrorLab(signal, apiConnectptr);
       return;
 
-    case 10:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
     case 11:
       jam();
       terrorCode = ZMORE_AI_IN_TCKEYREQ_ERROR;
       releaseAtErrorLab(signal, apiConnectptr);
-      return;
-
-    case 12:
-      jam();
-      terrorCode = ZSIMPLE_READ_WITHOUT_AI;
-      releaseAtErrorLab(signal, apiConnectptr);
-      return;
-
-    case 13:
-      jam();
-      switch (tcConnectptr.p->tcConnectstate) {
-        case OS_WAIT_KEYINFO:
-          jam();
-          printState(signal, 8, apiConnectptr);
-          terrorCode = ZSTATE_ERROR;
-          abortErrorLab(signal, apiConnectptr);
-          return;
-        default:
-          jam();
-          /********************************************************************/
-          /*       MISMATCH BETWEEN STATE ON API CONNECTION AND THIS          */
-          /*       PARTICULAR TC CONNECT RECORD. THIS MUST BE CAUSED BY NDB   */
-          /*       INTERNAL ERROR.                                            */
-          /********************************************************************/
-          systemErrorLab(signal, __LINE__);
-          return;
-      }  // switch
-      return;
-
-    case 15:
-      jam();
-      terrorCode = ZSCAN_NODE_ERROR;
-      releaseAtErrorLab(signal, apiConnectptr);
-      return;
-
-    case 16:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 17:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 20:
-      jam();
-      warningHandlerLab(signal, __LINE__);
-      return;
-
-    case 21:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 22:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 23:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 24:
-      jam();
-      appendToSectionErrorLab(signal, apiConnectptr);
-      return;
-
-    case 25:
-      jam();
-      warningHandlerLab(signal, __LINE__);
-      return;
-
-    case 26:
-      jam();
-      return;
-
-    case 27:
-      systemErrorLab(signal, __LINE__);
-      jam();
-      return;
-
-    case 28:
-      jam();
-      // NOT USED
-      return;
-
-    case 29:
-      jam();
-      systemErrorLab(signal, __LINE__);
       return;
 
     case 30:
@@ -2726,42 +2640,7 @@ Dbtc::TCKEY_abort(Signal* signal, int place, ApiConnectRecordPtr const apiConnec
       systemErrorLab(signal, __LINE__);
       return;
 
-    case 34:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 35:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 36:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
     case 37:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 38:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 39:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 40:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 42:
       jam();
       systemErrorLab(signal, __LINE__);
       return;
@@ -2781,44 +2660,7 @@ Dbtc::TCKEY_abort(Signal* signal, int place, ApiConnectRecordPtr const apiConnec
       systemErrorLab(signal, __LINE__);
       return;
 
-    case 47:
-      jam();
-      terrorCode = apiConnectptr.p->returncode;
-      releaseAtErrorLab(signal, apiConnectptr);
-      return;
-
-    case 48:
-      jam();
-      terrorCode = ZCOMMIT_TYPE_ERROR;
-      releaseAtErrorLab(signal, apiConnectptr);
-      return;
-
     case 49:
-      jam();
-      abortErrorLab(signal, apiConnectptr);
-      return;
-
-    case 50:
-      jam();
-      systemErrorLab(signal, __LINE__);
-      return;
-
-    case 51:
-      jam();
-      abortErrorLab(signal, apiConnectptr);
-      return;
-
-    case 52:
-      jam();
-      abortErrorLab(signal, apiConnectptr);
-      return;
-
-    case 53:
-      jam();
-      abortErrorLab(signal, apiConnectptr);
-      return;
-
-    case 54:
       jam();
       abortErrorLab(signal, apiConnectptr);
       return;
@@ -2889,17 +2731,13 @@ Dbtc::TCKEY_abort(Signal* signal, int place, ApiConnectRecordPtr const apiConnec
       jam();
       initApiConnectRec(signal, apiConnectptr.p, true);
       apiConnectptr.p->m_flags |= ApiConnectRecord::TF_EXEC_FLAG;
+      DEB_TRACK_EXEC_FLAG(("(%u) Set TF_EXEC_FLAG, apiPtrI: %u, line: %u",
+        instance(), apiConnectptr.i, __LINE__));
       goto start_failure;
     }
     case 61: {
       jam();
       terrorCode = ZUNLOCKED_IVAL_TOO_HIGH;
-      abortErrorLab(signal, apiConnectptr);
-      return;
-    }
-    case 62: {
-      jam();
-      terrorCode = ZUNLOCKED_OP_HAS_BAD_STATE;
       abortErrorLab(signal, apiConnectptr);
       return;
     }
@@ -2920,13 +2758,6 @@ Dbtc::TCKEY_abort(Signal* signal, int place, ApiConnectRecordPtr const apiConnec
     case 65: {
       jam();
       terrorCode = ZTRANS_TOO_BIG;
-      abortErrorLab(signal, apiConnectptr);
-      return;
-    }
-    case 66: {
-      jam();
-      /* Function not implemented yet */
-      terrorCode = 4003;
       abortErrorLab(signal, apiConnectptr);
       return;
     }
@@ -3591,7 +3422,6 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
   }
   UintR compare_transid1, compare_transid2;
   const TcKeyReq *const tcKeyReq = (TcKeyReq *)signal->getDataPtr();
-  UintR Treqinfo;
   SectionHandle handle(this, signal);
   jamEntryDebug();
   /*-------------------------------------------------------------------------
@@ -3601,12 +3431,15 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
   const UintR TapiIndex = tcKeyReq->apiConnectPtr;
   const UintR TtabIndex = tcKeyReq->tableId;
   const UintR TtabMaxIndex = ctabrecFilesize;
+  Uint32 Treqinfo = tcKeyReq->requestInfo;
 
+  Uint32 passQueueingFlag = TcKeyReq::getPassQueueingFlag(Treqinfo);
   ttransid_ptr = 6;
   ApiConnectRecordPtr apiConnectptr;
   apiConnectptr.i = TapiIndex;
   if (unlikely(!c_apiConnectRecordPool.getValidPtr(apiConnectptr))) {
     jam();
+    ndbrequire(!passQueueingFlag);
     releaseSections(handle);
     warningHandlerLab(signal, __LINE__);
     return;
@@ -3623,7 +3456,6 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
   }
 #endif
 
-  Treqinfo = tcKeyReq->requestInfo;
   //--------------------------------------------------------------------------
   // Optimised version of ptrAss(tabptr, tableRecord)
   // Optimised version of ptrAss(apiConnectptr, apiConnectRecord)
@@ -3635,6 +3467,8 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
   localTabptr.i = TtabIndex;
   localTabptr.p = &tableRecord[TtabIndex];
   if (unlikely(TtabIndex > TtabMaxIndex)) {
+    jam();
+    ndbrequire(!passQueueingFlag);
     releaseSections(handle);
     warningHandlerLab(signal, __LINE__);
     if (!is_transaction_to_start(regApiPtr, TstartFlag)) {
@@ -3650,7 +3484,6 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
   databaseRecordPtr.i = localTabptr.p->databaseRecord;
   databaseRecordPtr.p = nullptr;
 
-  Uint32 passQueueingFlag = TcKeyReq::getPassQueueingFlag(Treqinfo);
   passQueueingFlag = passQueueingFlag &&
                      handle.m_cnt > 0;
 
@@ -3662,6 +3495,7 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
                                 handle,
                                 Treqinfo,
                                 apiConnectptr)) {
+        jam();
         return;
       }
     }
@@ -3670,12 +3504,17 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
       /**
        * Added original senders block reference at end of signal.
        */
+      ndbrequire(regApiPtr->m_num_queued_outstanding > 0);
+      regApiPtr->m_num_queued_outstanding--;
       ndbrequire(databaseRecordPtr.p->m_outstanding_queries > 0);
       databaseRecordPtr.p->m_outstanding_queries--;
-      DEB_RATE_QUEUE(("(%u):%u, outstanding_queries dec,tk: %u",
+      DEB_RATE_QUEUE(("(%u):%u, outstanding_queries dec,tk: %u,"
+                      " apiPtrI: %u, api: %u",
                       instance(),
                       databaseRecordPtr.p->m_database_id,
-                      databaseRecordPtr.p->m_outstanding_queries));
+                      databaseRecordPtr.p->m_outstanding_queries,
+                      apiConnectptr.i,
+                      regApiPtr->m_num_queued_outstanding));
     } else if (unlikely(regApiPtr->m_first_queued_req != nullptr)) {
       jam();
       handle_queue_tckeyreq(signal,
@@ -3738,8 +3577,7 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
   bool isExecutingTrigger = Tspecial_op_flags & TcConnectRecord::SOF_TRIGGER;
   regApiPtr->m_special_op_flags = 0;  // Reset marker
   Uint32 prevExecFlag = regApiPtr->m_flags & ApiConnectRecord::TF_EXEC_FLAG;
-  if ((!(isExecutingTrigger || isIndexOpReturn)) && prevExecFlag)
-  {
+  if ((!(isExecutingTrigger || isIndexOpReturn)) && prevExecFlag) {
     /**
      * Only operations originating from NDB API with exec flag not
      * set will clear the Execute flag. This is the first signal
@@ -3769,13 +3607,21 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
       jamDebug();
       flags |= TexecFlag;
       flags |= ApiConnectRecord::TF_SINGLE_EXEC_FLAG;
+      DEB_TRACK_EXEC_FLAG(("(%u) TF_EXEC_FLAG = %u, apiPtrI: %u, line: %u",
+        instance(),
+        tc_testbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG),
+        apiConnectptr.i,
+        __LINE__));
     }
     regApiPtr->m_flags = flags;
-  }
-  else
-  {
+  } else {
     jamDebug();
     regApiPtr->m_flags |= TexecFlag;
+    DEB_TRACK_EXEC_FLAG(("(%u) TF_EXEC_FLAG = %u, apiPtrI: %u, line: %u",
+      instance(),
+      tc_testbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG),
+      apiConnectptr.i,
+      __LINE__));
   }
   tc_clearbit(regApiPtr->m_flags, ApiConnectRecord::TF_NOT_OUTSTANDING_FLAG);
   bool tabSingleUserMode = localTabptr.p->singleUserMode;
@@ -3800,6 +3646,11 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
         jam();
         initApiConnectRec(signal, regApiPtr);
         regApiPtr->m_flags |= TexecFlag;
+        DEB_TRACK_EXEC_FLAG(("(%u) TF_EXEC_FLAG = %u, apiPtrI: %u, line: %u",
+          instance(),
+          tc_testbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG),
+          apiConnectptr.i,
+          __LINE__));
       } else {
         jam();
         releaseSections(handle);
@@ -3845,6 +3696,11 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
         }
         initApiConnectRec(signal, regApiPtr);
         regApiPtr->m_flags |= TexecFlag;
+        DEB_TRACK_EXEC_FLAG(("(%u) TF_EXEC_FLAG = %u, apiPtrI: %u, line: %u",
+          instance(),
+          tc_testbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG),
+          apiConnectptr.i,
+          __LINE__));
       } else {
         //----------------------------------------------------------------------
         // Transaction is started already.
@@ -3915,6 +3771,11 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
           jam();
           initApiConnectRec(signal, regApiPtr);
           regApiPtr->m_flags |= TexecFlag;
+          DEB_TRACK_EXEC_FLAG(("(%u) TF_EXEC_FLAG = %u, apiPtrI: %u, line: %u",
+            instance(),
+            tc_testbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG),
+            apiConnectptr.i,
+            __LINE__));
         } else if (TexecFlag) {
           releaseSections(handle);
           TCKEY_abort(signal, 59, apiConnectptr);
@@ -3958,13 +3819,10 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
     case CS_RELEASE:
     {
       releaseSections(handle);
-      if (TstartFlag == 1)
-      {
+      if (TstartFlag == 1) {
         TCKEY_abort(signal, 2, apiConnectptr);
         return;
-      }
-      else if (TexecFlag)
-      {
+      } else if (TexecFlag) {
         TCKEY_abort(signal, 59, apiConnectptr);
         return;
       }
@@ -4284,7 +4142,6 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
     TCKEY_abort(signal, 70, apiConnectptr);
     return;
   }
-  Uint8 TexecuteFlag        = TexecFlag;
   Uint8 Treorg              = TcKeyReq::getReorgFlag(Treqinfo);
   Uint8 batchSafe           = TcKeyReq::getBatchSafeFlag(Treqinfo);
   Uint8 batchUnsafe         = TcKeyReq::getBatchUnsafeFlag(Treqinfo);
@@ -4426,8 +4283,10 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
     if (databaseRecordPtr.p != nullptr &&
         (abort_code = databaseRecordPtr.p->startNewOperation(regApiPtr,
                                                    localTabptr.p->m_disk_based,
-                                                   TOperationType)) != 0) {
-      TCKEY_abort(signal, abort_code, apiConnectptr);
+                                                   TOperationType,
+                                                   instance())) != 0) {
+      terrorCode = abort_code;
+      releaseAtErrorLab(signal, apiConnectptr);
       return;
     }
   } else if (TOperationType == ZREAD || TOperationType == ZREAD_EX) {
@@ -4436,8 +4295,10 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
     if (databaseRecordPtr.p != nullptr &&
         (abort_code = (databaseRecordPtr.p->startNewOperation(regApiPtr,
                        localTabptr.p->m_disk_based,
-                       TOperationType))) != 0) {
-      TCKEY_abort(signal, abort_code, apiConnectptr);
+                       TOperationType,
+                       instance()))) != 0) {
+      terrorCode = abort_code;
+      releaseAtErrorLab(signal, apiConnectptr);
       return;
     }
     c_counters.creadCount++;
@@ -4475,8 +4336,10 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
         (abort_code = databaseRecordPtr.p->startNewOperation(
           regApiPtr,
           localTabptr.p->m_disk_based,
-          TOperationType)) != 0) {
-      TCKEY_abort(signal, abort_code, apiConnectptr);
+          TOperationType,
+          instance())) != 0) {
+      terrorCode = abort_code;
+      releaseAtErrorLab(signal, apiConnectptr);
       return;
     }
     if (!tc_testbit(regApiPtr->m_flags,
@@ -4580,7 +4443,7 @@ void Dbtc::execTCKEYREQ(Signal *signal) {
    * If CommitFlag is set state accordingly and check for early abort
    *------------------------------------------------------------------------*/
   if (TcKeyReq::getCommitFlag(Treqinfo) == 1) {
-    ndbrequire(TexecuteFlag);
+    ndbrequire(TexecFlag);
     regApiPtr->apiConnectstate = CS_REC_COMMITTING;
   } else {
     /* ---------------------------------------------------------------------
@@ -6162,6 +6025,12 @@ void Dbtc::execSIGNAL_DROPPED_REP(Signal *signal) {
               ? ApiConnectRecord::TF_EXEC_FLAG
               : 0;
 
+      DEB_TRACK_EXEC_FLAG(("(%u) TF_EXEC_FLAG = %u, apiPtrI: %u, line: %u",
+        instance(),
+        tc_testbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG),
+        apiConnectptr.i,
+        __LINE__));
+
       DEBUG(" Execute flag set to "
             << tc_testbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG));
 
@@ -6869,6 +6738,8 @@ void Dbtc::sendtckeyconf(Signal *signal, UintR TcommitFlag,
   if (TcommitFlag) {
     jam();
     if (TcommitFlag == 1) {
+      DEB_TRACK_EXEC_FLAG(("(%u) Clear TF_EXEC_FLAG, apiPtrI: %u, line: %u",
+        instance(), apiConnectptr.i, __LINE__));
       tc_clearbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG);
       time_track_complete_transaction(regApiPtr);
     } else {
@@ -7187,6 +7058,7 @@ Dbtc::ApiConnectRecord::ApiConnectRecord()
       accumulatingIndexOp(RNIL),
   executingIndexOp(RNIL),
   m_num_queued(0),
+  m_num_queued_outstanding(0),
   m_queuedDatabasePtrI(RNIL64),
   m_parallel_transactions_db(RNIL64),
   m_first_queued_req(nullptr),
@@ -9088,12 +8960,16 @@ void Dbtc::execLQHKEYREF(Signal *signal) {
 
       if (unlikely(TapiConnectstate == CS_ABORTING || needAbort)) {
         jam();
+        DEB_RATE_QUEUE(("(%u) tcPtrI %u, apiPtrI: %u, do_abort",
+                  instance(), tcConnectptr.i, apiConnectptr.i));
         goto do_abort;
       }
       if (unlikely(TapiConnectstate == CS_RELEASE))
       {
         jam();
 	warningReport(signal, 25, tcConnectptr.i);
+        DEB_RATE_QUEUE(("(%u) tcPtrI %u, apiPtrI: %u, CS_RELEASE",
+                  instance(), tcConnectptr.i, apiConnectptr.i));
         return;
       }
 
@@ -9243,6 +9119,8 @@ void Dbtc::execLQHKEYREF(Signal *signal) {
         /**
          * We're already aborting' so don't send an "extra" TCKEYREF
          */
+        DEB_RATE_QUEUE(("(%u) tcPtrI %u, apiPtrI: %u, CS_ABORTING",
+                  instance(), tcConnectptr.i, apiConnectptr.i));
         jam();
         return;
       }
@@ -9253,6 +9131,8 @@ void Dbtc::execLQHKEYREF(Signal *signal) {
         /**
          * No error is allowed on this operation
          */
+        DEB_RATE_QUEUE(("(%u) tcPtrI %u, apiPtrI: %u, TCKEY_abort(49)",
+                  instance(), tcConnectptr.i, apiConnectptr.i));
         logAbortingOperation(signal, apiConnectptr, tcConnectptr, errCode);
         TCKEY_abort(signal, 49, apiConnectptr);
         return;
@@ -9287,6 +9167,8 @@ void Dbtc::execLQHKEYREF(Signal *signal) {
         jam();
         tcKeyRef->connectPtr = clientData;
         tcKeyRef->errorData = indexId;
+        DEB_QUOTA_ABORT(("(%u) Sending TCKEYREF to 0x%x",
+          instance(), regApiPtr->ndbapiBlockref));
         sendSignal(regApiPtr->ndbapiBlockref, GSN_TCKEYREF, signal,
                    TcKeyRef::SignalLength, JBB);
       }  // if
@@ -9389,6 +9271,8 @@ void Dbtc::execTC_COMMITREQ(Signal *signal) {
 
     tc_clearbit(regApiPtr->m_flags, ApiConnectRecord::TF_NOT_OUTSTANDING_FLAG);
     regApiPtr->m_flags |= ApiConnectRecord::TF_EXEC_FLAG;
+    DEB_TRACK_EXEC_FLAG(("(%u) Set TF_EXEC_FLAG, apiPtrI: %u, line: %u",
+      instance(), apiConnectptr.i, __LINE__));
     regApiPtr->m_simple_read_count = 0;
     regApiPtr->m_exec_count = 0;
     regApiPtr->m_tc_hbrep_timer = ctcTimer;
@@ -9536,6 +9420,8 @@ void Dbtc::execTCROLLBACKREQ(Signal *signal) {
   tc_clearbit(apiConnectptr.p->m_flags,
     ApiConnectRecord::TF_NOT_OUTSTANDING_FLAG);
   apiConnectptr.p->m_flags |= ApiConnectRecord::TF_EXEC_FLAG;
+  DEB_TRACK_EXEC_FLAG(("(%u) Set TF_EXEC_FLAG, apiPtrI: %u, line: %u",
+    instance(), apiConnectptr.i, __LINE__));
   apiConnectptr.p->m_tc_hbrep_timer = ctcTimer;
   switch (apiConnectptr.p->apiConnectstate) {
     case CS_STARTED:
@@ -9933,6 +9819,8 @@ void Dbtc::execABORTED(Signal *signal) {
    *-------------------------------------------------------------------------*/
   if (unlikely(!tcConnectRecord.getValidPtr(tcConnectptr)))
   {
+    DEB_RATE_QUEUE(("(%u) ABORTED from node: %u, tcPtrI: %u not valid",
+      instance(), Tnodeid, tcConnectptr.i));
     warningReport(signal, 2, tcConnectptr.i);
     return;
     /*-----------------------------------------------------------------------*/
@@ -9947,6 +9835,9 @@ void Dbtc::execABORTED(Signal *signal) {
   compare_transid1 = compare_transid1 | compare_transid2;
   if (unlikely(compare_transid1 != 0)) {
     jam();
+    DEB_RATE_QUEUE(("(%u) ABORTED from node: %u, tcPtrI: %u, apiPtrI: %u"
+                    " not valid trans",
+      instance(), Tnodeid, tcConnectptr.i, apiConnectptr.i));
     warningReport(signal, 1, tcConnectptr.i);
     return;
   }
@@ -9960,6 +9851,9 @@ void Dbtc::execABORTED(Signal *signal) {
       apiConnectptr.p->apiConnectstate == CS_WAIT_ABORT_CONF)
   {
     jam();
+    DEB_RATE_QUEUE(("(%u) ABORTED from node: %u, tcPtrI: %u apiPtrI: %u,"
+                    " CS_WAIT_ABORT_CONF",
+      instance(), Tnodeid, tcConnectptr.i, apiConnectptr.i));
     /**
      * Take over abort handling has taken over. Ignore any signals
      * received from the old process that returns ABORTED signals.
@@ -9993,6 +9887,9 @@ void Dbtc::execABORTED(Signal *signal) {
   }
   if (unlikely(Tfound == 0))
   {
+    DEB_RATE_QUEUE(("(%u) ABORTED from node: %u, tcPtrI: %u, apiPtrI: %u,"
+                    " Not found",
+      instance(), Tnodeid, tcConnectptr.i, apiConnectptr.i));
     warningReport(signal, 3, tcConnectptr.i);
     return;
   }
@@ -10003,6 +9900,9 @@ void Dbtc::execABORTED(Signal *signal) {
       /*--------------------------------------------------------------------
        * There are still outstanding ABORTED's to wait for.
        *--------------------------------------------------------------------*/
+      DEB_RATE_QUEUE(("(%u) ABORTED from node: %u, tcPtrI: %u, apiPtrI: %u,"
+                      " Wait for more",
+        instance(), Tnodeid, tcConnectptr.i, apiConnectptr.i));
       jam();
       return;
     }
@@ -10020,6 +9920,9 @@ void Dbtc::execABORTED(Signal *signal) {
      * limit where it is ok to resume sending again.
      */
     jam();
+    DEB_RATE_QUEUE(("(%u) ABORTED from node: %u, tcPtrI: %u, apiPtrI: %u,"
+                    " send_abort_break(2)",
+      instance(), Tnodeid, tcConnectptr.i, apiConnectptr.i));
     send_abort_break(signal,
                      apiConnectptr,
                      apiConnectptr.p->nextTcOperation,
@@ -10036,11 +9939,26 @@ void Dbtc::execABORTED(Signal *signal) {
       apiConnectptr.p->nextTcOperation != RNIL)
   {
     jam();
+    DEB_RATE_QUEUE(("(%u) ABORTED from node: %u, tcPtrI: %u, apiPtrI: %u,"
+                    " counter = %u, nextTcOp = %u",
+      instance(),
+      Tnodeid,
+      tcConnectptr.i,
+      apiConnectptr.i,
+      apiConnectptr.p->counter,
+      apiConnectptr.p->nextTcOperation));
     /*----------------------------------------------------------------------
      *       WE ARE STILL WAITING FOR MORE PARTICIPANTS TO SEND ABORTED.
      *----------------------------------------------------------------------*/
     return;
   }
+  DEB_RATE_QUEUE(("(%u) ABORTED from node: %u, tcPtrI: %u, apiPtrI: %u,"
+                  " counter = %u, call releaseAbortResources",
+    instance(),
+    Tnodeid,
+    tcConnectptr.i,
+    apiConnectptr.i,
+    apiConnectptr.p->counter));
   /*------------------------------------------------------------------------*/
   /*                                                                        */
   /*     WE HAVE NOW COMPLETED THE ABORT PROCESS. WE HAVE RECEIVED ABORTED  */
@@ -10072,17 +9990,23 @@ void Dbtc::abortErrorLab(Signal *signal,
                 transP->abortState != AS_IDLE)))
   {
     jam();
+    DEB_RATE_QUEUE(("(%u) tcPtrI %u, apiPtrI: %u, abortError(1)",
+      instance(), tcConnectptr.i, apiConnectptr.i));
     return;
   }
   if (unlikely(transP->apiConnectstate == CS_RELEASE))
   {
     jam();
+    DEB_RATE_QUEUE(("(%u) tcPtrI %u, apiPtrI: %u, abortError(2)",
+      instance(), tcConnectptr.i, apiConnectptr.i));
     return;
   }
   transP->returnsignal = RS_TCROLLBACKREP;
   if(transP->returncode == 0)
   {
     jam();
+    DEB_RATE_QUEUE(("(%u) tcPtrI %u, apiPtrI: %u, abortError(3), error: %u",
+      instance(), tcConnectptr.i, apiConnectptr.i, terrorCode));
     transP->returncode = terrorCode;
   }
   abort010Lab(signal, apiConnectptr);
@@ -10114,6 +10038,8 @@ void Dbtc::abort010Lab(Signal *signal,
     /*--------------------------------------------------------------------*/
     /* WE HAVE NO PARTICIPANTS IN THE TRANSACTION.                        */
     /*--------------------------------------------------------------------*/
+    DEB_RATE_QUEUE(("(%u) tcPtrI %u, apiPtrI: %u, abortError(4)",
+      instance(), tcConnectptr.i, apiConnectptr.i));
     releaseAbortResources(signal, apiConnectptr);
     return;
   }  // if
@@ -10139,6 +10065,11 @@ ABORT020:
   jam();
   TloopCount++;
   ndbrequire(tcConnectRecord.getValidPtr(tcConnectptr));
+  DEB_RATE_QUEUE(("(%u) tcPtrI %u, apiPtrI: %u, abort015, connectState: %u",
+    instance(),
+    tcConnectptr.i,
+    apiConnectptr.i,
+    tcConnectptr.p->tcConnectstate));
   switch (tcConnectptr.p->tcConnectstate)
   {
   case OS_WAIT_DIH:
@@ -10220,6 +10151,8 @@ ABORT020:
     {
       jam();
       send_abort_break(signal, apiConnectptr, tcConnectptr.i, __LINE__);
+      DEB_RATE_QUEUE(("(%u) apiPtrI: %u, send_abort_break, counter = %u",
+        instance(), apiConnectptr.i, apiConnectptr.p->counter));
       return;
     }
     else
@@ -10231,6 +10164,8 @@ ABORT020:
        * We abort in steps if transaction sizes go beyond 1024 operations.
        */
       apiConnectptr.p->nextTcOperation = tcConnectptr.i;
+      DEB_RATE_QUEUE(("(%u) apiPtrI: %u, wait abort, counter = %u",
+        instance(), apiConnectptr.i, apiConnectptr.p->counter));
     }
   }
 
@@ -10243,6 +10178,8 @@ ABORT020:
     jam();
     apiConnectptr.p->send_abort_done = true;
     setApiConTimer(apiConnectptr, ctcTimer, __LINE__);
+    DEB_RATE_QUEUE(("(%u) apiPtrI: %u, counter = %u",
+      instance(), apiConnectptr.i, apiConnectptr.p->counter));
     return;
   }
   /*-----------------------------------------------------------------------
@@ -10312,7 +10249,7 @@ int Dbtc::releaseAndAbort(Signal *signal, ApiConnectRecord *const regApiPtr) {
         len = Abort::SignalLengthKey;
         abo->instanceKey = instanceKey;
       }
-      DEB_ABORT_TRANS(("(%u)Send ABORT tcRef(%u,%x) transid(%u,%u)"
+      DEB_ABORT_TRANS(("(%u)TC: Send ABORT tcRef(%u,0x%x) transid(0x%x,0x%x)"
                        " to ref: %x",
                        instance(),
                        tcConnectptr.i,
@@ -10328,8 +10265,8 @@ int Dbtc::releaseAndAbort(Signal *signal, ApiConnectRecord *const regApiPtr) {
       prevAlive = true;
     } else {
       jam();
-      DEB_ABORT_TRANS(("(%u)Send ABORTED(dead) tcRef(%u,%x) transid(%u,%u)"
-                       ", node: %u",
+      DEB_ABORT_TRANS(("(%u)TC: Send ABORTED(dead) tcRef(%u,%x)"
+                       " transid(0x%x,0x%x), node: %u",
                        instance(),
                        tcConnectptr.i,
                        reference(),
@@ -15501,6 +15438,7 @@ void Dbtc::execSCAN_TABREQ(Signal *signal) {
   const Uint32 transid2 = scanTabReq->transId2;
   const Uint32 tmpXX = scanTabReq->buddyConPtr;
   const Uint32 buddyPtr = (tmpXX == 0xFFFFFFFF ? RNIL : tmpXX);
+  Uint32 passQueueingFlag = ScanTabReq::getPassQueueingFlag(ri);
   Uint32 currSavePointId = 0;
   ApiConnectRecordPtr transOwnerPtr;
 
@@ -15551,13 +15489,13 @@ void Dbtc::execSCAN_TABREQ(Signal *signal) {
 
   if (unlikely(!c_apiConnectRecordPool.getValidPtr(apiConnectptr))) {
     jam();
+    ndbrequire(!passQueueingFlag);
     releaseSections(handle);
     warningHandlerLab(signal, __LINE__);
     return;
   }  // if
 
   ApiConnectRecord *transP = apiConnectptr.p;
-  Uint32 passQueueingFlag = ScanTabReq::getPassQueueingFlag(ri);
   passQueueingFlag = passQueueingFlag &&
                      (refToMain(sendersBlockRef) == DBTC);
   if (unlikely(passQueueingFlag)) {
@@ -15570,6 +15508,7 @@ void Dbtc::execSCAN_TABREQ(Signal *signal) {
 #endif
 
   if (unlikely(tabptr.i >= ctabrecFilesize)) {
+    ndbrequire(!passQueueingFlag);
     errCode = ZUNKNOWN_TABLE_ERROR;
     goto SCAN_TAB_error;
   }
@@ -15634,7 +15573,7 @@ void Dbtc::execSCAN_TABREQ(Signal *signal) {
     } else {
       jam();
 #ifdef DEBUG_RATE_QUEUE
-    start_flag = false;
+      start_flag = false;
 #endif
     }
   }
@@ -15757,12 +15696,17 @@ void Dbtc::execSCAN_TABREQ(Signal *signal) {
        * Added original senders block reference at end of signal.
        * Commented out since not used hereafter.
        */
+      ndbrequire(transOwnerPtr.p->m_num_queued_outstanding > 0);
+      transOwnerPtr.p->m_num_queued_outstanding--;
       ndbrequire(databaseRecordPtr.p->m_outstanding_queries > 0);
       databaseRecordPtr.p->m_outstanding_queries--;
-      DEB_RATE_QUEUE(("(%u):%u, outstanding_queries dec,st: %u",
+      DEB_RATE_QUEUE(("(%u):%u, outstanding_queries dec,st: %u,"
+                      " apiPtrI: %u, api: %u",
                       instance(),
                       databaseRecordPtr.p->m_database_id,
-                      databaseRecordPtr.p->m_outstanding_queries));
+                      databaseRecordPtr.p->m_outstanding_queries,
+                      transOwnerPtr.i,
+                      transOwnerPtr.p->m_num_queued_outstanding));
     } else if (unlikely(transOwnerPtr.p->m_first_queued_req != nullptr)) {
       /**
        * Transaction is already in queueing mode, have to run the
@@ -15791,10 +15735,10 @@ void Dbtc::execSCAN_TABREQ(Signal *signal) {
                 instance(),
                 databaseRecordPtr.p->m_database_id,
                 passQueueingFlag,
-                databaseRecordPtr.p->m_api_ref_count,
                 databaseRecordPtr.p->m_first_queued_req,
                 databaseRecordPtr.p->m_is_queueing_start,
                 databaseRecordPtr.p->m_is_queueing_all,
+                databaseRecordPtr.p->m_api_ref_count,
                 transOwnerPtr.p->m_first_queued_req,
                 transOwnerPtr.p->tcConnect.isEmpty(),
                 is_transaction_to_start(transOwnerPtr.p, start_flag),
@@ -17439,6 +17383,7 @@ void Dbtc::execSCAN_NEXTREQ(Signal *signal) {
   apiConnectptr.i = req->apiConnectPtr;
   if (unlikely(!c_apiConnectRecordPool.getValidPtr(apiConnectptr))) {
     jam();
+    ndbrequire(!sent_from_queue);
     releaseSections(handle);
     warningHandlerLab(signal, __LINE__);
     return;
@@ -17451,6 +17396,7 @@ void Dbtc::execSCAN_NEXTREQ(Signal *signal) {
   const UintR ctransid2 = apiConnectptr.p->transid[1] ^ transid2;
   if (unlikely((ctransid1 | ctransid2) != 0)) {
     jam();
+    ndbrequire(!sent_from_queue);
     releaseSections(handle);
     ScanTabRef *ref = (ScanTabRef *)&signal->theData[0];
     ref->apiConnectPtr = apiConnectptr.p->ndbapiConnect;
@@ -17481,12 +17427,14 @@ void Dbtc::execSCAN_NEXTREQ(Signal *signal) {
       DEBUG("scanTabRefLab: ZSCANTIME_OUT_ERROR2");
       g_eventLogger->info("apiConnectptr(%d) -> abort ZSCANTIMEOUT_ERROR2", apiConnectptr.i);
       ndbassert(false);  // B2 indication of strange things going on
+      ndbrequire(!sent_from_queue);
       scanTabRefLab(signal, ZSCANTIME_OUT_ERROR2, apiConnectptr.p);
       return;
     }
     DEBUG("scanTabRefLab: ZSTATE_ERROR");
     DEBUG("  apiConnectstate=" << apiConnectptr.p->apiConnectstate);
     g_eventLogger->info("apiConnectptr(%d) -> abort ZSTATE_ERROR", apiConnectptr.i);
+    ndbrequire(!sent_from_queue);
     ndbassert(false);  // B2 indication of strange things going on
     scanTabRefLab(signal, ZSTATE_ERROR, apiConnectptr.p);
     return;
@@ -17503,6 +17451,7 @@ void Dbtc::execSCAN_NEXTREQ(Signal *signal) {
     // How can this happen?
     // Assert to catch if path is tested, remove if hit and analyzed.
     jam();
+    ndbrequire(!sent_from_queue);
     ndbassert(false);
     releaseSections(handle);
     ScanTabRef *ref = (ScanTabRef *)&signal->theData[0];
@@ -17558,12 +17507,17 @@ void Dbtc::execSCAN_NEXTREQ(Signal *signal) {
     DatabaseRecordPtr databaseRecordPtr;
     databaseRecordPtr.i = apiConnectptr.p->m_queuedDatabasePtrI;
     ndbrequire(m_databaseRecordPool.getPtr(databaseRecordPtr));
+    ndbrequire(apiConnectptr.p->m_num_queued_outstanding > 0);
+    apiConnectptr.p->m_num_queued_outstanding--;
     ndbrequire(databaseRecordPtr.p->m_outstanding_queries > 0);
     databaseRecordPtr.p->m_outstanding_queries--;
-    DEB_RATE_QUEUE(("(%u):%u, outstanding_queries dec,sn: %u",
+    DEB_RATE_QUEUE(("(%u):%u, outstanding_queries dec,sn: %u,"
+                    " apiPtrI: %u, api: %u",
                     instance(),
                     databaseRecordPtr.p->m_database_id,
-                    databaseRecordPtr.p->m_outstanding_queries));
+                    databaseRecordPtr.p->m_outstanding_queries,
+                    apiConnectptr.i,
+                    apiConnectptr.p->m_num_queued_outstanding));
   }
 
   ScanRecord *scanP = scanptr.p;
@@ -18877,6 +18831,30 @@ void Dbtc::releaseAbortResources(Signal* signal,
   }
   jamDebug();
 
+  if (apiConnectptr.p->m_num_queued_outstanding > 0) {
+    jam();
+    /**
+     * We are aborting a transaction that still have outstanding
+     * signals in job buffer. Send another CONTINUEB to give those
+     * signals a chance to be handled before we sent the response
+     * to the API. Otherwise those signals could be mixed up with
+     * signals arriving for the next transaction.
+     */
+    DEB_RATE_QUEUE(("(%u) Wait due to m_num_queued_outstanding = %u"
+                    " for apiPtrI: %u",
+      instance(), apiConnectptr.p->m_num_queued_outstanding, apiConnectptr.i));
+
+    setApiConTimer(apiConnectptr, ctcTimer, __LINE__);
+    signal->theData[0] = TcContinueB::ZRELEASE_ABORT_RESOURCES;
+    signal->theData[1] = apiConnectptr.i;
+    sendSignal(reference(),
+               GSN_CONTINUEB,
+               signal,
+               2,
+               JBB);
+    return;
+  }
+
   release_queue_record_tc(signal, apiConnectptr, loop_count);
   if (loop_count > ZMAX_RELEASE_PER_RT_BREAK) {
     jam();
@@ -18909,7 +18887,18 @@ void Dbtc::releaseAbortResources(Signal* signal,
     Uint32 blockRef = apiConnectptr.p->ndbapiBlockref;
     ReturnSignal ret = apiConnectptr.p->returnsignal;
     apiConnectptr.p->returnsignal = RS_NO_RETURN;
+
+    DEB_ABORT_TRANS(("(%u) apiPtrI: %u, returnsignal: %u, flags: 0x%x, "
+                     "apiFailState: %u",
+      instance(),
+      apiConnectptr.i,
+      Uint32(ret),
+      apiConnectptr.p->m_flags,
+      apiConnectptr.p->apiFailState));
     tc_clearbit(apiConnectptr.p->m_flags, ApiConnectRecord::TF_EXEC_FLAG);
+    DEB_TRACK_EXEC_FLAG(("(%u) Clear TF_EXEC_FLAG, apiPtrI: %u, line: %u",
+      instance(), apiConnectptr.i, __LINE__));
+
     switch(ret){
     case RS_TCROLLBACKCONF:
       jam();
@@ -18952,6 +18941,14 @@ void Dbtc::releaseAbortResources(Signal* signal,
       g_eventLogger->info("returnsignal = %d", apiConnectptr.p->returnsignal);
       sendSystemError(signal, __LINE__);
     }  // if
+  } else {
+    DEB_ABORT_TRANS(("(%u) apiPtrI: %u, returnsignal: %u, flags: 0x%x"
+                     ", apiFailState: %u, No ret signal sent",
+      instance(),
+      apiConnectptr.i,
+      apiConnectptr.p->returnsignal,
+      apiConnectptr.p->m_flags,
+      apiConnectptr.p->apiFailState));
   }
   setApiConTimer(apiConnectptr, 0,
                  100000 + apiConnectptr.p->m_apiConTimer_line);
@@ -21341,12 +21338,14 @@ void Dbtc::execTCINDXREQ(Signal *signal) {
   Uint32 tcIndxRequestInfo = tcIndxReq->requestInfo;
   Uint32 startFlag = tcIndxReq->getStartFlag(tcIndxRequestInfo);
   ApiConnectRecordPtr transPtr;
+  Uint32 passQueueingFlag = TcKeyReq::getPassQueueingFlag(tcIndxRequestInfo);
   bool isLongTcIndxReq = (signal->getNoOfSections() != 0);
   SectionHandle handle(this, signal);
 
   transPtr.i = TapiIndex;
   if (unlikely(!c_apiConnectRecordPool.getValidPtr(transPtr))) {
     jam();
+    ndbrequire(!passQueueingFlag);
     warningHandlerLab(signal, __LINE__);
     releaseSections(handle);
     return;
@@ -21354,6 +21353,8 @@ void Dbtc::execTCINDXREQ(Signal *signal) {
   ApiConnectRecord * const regApiPtr = transPtr.p;  
   if (unlikely(regApiPtr->apiConnectstate == CS_RELEASE))
   {
+    jam();
+    ndbrequire(!passQueueingFlag);
     warningHandlerLab(signal, __LINE__);
     releaseSections(handle);
     return;
@@ -21375,6 +21376,7 @@ void Dbtc::execTCINDXREQ(Signal *signal) {
   localTabptr.i = TtabIndex;
   localTabptr.p = &tableRecord[TtabIndex];
   if (unlikely(TtabIndex > TtabMaxIndex)) {
+    ndbrequire(!passQueueingFlag);
     releaseSections(handle);
     warningHandlerLab(signal, __LINE__);
     if (!is_transaction_to_start(regApiPtr, startFlag)) {
@@ -21385,7 +21387,6 @@ void Dbtc::execTCINDXREQ(Signal *signal) {
   databaseRecordPtr.i = localTabptr.p->databaseRecord;
   databaseRecordPtr.p = nullptr;
 
-  Uint32 passQueueingFlag = TcKeyReq::getPassQueueingFlag(tcIndxRequestInfo);
   passQueueingFlag = passQueueingFlag &&
                      handle.m_cnt > 0;
 
@@ -21396,6 +21397,7 @@ void Dbtc::execTCINDXREQ(Signal *signal) {
                               handle,
                               tcIndxRequestInfo,
                               transPtr)) {
+      jam();
       return;
     }
   }
@@ -21404,12 +21406,17 @@ void Dbtc::execTCINDXREQ(Signal *signal) {
     /**
      * Added original senders block reference at end of signal.
      */
+    ndbrequire(transPtr.p->m_num_queued_outstanding > 0);
+    transPtr.p->m_num_queued_outstanding--;
     ndbrequire(databaseRecordPtr.p->m_outstanding_queries > 0);
     databaseRecordPtr.p->m_outstanding_queries--;
-    DEB_RATE_QUEUE(("(%u):%u, outstanding_queries dec,ti: %u",
+    DEB_RATE_QUEUE(("(%u):%u, outstanding_queries dec,ti: %u,"
+                    " apiPtrI: %u, api: %u",
                     instance(),
                     databaseRecordPtr.p->m_database_id,
-                    databaseRecordPtr.p->m_outstanding_queries));
+                    databaseRecordPtr.p->m_outstanding_queries,
+                    transPtr.i,
+                    transPtr.p->m_num_queued_outstanding));
   } else if (unlikely(regApiPtr->m_first_queued_req != nullptr)) {
     jam();
     handle_queue_tckeyreq(signal,
@@ -21455,6 +21462,11 @@ void Dbtc::execTCINDXREQ(Signal *signal) {
     regApiPtr->m_flags |= TcKeyReq::getExecuteFlag(tcIndxRequestInfo)
                               ? ApiConnectRecord::TF_EXEC_FLAG
                               : 0;
+    DEB_TRACK_EXEC_FLAG(("(%u) TF_EXEC_FLAG = %u, apiPtrI: %u, line: %u",
+      instance(),
+      tc_testbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG),
+      transPtr.i,
+      __LINE__));
     abortErrorLab(signal, transPtr);
     return;
   }
@@ -21468,6 +21480,11 @@ void Dbtc::execTCINDXREQ(Signal *signal) {
       regApiPtr->m_flags |= TcKeyReq::getExecuteFlag(tcIndxRequestInfo)
                                 ? ApiConnectRecord::TF_EXEC_FLAG
                                 : 0;
+      DEB_TRACK_EXEC_FLAG(("(%u) TF_EXEC_FLAG = %u, apiPtrI: %u, line: %u",
+        instance(),
+        tc_testbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG),
+        transPtr.i,
+        __LINE__));
       abortErrorLab(signal, transPtr);
       return;
     }
@@ -21481,6 +21498,11 @@ void Dbtc::execTCINDXREQ(Signal *signal) {
     regApiPtr->m_flags |= TcKeyReq::getExecuteFlag(tcIndxRequestInfo)
                               ? ApiConnectRecord::TF_EXEC_FLAG
                               : 0;
+    DEB_TRACK_EXEC_FLAG(("(%u) TF_EXEC_FLAG = %u, apiPtrI: %u, line: %u",
+      instance(),
+      tc_testbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG),
+      transPtr.i,
+      __LINE__));
     abortErrorLab(signal, transPtr);
     return;
   }
@@ -21676,8 +21698,11 @@ int Dbtc::saveINDXKEYINFO(Signal *signal, TcIndexOperation *indexOp,
     c_apiConnectRecordPool.getPtr(apiConnectptr);
     releaseIndexOperation(apiConnectptr.p, indexOp);
     terrorCode = 289;
-    if (TcKeyReq::getExecuteFlag(indexOp->tcIndxReq.requestInfo))
+    if (TcKeyReq::getExecuteFlag(indexOp->tcIndxReq.requestInfo)) {
       apiConnectptr.p->m_flags |= ApiConnectRecord::TF_EXEC_FLAG;
+      DEB_TRACK_EXEC_FLAG(("(%u) Set  TF_EXEC_FLAG, apiPtrI: %u, line: %u",
+        instance(), apiConnectptr.i, __LINE__));
+    }
     abortErrorLab(signal, apiConnectptr);
     return -1;
   }
@@ -21712,8 +21737,11 @@ int Dbtc::saveINDXATTRINFO(Signal *signal, TcIndexOperation *indexOp,
     c_apiConnectRecordPool.getPtr(apiConnectptr);
     releaseIndexOperation(apiConnectptr.p, indexOp);
     terrorCode = 289;
-    if (TcKeyReq::getExecuteFlag(indexOp->tcIndxReq.requestInfo))
+    if (TcKeyReq::getExecuteFlag(indexOp->tcIndxReq.requestInfo)) {
       apiConnectptr.p->m_flags |= ApiConnectRecord::TF_EXEC_FLAG;
+      DEB_TRACK_EXEC_FLAG(("(%u) Set  TF_EXEC_FLAG, apiPtrI: %u, line: %u",
+        instance(), apiConnectptr.i, __LINE__));
+    }
     abortErrorLab(signal, apiConnectptr);
     return -1;
   }
@@ -22238,6 +22266,11 @@ void Dbtc::readIndexTable(Signal *signal, ApiConnectRecordPtr transPtr,
     regApiPtr->m_flags |= TcKeyReq::getExecuteFlag(tcKeyRequestInfo)
                               ? ApiConnectRecord::TF_EXEC_FLAG
                               : 0;
+    DEB_TRACK_EXEC_FLAG(("(%u) TF_EXEC_FLAG = %u, apiPtrI: %u, line: %u",
+      instance(),
+      tc_testbit(regApiPtr->m_flags, ApiConnectRecord::TF_EXEC_FLAG),
+      transPtr.i,
+      __LINE__));
     abortErrorLab(signal, transPtr);
     return;
   }
@@ -25414,7 +25447,9 @@ Dbtc::query_thread_usage(Signal *signal)
 Uint32
 Dbtc::DatabaseRecord::startNewOperation(ApiConnectRecord *regApiPtr,
                                         bool is_disk_based,
-                                        Uint32 op_type) {
+                                        Uint32 op_type,
+                                        Uint32 instance) {
+  (void)instance;
   if (!m_is_quota_committed) {
     return 0;
   }
@@ -25423,6 +25458,12 @@ Dbtc::DatabaseRecord::startNewOperation(ApiConnectRecord *regApiPtr,
        m_max_transaction_size)) {
     return ZTOO_MANY_OPERATIONS_IN_TRANSACTION_ERROR;
   }
+#ifdef DEBUG_QUOTAS
+  if (m_is_memory_quota_exceeded) {
+    DEB_QUOTAS(("(%u) startNewOperation(%u)",
+      instance, op_type));
+  }
+#endif
   if ((m_is_memory_quota_exceeded ||
        (is_disk_based && m_is_disk_quota_exceeded)) &&
       (op_type == ZINSERT || op_type == ZUPDATE || op_type == ZWRITE)) {
@@ -25502,6 +25543,13 @@ void Dbtc::sendQUOTA_OVERLOAD_REP(Signal *signal,
     sendSignal(DBTC_REF, GSN_QUOTA_OVERLOAD_REP, signal,
                QuotaOverloadRep::SignalLength, JBB);
   }
+  DEB_QUOTAS(("(%u) db: %u, Send Change memory quota to %u, disk quota to %u"
+              ", send_tc_flag: %u",
+    instance(),
+    dbPtrP->m_database_id,
+    rep->is_memory_quota_exceeded,
+    rep->is_disk_quota_exceeded,
+    send_tc));
 }
 
 #define RELEASE_QUOTA_EXCEED_LIMIT 105
@@ -25527,6 +25575,9 @@ bool Dbtc::check_quota_exceeded(Signal *signal, DatabaseRecord *dbPtrP) {
     if (memory_percentage <= RELEASE_QUOTA_EXCEED_LIMIT) {
       jam();
       report = true;
+      DEB_QUOTAS_REP(("(%u) Memory Quota no longer exceeded for Db: %u,"
+                      " perc: %llu",
+        instance(), dbPtrP->m_database_id, memory_percentage));
       dbPtrP->m_is_memory_quota_exceeded_reported = false;
     }
   } else {
@@ -25534,6 +25585,8 @@ bool Dbtc::check_quota_exceeded(Signal *signal, DatabaseRecord *dbPtrP) {
       jam();
       report = true;
       dbPtrP->m_is_memory_quota_exceeded_reported = true;
+      DEB_QUOTAS_REP(("(%u) Memory Quota exceeded for Db: %u, perc: %llu",
+        instance(), dbPtrP->m_database_id, memory_percentage));
     }
   }
   if (dbPtrP->m_is_disk_quota_exceeded_reported) {
@@ -25542,12 +25595,18 @@ bool Dbtc::check_quota_exceeded(Signal *signal, DatabaseRecord *dbPtrP) {
       jam();
       report = true;
       dbPtrP->m_is_disk_quota_exceeded_reported = false;
+      DEB_QUOTAS_REP(("(%u) Disk Quota no longer exceeded for Db: %u,"
+                      " perc: %llu",
+        instance(), dbPtrP->m_database_id, disk_percentage));
     }
   } else {
     if (disk_percentage >= SET_QUOTA_EXCEED_LIMIT) {
       jam();
       report = true;
       dbPtrP->m_is_disk_quota_exceeded_reported = true;
+      DEB_QUOTAS_REP(("(%u) Disk Quota exceeded for Db: %u,"
+                      " perc: %llu",
+        instance(), dbPtrP->m_database_id, disk_percentage));
     }
   }
   return report;
@@ -25721,12 +25780,13 @@ Dbtc::send_queued_query(Signal *signal, QueueRecord *queue_record) {
 #if defined(VM_TRACE) || defined(ERROR_INSERT)
     m_tot_send_queued_tckeyreq++;
 #endif
-    DEB_RATE_QUEUE(("(%u) Send Queued %s, tick: %llu, ptr: %p"
+    DEB_RATE_QUEUE(("(%u) Send Queued %s, apiPtrI: %u, tick: %llu, ptr: %p"
               ", sections: %u, sig_len: %u, key_len: %u, ai_len: %u"
               ", queued: %llu, send_queued: %llu, key[%u,%u,%u,%u,%u,%u]",
               instance(),
               queue_record->m_gsn == GSN_TCKEYREQ ?
                 "TCKEYREQ" : "TCINDXREQ",
+              queue_record->apiPtrI,
               queue_record->m_queued_ticks.getUint64(),
               queue_record,
               num_sections,
@@ -25755,10 +25815,11 @@ Dbtc::send_queued_query(Signal *signal, QueueRecord *queue_record) {
 #if defined(VM_TRACE) || defined(ERROR_INSERT)
     m_tot_send_queued_scan_tabreq++;
 #endif
-    DEB_RATE_QUEUE(("(%u) Send Queued SCAN_TABREQ, tick: %llu, ptr: %p"
-              ", num_sections: %u, rec_id_len: %u, ai_len: %u, "
+    DEB_RATE_QUEUE(("(%u) Send Queued SCAN_TABREQ, apiPtrI: %u, tick: %llu,"
+              " ptr: %p, num_sections: %u, rec_id_len: %u, ai_len: %u, "
               "key_len: %u, queued: %llu, send_queued: %llu",
               instance(),
+              queue_record->apiPtrI,
               queue_record->m_queued_ticks.getUint64(),
               queue_record,
               num_sections,
@@ -25856,12 +25917,29 @@ Dbtc::handleBackgroundRateQueues(Signal *signal, Uint32 databaseId) {
     dbPtr.p->m_is_delayed_signal_sent = false;
   }
   if (queue_record != nullptr) {
-    dbPtr.p->m_outstanding_queries++;
-    DEB_RATE_QUEUE(("(%u): %u, outstanding_queries: %u",
-                    instance(),
-                    dbPtr.p->m_database_id,
-                    dbPtr.p->m_outstanding_queries));
-    send_queued_query(signal, queue_record);
+    ApiConnectRecordPtr transPtr;
+    transPtr.i = queue_record->apiPtrI;
+    ndbrequire(c_apiConnectRecordPool.getValidPtr(transPtr));
+    if (transPtr.p->apiConnectstate != CS_RELEASE) {
+      jam();
+      dbPtr.p->m_outstanding_queries++;
+      transPtr.p->m_num_queued_outstanding++;
+
+      DEB_RATE_QUEUE(("(%u): %u, outstanding_queries: %u, apiPtrI: %u, api: %u",
+        instance(),
+        dbPtr.p->m_database_id,
+        dbPtr.p->m_outstanding_queries,
+        transPtr.i,
+        transPtr.p->m_num_queued_outstanding));
+
+      jam();
+      /* No need to send while releaseAbortResources are ongoing */
+      send_queued_query(signal, queue_record);
+    } else {
+      DEB_RATE_QUEUE(("(%u): Skip queued record due to CS_RELEASE state"
+                      ", apiPtrI: %u",
+        instance(), transPtr.i));
+    }
     release_queue_record(queue_record);
     if (!cont) {
       if (dbPtr.p->m_queueing_time_us == 0) {
@@ -26062,12 +26140,12 @@ void Dbtc::set_queueing_environment(Signal *signal,
     } else {
 #ifdef DEBUG_RATE_QUEUE_SET
       NDB_TICKS now = getHighResTimer();
-      NDB_TICKS start = dbPtr.p->m_last_rate_decrement;
+      NDB_TICKS start = dbPtrP->m_last_rate_decrement;
       Uint64 milliSec = NdbTick_Elapsed(start, now).milliSec();
       g_eventLogger->info("(%u:%u), Overload=1, Queueing already, millis: %llu",
                           instance(),
                           dbPtrP->m_database_id,
-                          millliSec);
+                          milliSec);
 #endif
     }
   }
@@ -26725,6 +26803,16 @@ void Dbtc::execQUOTA_OVERLOAD_REP(Signal *signal) {
     jam();
     return;
   }
+#ifdef DEBUG_QUOTAS
+  if (dbPtr.p->m_is_memory_quota_exceeded != rep.is_memory_quota_exceeded ||
+      dbPtr.p->m_is_disk_quota_exceeded != rep.is_disk_quota_exceeded) {
+    DEB_QUOTAS(("(%u) db: %u, Changing memory quota to %u, disk quota to %u",
+      instance(),
+      dbPtr.p->m_database_id,
+      rep.is_memory_quota_exceeded,
+      rep.is_disk_quota_exceeded));
+  }
+#endif
   dbPtr.p->m_is_memory_quota_exceeded = rep.is_memory_quota_exceeded;
   dbPtr.p->m_is_disk_quota_exceeded = rep.is_disk_quota_exceeded;
 }
@@ -26807,11 +26895,15 @@ void Dbtc::db_abort_handling(Signal *signal,
     if (execFlag) {
       jam();
       apiConnectptr.p->m_flags |= ApiConnectRecord::TF_EXEC_FLAG;
+      DEB_TRACK_EXEC_FLAG(("(%u) Set  TF_EXEC_FLAG, apiPtrI: %u, line: %u",
+        instance(), apiConnectptr.i, __LINE__));
     }
   } else {
     if (execFlag) {
       jam();
       apiConnectptr.p->m_flags |= ApiConnectRecord::TF_EXEC_FLAG;
+      DEB_TRACK_EXEC_FLAG(("(%u) Set  TF_EXEC_FLAG, apiPtrI: %u, line: %u",
+        instance(), apiConnectptr.i, __LINE__));
     }
   }
   terrorCode = errorCode;
@@ -26861,12 +26953,13 @@ bool Dbtc::get_next_queue_record(DatabaseRecordPtr dbPtr,
     jam();
     return true;
   }
-  DEB_RATE_QUEUE(("(%u) Send Queued %s: %p after %llu us wait",
+  DEB_RATE_QUEUE(("(%u) Send Queued %s: apiPtrI: %u, %p after %llu us wait",
                   instance(),
                   queue_record->m_gsn == GSN_TCKEYREQ ? "TCKEYREQ" :
                     queue_record->m_gsn == GSN_SCAN_TABREQ ? "SCAN_TABREQ" :
                     queue_record->m_gsn == GSN_SCAN_NEXTREQ ? "SCAN_NEXTREQ" :
                     "Other",
+                  queue_record->apiPtrI,
                   queue_record,
                   elapsed_us));
   ApiConnectRecordPtr transPtr;
@@ -26975,6 +27068,16 @@ void Dbtc::release_queue_record_tc(Signal *signal,
     if (loop_count > ZMAX_RELEASE_PER_RT_BREAK) {
       transPtr.p->m_first_queued_req = queue_record;
       return;
+    }
+    char *signal_area = ((char*)queue_record) + sizeof(QueueRecord);
+    TcKeyReq *const tcKeyReq = (TcKeyReq *)signal_area;
+    Uint32 requestInfo = tcKeyReq->requestInfo;
+    Uint32 TexecFlag = TcKeyReq::getExecuteFlag(requestInfo) ?
+      ApiConnectRecord::TF_EXEC_FLAG : 0;
+    if (TexecFlag) {
+      transPtr.p->m_flags |= ApiConnectRecord::TF_EXEC_FLAG;
+      DEB_TRACK_EXEC_FLAG(("(%u) Set TF_EXEC_FLAG, apiPtrI: %u, line: %u",
+        instance(), transPtr.i, __LINE__));
     }
     ndbrequire(transPtr.p->m_num_queued > 0);
     transPtr.p->m_num_queued--;

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
@@ -6294,8 +6294,8 @@ void MgmtSrvr::backup_quotas(Uint32 nextDatabaseId, NdbOut& out) {
         /* Next send the result data with 9 rows */
         const char *databaseName = (const char*)signal->ptr[0].p;
         out << "DATABASE QUOTA SET " << databaseName;
-        out << " --in-memory-size = " << conf->InMemorySizeMB << "M";
-        out << " --on-disk-size = " << conf->DiskSpaceSizeGB << "G";
+        out << " --in-memory-size = " << conf->InMemorySizeMB;
+        out << " --on-disk-size = " << conf->DiskSpaceSizeGB;
         out << " --rate-per-sec = " << conf->RatePerSec;
         out << " --max-transaction-size = " << conf->MaxTransactionSize;
         out << " --max-parallel-transactions = ";


### PR DESCRIPTION
In CREATE DATABASE QUOTA we should have used the unit MBytes and not bytes. This led to errors in DATABASE QUOTA GET command.

Abort handling concurrent with queueing had some weaknesses. While running the releaseAbortResources (through its CONTINUEB phases) one could send queued signals and this could arrive after transaction was completed and reported back to API. We lost the TF_EXEC_FLAG when releasing queued records at the end of the processing of releaseAbortResources. This led to not sending any response to the API and thus a hanging transaction. Added a check when release those queued records if TF_EXEC_FLAG was set it would be set on transaction to ensure that we send a response to API.

Solution was to track number of outstanding queued requests and ensuring that the number was 0 when starting to release queued records. The normal sending of queued queries will now not send when releaseAbortResources processing have already started (signalled through setting state to CS_RELEASE).

Added loads of debugging statements to track this.

Added ndbrequire's such that we cannot lose signals with passQueueing Flag set. Added a set of jam's to also make debugging in the future easier.

Added tests of quota handling, both positive and negative tests.