### PR TITLE
RDRS: Enable index_scan in MTR and fix potential shutdown hang

### DIFF
--- a/mysql-test/suite/rdrs2-golang/disabled.def
+++ b/mysql-test/suite/rdrs2-golang/disabled.def
@@ -11,6 +11,5 @@
 #   - Length of a comment section must not be more than 80 characters.
 #
 ##############################################################################
-rdrs2-golang.rdrs2-golang_index_scan : WL#12345678 Not ready yet
 rdrs2-golang.rdrs2-golang_stat       : RONDB-718 Not implemented yet
 

--- a/mysql-test/suite/rdrs2-golang/r/rdrs2-golang_index_scan.result
+++ b/mysql-test/suite/rdrs2-golang/r/rdrs2-golang_index_scan.result
@@ -1,0 +1,8 @@
+## Run rdrs2-golang_index_scan.test without TLS
+ok  	hopsworks.ai/rdrs2/internal/integrationtests/index_scan
+
+Golang test for hopsworks.ai/rdrs2/internal/integrationtests/index_scan exited with code 0
+## Run rdrs2-golang_index_scan.test with TLS and server-side cert
+ok  	hopsworks.ai/rdrs2/internal/integrationtests/index_scan
+
+Golang test for hopsworks.ai/rdrs2/internal/integrationtests/index_scan exited with code 0

--- a/storage/ndb/rest-server2/server/src/ttl_purge.cpp
+++ b/storage/ndb/rest-server2/server/src/ttl_purge.cpp
@@ -703,6 +703,9 @@ trx_err:
                 if (trx_failure_times > 10) {
                   goto err;
                 } else {
+                  if (exit_) {
+                    goto err;
+                  }
                   sleep(1);
                 }
               }
@@ -1129,6 +1132,9 @@ void TTLPurger::PurgeWorkerJob() {
     }
     if (shard == kShardNotPurger) {
       g_eventLogger->info("Not the configured purging node, skip purging...");
+      if (purge_worker_exit_) {
+        break;
+      }
       sleep(2);
       continue;
     }
@@ -1151,6 +1157,9 @@ void TTLPurger::PurgeWorkerJob() {
       // No TTL table is found
       UpdateStatus(TTLPurgeStatus::State::kPaused);
       UpdateCurrentTable("", 0);
+      if (purge_worker_exit_) {
+        break;
+      }
       sleep(2);
       continue;
     }
@@ -1746,6 +1755,9 @@ err:
         trans = nullptr;
       }
       trx_failure_times++;
+      if (purge_worker_exit_) {
+        break;
+      }
       sleep(1);
       if (trx_failure_times > kMaxTrxRetryTimes) {
         g_eventLogger->warning("[TTL PWorker] Has retried for %d times..."

--- a/storage/ndb/rest-server2/server/test_go/internal/integrationtests/index_scan/index_scan_test.go
+++ b/storage/ndb/rest-server2/server/test_go/internal/integrationtests/index_scan/index_scan_test.go
@@ -18,8 +18,11 @@
 package index_scan
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
+	"io"
 	"math"
 	"net/http"
 	"sync/atomic"
@@ -27,6 +30,7 @@ import (
 	"time"
 
 	"hopsworks.ai/rdrs2/internal/common"
+	"hopsworks.ai/rdrs2/internal/config"
 	"hopsworks.ai/rdrs2/internal/integrationtests/testclient"
 	"hopsworks.ai/rdrs2/internal/testutils"
 	"hopsworks.ai/rdrs2/pkg/api"
@@ -552,6 +556,11 @@ func Test_SchemaVersionChangeNonConcurrent(t *testing.T) {
 
 // Test_SchemaVersionChangeConcurrent runs scan operations concurrently while schema is being changed.
 // This tests the REST server's ability to handle schema version mismatch errors (error 241).
+// During schema change (DROP + CREATE TABLE), requests may transiently fail with 400 errors
+// because the table temporarily doesn't exist. The test verifies that:
+// 1. Operations succeed before schema change
+// 2. Operations eventually succeed after schema change
+// 3. Transient failures during schema change don't break the server
 func Test_SchemaVersionChangeConcurrent(t *testing.T) {
 	// Reset database at start
 	err := testutils.RunQueriesOnDataCluster(testdbs.DB025Scheme)
@@ -583,21 +592,71 @@ func Test_SchemaVersionChangeConcurrent(t *testing.T) {
 	numWorkers := 1
 	var stop atomic.Bool
 	stop.Store(false)
-	done := make(chan int, numWorkers)
+
+	type workerStats struct {
+		successes int
+		failures  int
+	}
+	done := make(chan workerStats, numWorkers)
+
+	// Create HTTP client for direct requests (to avoid t.Fatalf on transient errors)
+	httpClient := testutils.SetupHttpClient(t)
+	url := NewIndexScanURL(database, table)
 
 	for i := 0; i < numWorkers; i++ {
 		go func(workerID int) {
-			count := 0
+			stats := workerStats{}
 			defer func() {
-				done <- count
+				done <- stats
 			}()
 			for !stop.Load() {
-				restRows, _, _, _ := ExecuteUsingRESTServer(t, database, table, &query, EMPTY_STRING, http.StatusOK)
-				if len(restRows) != 1 {
-					stop.Store(true)
-					t.Errorf("worker %d: wrong data read. Expecting one row to read. Got: %d rows", workerID, len(restRows))
+				// Make direct HTTP request to tolerate transient errors during schema change
+				jsonBytes, err := json.Marshal(query)
+				if err != nil {
+					t.Errorf("worker %d: failed to marshal query: %v", workerID, err)
+					return
 				}
-				count++
+
+				req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(jsonBytes))
+				if err != nil {
+					t.Errorf("worker %d: failed to create request: %v", workerID, err)
+					return
+				}
+				req.Header.Set("Content-Type", "application/json")
+				// Set API key header if required by configuration
+				conf := config.GetAll()
+				if conf.Security.APIKey.UseHopsworksAPIKeys {
+					req.Header.Set(config.API_KEY_NAME, testutils.HOPSWORKS_TEST_API_KEY)
+				}
+
+				resp, err := httpClient.Do(req)
+				if err != nil {
+					// Network error - count as failure but continue
+					stats.failures++
+					continue
+				}
+
+				respBody, _ := io.ReadAll(resp.Body)
+				resp.Body.Close()
+
+				if resp.StatusCode == http.StatusOK {
+					// Parse response to verify row count
+					var scanResp api.IndexScanResponse
+					if err := json.Unmarshal(respBody, &scanResp); err != nil {
+						t.Errorf("worker %d: failed to unmarshal response: %v", workerID, err)
+						stats.failures++
+						continue
+					}
+					if len(scanResp.Data) != 1 {
+						t.Errorf("worker %d: wrong data read. Expecting 1 row, got: %d rows", workerID, len(scanResp.Data))
+						stats.failures++
+						continue
+					}
+					stats.successes++
+				} else {
+					// Non-200 response (expected during schema change window)
+					stats.failures++
+				}
 			}
 		}(i)
 	}
@@ -620,12 +679,20 @@ func Test_SchemaVersionChangeConcurrent(t *testing.T) {
 	// Stop workers
 	stop.Store(true)
 
-	// Wait for all workers and count total operations
-	totalOps := 0
+	// Wait for all workers and collect stats
+	totalSuccesses := 0
+	totalFailures := 0
 	for i := 0; i < numWorkers; i++ {
-		totalOps += <-done
+		stats := <-done
+		totalSuccesses += stats.successes
+		totalFailures += stats.failures
 	}
-	t.Logf("Total operations completed: %d", totalOps)
+	t.Logf("Total operations: successes=%d, failures=%d", totalSuccesses, totalFailures)
+
+	// Verify we had some successful operations (test was actually running)
+	if totalSuccesses == 0 {
+		t.Fatalf("No successful operations - test may not have been working correctly")
+	}
 
 	// Verify final state - requests should work after schema change
 	mysqlRows, mysqlCols, err := ExecuteUsingMySQLServer(t, database, table, &query, DATA_DOES_NOT_NEED_BINARY_ENCODING)


### PR DESCRIPTION
  index_scan test: Improve Test_SchemaVersionChangeConcurrent to
  tolerate transient errors during schema changes and track
  success/failure stats separately. Enable test in MTR.

  TTL purge: Add exit flag checks before sleep() calls.