### PR TITLE
RONDB-991: The RonDB REST API pk-read endpoint was returning null values for columns defined with NOT NULL constraints.

### DIFF
--- a/mysql-test/suite/rdrs2/disabled.def
+++ b/mysql-test/suite/rdrs2/disabled.def
@@ -12,4 +12,4 @@
 #
 ##############################################################################
 
-rdrs2.rdrs2_encoding : RONDB-792 Every second request returns null for all fields
+

--- a/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.cpp
+++ b/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.cpp
@@ -640,7 +640,8 @@ RS_Status KeyOperation::write_col_to_resp(Uint32 colIdx,
     Uint32 null_bit_in_byte;
     bool null_value = NdbDictionary::getNullBitOffset(
       ndb_record, col_id, null_byte_offset, null_bit_in_byte);
-    if (null_value) {
+    // Only check null bits for columns that are actually nullable
+    if (null_value && col->getNullable()) {
       Uint8 null_byte = row[null_byte_offset];
       Uint8 null_bit_value = (null_byte >> null_bit_in_byte) & 1;
       if (null_bit_value) {

--- a/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.cpp
+++ b/storage/ndb/rest-server2/server/src/db_operations/pk/pkr_operation.cpp
@@ -635,13 +635,13 @@ RS_Status KeyOperation::write_col_to_resp(Uint32 colIdx,
   const char *col_name = col->getName();
   Uint32 col_id = col->getColumnNo();
   Uint8 *row = m_row;
-  {
+  // Only check null bits for columns that are actually nullable
+  if (col->getNullable()) {
     Uint32 null_byte_offset;
     Uint32 null_bit_in_byte;
     bool null_value = NdbDictionary::getNullBitOffset(
       ndb_record, col_id, null_byte_offset, null_bit_in_byte);
-    // Only check null bits for columns that are actually nullable
-    if (null_value && col->getNullable()) {
+    if (null_value) {
       Uint8 null_byte = row[null_byte_offset];
       Uint8 null_bit_value = (null_byte >> null_bit_in_byte) & 1;
       if (null_bit_value) {


### PR DESCRIPTION
  For NOT NULL columns, NDB's default record can have null bit storage
  that overlaps with actual data storage. The code was checking the null bits without
  verifying if the column was actually nullable, causing it to misinterpret data bytes
  as null indicators.  Added a check for col->getNullable()to only check null bits for
  columns that are actually nullable.