### PR TITLE
Add MTR test for index_scan Go package (disabled)

### DIFF
--- a/mysql-test/suite/rdrs2-golang/disabled.def
+++ b/mysql-test/suite/rdrs2-golang/disabled.def
@@ -11,5 +11,6 @@
 #   - Length of a comment section must not be more than 80 characters.
 #
 ##############################################################################
-rdrs2-golang.rdrs2-golang_stat   : RONDB-718 Not implemented yet
+rdrs2-golang.rdrs2-golang_index_scan : WL#12345678 Not ready yet
+rdrs2-golang.rdrs2-golang_stat       : RONDB-718 Not implemented yet
 

--- a/mysql-test/suite/rdrs2-golang/include/run_gotest.inc
+++ b/mysql-test/suite/rdrs2-golang/include/run_gotest.inc
@@ -37,6 +37,7 @@ my %mtr_to_go = (
   'rdrs2-golang_config.test'            => 'hopsworks.ai/rdrs2/internal/config',                             #
   'rdrs2-golang_feature_store.test'     => 'hopsworks.ai/rdrs2/internal/feature_store',                      #
   'rdrs2-golang_health.test'            => 'hopsworks.ai/rdrs2/internal/integrationtests/health',            #
+  'rdrs2-golang_index_scan.test'        => 'hopsworks.ai/rdrs2/internal/integrationtests/index_scan',        #
   'rdrs2-golang_int_feature_store.test' => 'hopsworks.ai/rdrs2/internal/integrationtests/feature_store',     #
   'rdrs2-golang_integrationtests.test'  => 'hopsworks.ai/rdrs2/internal/integrationtests',                   #
   'rdrs2-golang_log.test'               => 'hopsworks.ai/rdrs2/internal/log',                                #

--- a/mysql-test/suite/rdrs2-golang/t/rdrs2-golang_index_scan.test
+++ b/mysql-test/suite/rdrs2-golang/t/rdrs2-golang_index_scan.test
@@ -1,0 +1,1 @@
+--source suite/rdrs2-golang/include/run_gotest.inc


### PR DESCRIPTION
Add the missing MTR test file and mapping for the new index_scan integration test package to fix the test list mismatch. Test is disabled until ready.