### PR TITLE
RONDB-1003: Add support for TIMESTAMP as primary key column in ClusterJ

### DIFF
--- a/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/metadata/AbstractDomainFieldHandlerImpl.java
+++ b/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/metadata/AbstractDomainFieldHandlerImpl.java
@@ -1849,6 +1849,86 @@ public abstract class AbstractDomainFieldHandlerImpl implements DomainFieldHandl
 
     };
 
+    /** Handler for java.sql.Timestamp primary key fields.
+     * Unlike the regular timestamp handler, this one:
+     * - Uses equalLong() for setting PK values (not setLong())
+     * - Properly implements partitionKeySetPart() for partition key support
+     */
+    protected static ObjectOperationHandler objectOperationHandlerKeyJavaSqlTimestamp = new ObjectOperationHandler() {
+
+        public boolean isPrimitive() {
+            return false;
+        }
+
+        public void objectInitializeJavaDefaultValue(AbstractDomainFieldHandlerImpl fmd, ValueHandler handler) {
+        }
+
+        public void operationGetValue(AbstractDomainFieldHandlerImpl fmd, Operation op) {
+            op.getValue(fmd.storeColumn);
+        }
+
+        public Object getDefaultValueFor(AbstractDomainFieldHandlerImpl fmd, String columnDefaultValue) {
+            if (columnDefaultValue == null) {
+                return new Timestamp(new java.util.Date().getTime());
+            } else {
+                return Timestamp.valueOf(columnDefaultValue);
+            }
+        }
+
+        public void operationSetValue(AbstractDomainFieldHandlerImpl fmd, Object value, Operation op) {
+            op.equalLong(fmd.storeColumn, ((Timestamp)value).getTime());
+        }
+
+        public void operationSetValue(AbstractDomainFieldHandlerImpl fmd, ValueHandler handler, Operation op) {
+            if (logger.isDetailEnabled()) {
+                logger.detail("Column " + fmd.columnName + " set to value " + handler.getJavaSqlTimestamp(fmd.fieldNumber));
+            }
+            op.equalLong(fmd.storeColumn, (handler.getJavaSqlTimestamp(fmd.fieldNumber)).getTime());
+        }
+
+        public String handler() {
+            return "key java.sql.Timestamp";
+        }
+
+        public void objectSetValue(AbstractDomainFieldHandlerImpl fmd, ResultData rs, ValueHandler handler) {
+            handler.setJavaSqlTimestamp(fmd.fieldNumber, new Timestamp(rs.getLong(fmd.storeColumn)));
+        }
+
+        public void operationSetBounds(AbstractDomainFieldHandlerImpl fmd, Object value, IndexScanOperation.BoundType type, IndexScanOperation op) {
+            op.setBoundLong(fmd.storeColumn, type, ((Timestamp)value).getTime());
+        }
+
+        public void filterCompareValue(AbstractDomainFieldHandlerImpl fmd, Object value, ScanFilter.BinaryCondition condition, ScanFilter filter) {
+            filter.cmpLong(condition, fmd.storeColumn, ((Timestamp)value).getTime());
+        }
+
+        public void operationEqual(AbstractDomainFieldHandlerImpl fmd, Object value, Operation op) {
+            op.equalLong(fmd.storeColumn, ((Timestamp)value).getTime());
+        }
+
+        public boolean isValidIndexType(AbstractDomainFieldHandlerImpl fmd, boolean hashNotOrdered) {
+            return true;
+        }
+
+        public void partitionKeySetPart(AbstractDomainFieldHandlerImpl fmd,
+                PartitionKey partitionKey, ValueHandler keyValueHandler) {
+            partitionKey.addTimestampKey(fmd.storeColumn, (keyValueHandler.getJavaSqlTimestamp(fmd.fieldNumber)).getTime());
+        }
+
+        public Object getValue(QueryExecutionContext context, String index) {
+            return context.getJavaSqlTimestamp(index);
+        }
+
+        public Object objectGetValue(AbstractDomainFieldHandlerImpl fmd, ValueHandler handler) {
+            return handler.getJavaSqlTimestamp(fmd.fieldNumber);
+        }
+
+        public void objectSetValue(AbstractDomainFieldHandlerImpl fmd, Object value, ValueHandler handler) {
+            handler.setJavaSqlTimestamp(fmd.fieldNumber, (java.sql.Timestamp)value);
+        }
+
+    };
+
     protected static ObjectOperationHandler objectOperationHandlerJavaUtilDate = new ObjectOperationHandler() {
 
         public boolean isPrimitive() {

--- a/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/metadata/DomainFieldHandlerImpl.java
+++ b/storage/ndb/clusterj/clusterj-core/src/main/java/com/mysql/clusterj/core/metadata/DomainFieldHandlerImpl.java
@@ -201,6 +201,8 @@ public class DomainFieldHandlerImpl extends AbstractDomainFieldHandlerImpl {
                 objectOperationHandlerDelegate = objectOperationHandlerKeyByte;
             } else if (type.equals(java.sql.Date.class)) {
                 objectOperationHandlerDelegate = objectOperationHandlerKeyJavaSqlDate;
+            } else if (type.equals(java.sql.Timestamp.class)) {
+                objectOperationHandlerDelegate = objectOperationHandlerKeyJavaSqlTimestamp;
             } else {
                 objectOperationHandlerDelegate = objectOperationHandlerUnsupportedType;
                 error(
@@ -397,6 +399,10 @@ public class DomainFieldHandlerImpl extends AbstractDomainFieldHandlerImpl {
                 case Date:
                     this.objectOperationHandlerDelegate = objectOperationHandlerKeyJavaSqlDate;
                     this.type = java.sql.Date.class;
+                    break;
+                case Timestamp2:
+                    this.objectOperationHandlerDelegate = objectOperationHandlerKeyJavaSqlTimestamp;
+                    this.type = java.sql.Timestamp.class;
                     break;
                 default:
                     error(local.message("ERR_Primary_Column_Type", domainTypeHandler.getName(), name, this.storeColumnType));

--- a/storage/ndb/clusterj/clusterj-core/src/main/resources/com/mysql/clusterj/core/Bundle.properties
+++ b/storage/ndb/clusterj/clusterj-core/src/main/resources/com/mysql/clusterj/core/Bundle.properties
@@ -114,7 +114,7 @@ if they have the same type in each place. The parameter {0} has different types 
 ERR_Get_Ndb_Index:Error getting NdbIndex for table: {0}, index: {1}.
 ERR_No_Object_Found:No object found from class {0} with key {1}.
 ERR_Invalid_Index_For_Type:For class {0}, field {1}, column {2}, index {3}, type {4}: \
-hash indexes on float and double; and indexes on lob types are not supported.
+hash indexes on float and double; and indexes on blob types are not supported.
 ERR_Field_Not_Valid:The field {1} in class {0} cannot be persistent:\n
 ERR_Key_Must_Be_An_Object_Array:Key must be an Object[] with {0} dimensions.
 ERR_Key_Must_Not_Be_Null:Key must not be null, class {0} field {1}.

--- a/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/TimestampPKTest.java
+++ b/storage/ndb/clusterj/clusterj-test/src/main/java/testsuite/clusterj/TimestampPKTest.java
@@ -1,0 +1,218 @@
+/*
+   Copyright (c) 2026 Hopsworks and/or its affiliates.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
+
+   This program is designed to work with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have either included with
+   the program or referenced in the documentation.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+package testsuite.clusterj;
+
+import com.mysql.clusterj.Constants;
+import com.mysql.clusterj.DynamicObject;
+import com.mysql.clusterj.Session;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Properties;
+
+public class TimestampPKTest extends AbstractClusterJModelTest {
+
+  private static final int NUMBER_TO_INSERT = 128;
+  private static String defaultDB;
+
+  boolean useCache = false;
+
+  public static class TimestampPK extends DynamicObject {
+    @Override
+    public String table() {
+      return "timestamppk";
+    }
+  }
+
+  public static class TimestampPK3 extends DynamicObject {
+    @Override
+    public String table() {
+      return "timestamppk3";
+    }
+  }
+
+  public static class TimestampPK6 extends DynamicObject {
+    @Override
+    public String table() {
+      return "timestamppk6";
+    }
+  }
+
+  @Override
+  protected Properties modifyProperties() {
+    props.put(Constants.PROPERTY_CLUSTER_MAX_CACHED_SESSIONS, 10);
+    return props;
+  }
+
+  @Override
+  public void localSetUp() {
+    createSessionFactory();
+    defaultDB = props.getProperty(Constants.PROPERTY_CLUSTER_DATABASE);
+  }
+
+  public void cleanUp() {
+    cleanUpInt("test3", TimestampPK.class);
+    cleanUpInt("test3", TimestampPK3.class);
+    cleanUpInt("test3", TimestampPK6.class);
+  }
+
+  public void cleanUpInt(String db, Class c) {
+    Session s = getSession(db);
+    s.deletePersistentAll(c);
+    returnSession(s);
+  }
+
+  public void testSimple() {
+    useCache = false;
+    cleanUp();
+    runTest("test3", TimestampPK.class);
+    runTest("test3", TimestampPK3.class);
+    runTest("test3", TimestampPK6.class);
+  }
+
+//  public void testSimpleWithCache() {
+//    useCache = true;
+//    cleanUp();
+//    runTest("test3", TimestampPK.class);
+//  }
+
+  public void runTest(String db, Class cls) {
+    // Insert rows
+    for (int i = 0; i < NUMBER_TO_INSERT; i++) {
+      Session s = getSession(db);
+      DynamicObject e = (DynamicObject) s.newInstance(cls);
+      setFields(this, e, i);
+      s.savePersistent(e);
+      closeDTO(s, e, cls);
+      returnSession(s);
+    }
+
+    // now verify data
+    Session s = getSession(db);
+    s.currentTransaction().begin();
+    ArrayList<DynamicObject> list = new ArrayList<DynamicObject>(NUMBER_TO_INSERT);
+    for (int i = 0; i < NUMBER_TO_INSERT; i++) {
+      // Use timestamp as the primary key
+      Timestamp key = getTimestampKey(i);
+      DynamicObject e = (DynamicObject) s.newInstance(cls, key);
+      list.add(e);
+      s.load(e);
+    }
+    s.flush();
+
+    for (int i = 0; i < NUMBER_TO_INSERT; i++) {
+      verifyFields(this, list.get(i), i);
+      closeDTO(s, list.get(i), cls);
+    }
+    list.clear();
+    s.currentTransaction().commit();
+    returnSession(s);
+
+    // now delete data
+    for (int i = 0; i < NUMBER_TO_INSERT; i++) {
+      s = getSession(db);
+      Timestamp key = getTimestampKey(i);
+      DynamicObject e = (DynamicObject) s.find(cls, key);
+      if (e != null) {
+        s.deletePersistent(e);
+        closeDTO(s, e, cls);
+      } else {
+        error("Failed to find row with key: " + key);
+      }
+      returnSession(s);
+    }
+
+    failOnError();
+  }
+
+  /** Create a timestamp key for the given index */
+  private Timestamp getTimestampKey(int num) {
+    long baseTime = Timestamp.valueOf("2024-01-01 00:00:00").getTime();
+    return new Timestamp(baseTime + (num * 1000L)); // add num seconds
+  }
+
+  /** Verify the fields of a loaded object */
+  private void verifyFields(AbstractClusterJModelTest test, DynamicObject e, int num) {
+    for (int i = 0; i < e.columnMetadata().length; i++) {
+      String fieldName = e.columnMetadata()[i].name();
+      if (fieldName.equals("id")) {
+        Timestamp expected = getTimestampKey(num);
+        Timestamp actual = (Timestamp) e.get(i);
+        if (actual == null || actual.getTime() != expected.getTime()) {
+          test.error("Mismatch for id: expected " + expected + " but got " + actual);
+        }
+      } else if (fieldName.equals("data")) {
+        Integer expected = num;
+        Integer actual = (Integer) e.get(i);
+        if (!expected.equals(actual)) {
+          test.error("Mismatch for data: expected " + expected + " but got " + actual);
+        }
+      } else {
+        test.error("Unexpected Column: " + fieldName);
+      }
+    }
+  }
+
+  private boolean setFields(AbstractClusterJModelTest test, DynamicObject e,
+                                          int num) {
+    for (int i = 0; i < e.columnMetadata().length; i++) {
+      String fieldName = e.columnMetadata()[i].name();
+      if (fieldName.equals("id")) {
+        e.set(i, getTimestampKey(num));
+      } else if (fieldName.equals("data")) {
+        e.set(i, num);
+      } else {
+        test.error("Unexpected Column");
+        return false;
+      }
+    }
+    return true;
+  }
+
+  Session getSession(String db) {
+    if (db == null) {
+      return sessionFactory.getSession();
+    } else {
+      return sessionFactory.getSession(db);
+    }
+  }
+
+  void returnSession(Session s) {
+    if (useCache) {
+      s.closeCache();
+    } else {
+      s.close();
+    }
+  }
+
+  void closeDTO(Session s, DynamicObject dto, Class dtoClass) {
+    if (useCache) {
+      s.releaseCache(dto, dtoClass);
+    } else {
+      s.release(dto);
+    }
+  }
+}

--- a/storage/ndb/clusterj/clusterj-test/src/main/resources/schema.sql
+++ b/storage/ndb/clusterj/clusterj-test/src/main/resources/schema.sql
@@ -1123,4 +1123,22 @@ create table same_table (
   primary key(id)
 ) ENGINE=ndbcluster;
 
+drop table if exists timestamppk;
+CREATE TABLE timestamppk (
+    id TIMESTAMP PRIMARY KEY,
+    data INT
+) ENGINE=ndbcluster;
+
+drop table if exists timestamppk3;
+CREATE TABLE timestamppk3 (
+    id TIMESTAMP(3) PRIMARY KEY,
+    data INT
+) ENGINE=ndbcluster;
+
+drop table if exists timestamppk6;
+CREATE TABLE timestamppk6 (
+    id TIMESTAMP(6) PRIMARY KEY,
+    data INT
+) ENGINE=ndbcluster;
+
 use test;

--- a/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/PartitionKeyImpl.java
+++ b/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/PartitionKeyImpl.java
@@ -156,6 +156,31 @@ class PartitionKeyImpl implements PartitionKey {
         });
     }
 
+    /** Add a timestamp key to the partition key.
+     * Uses the actual storage size (4-7 bytes for TIMESTAMP2 based on precision).
+     * The partition key will actually be constructed when needed, at enlist time.
+     */
+    public void addTimestampKey(final Column storeColumn, final long key) {
+        // Calculate actual storage size from precision (not getSize() which may be aligned to 8)
+        final int columnSize = Utility.getTimestamp2StorageSize(storeColumn.getPrecision());
+        keyPartBuilders.add(new KeyPartBuilderImpl(columnSize) {
+            public void addKeyPart(BufferManager bufferManager) {
+                this.bufferManager = bufferManager;
+                buffer = bufferManager.borrowPartitionKeyPartBuffer(length);
+                if (buffer.capacity() < length || buffer.position() != 0 || buffer.position() + length < buffer.limit()) {
+                    System.out.println("PartitionKeyImpl.addTimestampKey.addKeyPart() got buffer for length: " + length +
+                        " buffer: " + buffer.capacity() + " " + buffer.position() + " " + buffer.limit());
+                }
+                Utility.convertValueForTimestampKey(buffer, storeColumn, key);
+                KeyPart keyPart = new KeyPart(buffer, buffer.limit());
+                keyParts.add(keyPart);
+            }
+            public void release() {
+//                System.out.println("PartitionKeyImpl.addTimestampKey.release() " + length);
+            }
+        });
+    }
+
     /** Add a String key to the partition key.
      * The partition key will actually be constructed when needed, at enlist time.
      * This is done so that the buffer manager can be used to efficiently create

--- a/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/Utility.java
+++ b/storage/ndb/clusterj/clusterj-tie/src/main/java/com/mysql/clusterj/tie/Utility.java
@@ -1650,6 +1650,58 @@ public class Utility {
         endianManager.convertValue(buffer, storeColumn, value);
     }
 
+    /** Get the actual storage size for TIMESTAMP2 based on precision.
+     * TIMESTAMP2 storage: 4 bytes for seconds + fractional bytes based on precision
+     *   - precision 0: 0 extra bytes (total 4)
+     *   - precision 1-2: 1 extra byte (total 5)
+     *   - precision 3-4: 2 extra bytes (total 6)
+     *   - precision 5-6: 3 extra bytes (total 7)
+     * @param precision the fractional seconds precision (0-6)
+     * @return the storage size in bytes (4-7)
+     */
+    public static int getTimestamp2StorageSize(int precision) {
+        if (precision == 0) return 4;
+        if (precision <= 2) return 5;
+        if (precision <= 4) return 6;
+        return 7;
+    }
+
+    /** Convert a timestamp value for use as a partition key.
+     * This method writes only the correct number of bytes based on precision,
+     * which is important for TIMESTAMP/TIMESTAMP2 partition keys.
+     *
+     * TIMESTAMP2 storage format (big-endian):
+     * - 4 bytes for seconds since epoch
+     * - 0-3 additional bytes for fractional seconds based on precision
+     *
+     * @param buffer the ByteBuffer to write to
+     * @param storeColumn the column definition
+     * @param millis the timestamp value in milliseconds since epoch
+     */
+    public static void convertValueForTimestampKey(ByteBuffer buffer, Column storeColumn, long millis) {
+        int precision = storeColumn.getPrecision();
+        int actualSize = getTimestamp2StorageSize(precision);
+
+        // Use packTimestamp2 to get the properly formatted value
+        // packTimestamp2 returns: (seconds << 32) + (packedFraction << 8)
+        // So bytes 0-3 are seconds, bytes 4-6 are fractional, byte 7 is unused
+        long packed = packTimestamp2(precision, millis);
+
+        buffer.order(ByteOrder.BIG_ENDIAN);
+
+        // Write only the bytes needed based on precision
+        // For size 4: write bytes 0-3 (seconds only)
+        // For size 5: write bytes 0-4 (seconds + 1 fractional byte)
+        // etc.
+        for (int i = 0; i < actualSize; i++) {
+            // Extract byte i from the packed value (big-endian, so byte 0 is the highest)
+            int shift = (7 - i) * 8;
+            buffer.put((byte) ((packed >> shift) & 0xFF));
+        }
+
+        buffer.flip();
+    }
+
     /** Encode a String as a ByteBuffer that can be passed to ndbjtie.
      * Put the length information in the beginning of the buffer.
      * Pad fixed length strings with blanks.

--- a/storage/ndb/clusterj/clusterj-tie/src/test/java/testsuite/clusterj/tie/TimestampPKTest.java
+++ b/storage/ndb/clusterj/clusterj-tie/src/test/java/testsuite/clusterj/tie/TimestampPKTest.java
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2010, 2025, Oracle and/or its affiliates.
+   Copyright (c) 2026 Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -23,33 +23,8 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 */
 
-package com.mysql.clusterj.core.store;
+package testsuite.clusterj.tie;
 
-
-/** This interface represents a partition key. A partition key
- * consists of a table and values that make up the partition key.
- * An instance of this interface can be used to specify the
- * partition key used when starting a transaction.
- */
-public interface PartitionKey {
-
-    public void addIntKey(Column storeColumn, int key);
-
-    public void addLongKey(Column storeColumn, long key);
-
-    public void addStringKey(Column storeColumn, String string);
-
-    public void addBytesKey(Column storeColumn, byte[] bytes);
-
-    public void addShortKey(Column storeColumn, short key);
-
-    public void addByteKey(Column storeColumn, byte key);
-
-    /** Add a timestamp key to the partition key.
-     * Uses the column's actual size (4-7 bytes for TIMESTAMP2 based on precision).
-     * @param storeColumn the column metadata
-     * @param key the timestamp value in milliseconds since epoch
-     */
-    public void addTimestampKey(Column storeColumn, long key);
+public class TimestampPKTest extends testsuite.clusterj.TimestampPKTest {
 
 }


### PR DESCRIPTION
ClusterJ previously did not support TIMESTAMP columns as primary keys, even though the native NDB API supports this. This change adds full support for TIMESTAMP/TIMESTAMP2 primary key columns.