### PR TITLE
RONDB-998: Fix problem at shutdown in ConcurrencyLimiterWithQueue

### DIFF
--- a/storage/ndb/rest-server/rest-api-server/internal/middleware/concurrency_limiter.go
+++ b/storage/ndb/rest-server/rest-api-server/internal/middleware/concurrency_limiter.go
@@ -18,6 +18,8 @@
 package middleware
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -33,13 +35,17 @@ func ConcurrencyLimiterWithQueue(maxConcurrent uint32) gin.HandlerFunc {
 	semaphore := make(chan struct{}, maxConcurrent)
 
 	return func(c *gin.Context) {
-		// Acquire slot (blocks if at capacity)
-		semaphore <- struct{}{}
-
-		// Release slot when done
-		defer func() { <-semaphore }()
-
-		// Process request
-		c.Next()
+		// Acquire slot or abort if context is cancelled
+		select {
+		case semaphore <- struct{}{}:
+			// Release slot when done
+			defer func() { <-semaphore }()
+			// Process request
+			c.Next()
+		case <-c.Request.Context().Done():
+			// Context cancelled (client disconnect or server shutdown)
+			c.AbortWithStatus(http.StatusServiceUnavailable)
+			return
+		}
 	}
 }


### PR DESCRIPTION
Fix goroutine deadlock in ConcurrencyLimiterWithQueue middleware

Add context cancellation support to prevent goroutines from blocking indefinitely when waiting to acquire a semaphore slot. Previously, requests would block forever on channel send if all slots were full and the server was shutting down or the client disconnected.

Now uses select to listen for context cancellation, returning 503 Service Unavailable when the request context is done.