### PR TITLE
RONDB-956: Fix of rate limit handling

### DIFF
--- a/mysql-test/suite/ndb_quota/ndb_quota_commands.test
+++ b/mysql-test/suite/ndb_quota/ndb_quota_commands.test
@@ -246,6 +246,25 @@ SELECT * from t2;
 UPDATE t2 SET b = 0 where a = 2;
 COMMIT;
 
+connection default;
+
+let $i_def = 10;
+while ($i_def)
+{
+--error 0,1297
+  SELECT pk1,b1 from t1 limit 10;
+  dec $i_def;
+}
+
+connection mysqld2;
+let $i_2 = 10;
+while ($i_2)
+{
+--error 0,1297
+  SELECT pk1, b1 from t1 limit 10;
+  dec $i_2;
+}
+
 --enable_result_log
 --enable_query_log
 

--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
@@ -15665,9 +15665,13 @@ void Dbtc::execSCAN_TABREQ(Signal *signal) {
           ndbrequire(m_databaseRecordPool.getPtr(databaseRecordPtr));
           if (databaseRecordPtr.p->m_is_queueing_abort_read) {
             jam();
-            DEB_RATE_OVERFLOW(("(%u) db: %llu, apiPtrI: %u",
-              instance(), databaseRecordPtr.i, apiConnectptr.i));
             releaseSections(handle);
+            DEB_RATE_OVERFLOW(("(%u) Rate Overflow db: %llu, apiPtrI: %u"
+                               ", line: %u",
+              instance(),
+              databaseRecordPtr.p->m_database_id,
+              apiConnectptr.i,
+              __LINE__));
             errCode = ZRATE_OVERFLOW_ERROR;
             goto SCAN_TAB_error;
           }
@@ -15701,8 +15705,12 @@ void Dbtc::execSCAN_TABREQ(Signal *signal) {
           if (databaseRecordPtr.p->m_is_queueing_abort_read) {
             jam();
             releaseSections(handle);
-            DEB_RATE_OVERFLOW(("(%u) db: %llu, transOwnerPtrI: %u",
-              instance(), databaseRecordPtr.i, transOwnerPtr.i));
+            DEB_RATE_OVERFLOW(("(%u) Rate Overflow: db: %llu,"
+              " transOwnerPtrI: %u, line: %u",
+              instance(),
+              databaseRecordPtr.p->m_database_id,
+              transOwnerPtr.i,
+              __LINE__));
             errCode = ZRATE_OVERFLOW_ERROR;
             goto SCAN_TAB_error;
           }
@@ -25717,6 +25725,10 @@ Dbtc::execDATABASE_RATE_ORD(Signal *signal) {
       dbPtr.p->m_is_queueing_all = false;
       dbPtr.p->m_queueing_time_us = 0;
     }
+    dbPtr.p->m_is_queueing_abort_read = false;
+    dbPtr.p->m_is_queueing_abort = false;
+    DEB_RATE_QUEUE_SET(("(%u):%u No Aborted actions (0)",
+      instance(), databaseId));
   } else {
     jam();
     dbPtr.p->m_is_queueing_start = true;
@@ -25724,11 +25736,33 @@ Dbtc::execDATABASE_RATE_ORD(Signal *signal) {
     if (delay_us >= 2000) {
       jam();
       dbPtr.p->m_is_queueing_all = true;
-      DEB_RATE_QUEUE_SET(("(%u):%u No Set m_is_queueing_all"
+      DEB_RATE_QUEUE_SET(("(%u):%u Set m_is_queueing_all"
                           ", set m_queueing_time_us: %u",
                           instance(), databaseId, delay_us));
+      if (delay_us >= (MAX_QUEUE_TIME_MS * 1000)) {
+        jam();
+        dbPtr.p->m_is_queueing_abort_read = true;
+        dbPtr.p->m_is_queueing_abort = true;
+        DEB_RATE_QUEUE_SET(("(%u):%u Abort all actions (%u)",
+          instance(), databaseId, delay_us));
+      } else if (delay_us >= (MAX_READ_QUEUE_TIME_MS * 1000)) {
+        jam();
+        dbPtr.p->m_is_queueing_abort_read = true;
+        dbPtr.p->m_is_queueing_abort = false;
+        DEB_RATE_QUEUE_SET(("(%u):%u Abort read actions (%u)",
+          instance(), databaseId, delay_us));
+      } else {
+        jam();
+        dbPtr.p->m_is_queueing_abort_read = false;
+        dbPtr.p->m_is_queueing_abort = false;
+        DEB_RATE_QUEUE_SET(("(%u):%u No Aborted actions (%u)",
+          instance(), databaseId, delay_us));
+      }
     } else {
-      DEB_RATE_QUEUE_SET(("(%u):%u No Set m_is_queueing_start"
+      jam();
+      dbPtr.p->m_is_queueing_abort_read = false;
+      dbPtr.p->m_is_queueing_abort = false;
+      DEB_RATE_QUEUE_SET(("(%u):%u Not Set m_is_queueing_start"
                           ", set m_queueing_time_us = %u",
                           instance(), databaseId, delay_us));
     }
@@ -26136,7 +26170,7 @@ void Dbtc::set_queueing_environment(Signal *signal,
     return;
   }
   Uint32 overload = current_used_rate / rate_per_sec;
-  if (overload > MAX_QUEUE_TIME_MS) {
+  if (overload >= MAX_QUEUE_TIME_MS) {
     jam();
     dbPtrP->m_queueing_time_us = MAX_QUEUE_TIME_MS * 1000;
     dbPtrP->m_is_queueing_abort = true;
@@ -26146,7 +26180,7 @@ void Dbtc::set_queueing_environment(Signal *signal,
                         instance(),
                         dbPtrP->m_database_id,
                         dbPtrP->m_queueing_time_us));
-  } else if (overload > MAX_READ_QUEUE_TIME_MS) {
+  } else if (overload >= MAX_READ_QUEUE_TIME_MS) {
     jam();
     dbPtrP->m_is_queueing_abort_read = true;
     dbPtrP->m_is_queueing_abort = false;
@@ -26161,6 +26195,11 @@ void Dbtc::set_queueing_environment(Signal *signal,
     dbPtrP->m_is_queueing_abort_read = false;
     dbPtrP->m_queueing_time_us =
       (overload * Uint64(1000)) + dbPtrP->m_derivative_delay_us;
+    DEB_RATE_QUEUE_SET(("(%u):%u overload: %u, queueing_time: %u",
+                        instance(),
+                        dbPtrP->m_database_id,
+                        overload,
+                        dbPtrP->m_queueing_time_us));
   }
   if (overload == 0) {
     /**
@@ -27550,6 +27589,12 @@ bool Dbtc::check_tckey_queueing(Signal *signal,
     if (unlikely(databaseRecordPtr.p->m_is_queueing_abort)) {
       jam();
       releaseSections(handle);
+      DEB_RATE_OVERFLOW(("(%u) Rate Overflow: db: %llu, apiConnectptr.i: %u"
+                         ", line: %u",
+        instance(),
+        databaseRecordPtr.p->m_database_id,
+        apiConnectptr.i,
+        __LINE__));
       db_abort_handling(signal,
                         apiConnectptr,
                         TstartFlag,
@@ -27567,6 +27612,12 @@ bool Dbtc::check_tckey_queueing(Signal *signal,
           op_type != ZUNLOCK) {
         jam();
         releaseSections(handle);
+        DEB_RATE_OVERFLOW(("(%u) Rate Overflow: db: %llu, apiConnectptr.i: %u"
+                           ", line: %u",
+          instance(),
+          databaseRecordPtr.p->m_database_id,
+          apiConnectptr.i,
+          __LINE__));
         db_abort_handling(signal,
                           apiConnectptr,
                           TstartFlag,
@@ -27595,6 +27646,12 @@ bool Dbtc::check_tckey_queueing(Signal *signal,
                                    apiConnectptr))) {
         jam();
         releaseSections(handle);
+        DEB_RATE_OVERFLOW(("(%u) Rate Overflow: db: %llu, apiConnectptr.i: %u"
+                           ", line: %u",
+          instance(),
+          databaseRecordPtr.p->m_database_id,
+          apiConnectptr.i,
+          __LINE__));
         db_abort_handling(signal,
                           apiConnectptr,
                           TstartFlag,
@@ -27625,6 +27682,12 @@ void Dbtc::handle_queue_tckeyreq(Signal *signal,
                                apiConnectptr))) {
     jam();
     releaseSections(handle);
+    DEB_RATE_OVERFLOW(("(%u) Rate Overflow: db: %llu, apiConnectptr.i: %u"
+                       ", line: %u",
+      instance(),
+      databaseRecordPtr.p->m_database_id,
+      apiConnectptr.i,
+      __LINE__));
     db_abort_handling(signal,
                       apiConnectptr,
                       TstartFlag,


### PR DESCRIPTION
When overload becomes severe we are supposed to start aborting. This was however only happening on the TC thread "owning" the database quota object. Thus it had to be handled also in execDATABASE_RATE_ORD signal.