### PR TITLE
RONDB-TTL: Fix AlterTabOperation pool leak for TTL-only ALTER TABLE

### DIFF
--- a/storage/ndb/src/kernel/blocks/dbtup/DbtupMeta.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtup/DbtupMeta.cpp
@@ -1543,6 +1543,19 @@ void Dbtup::handleAlterTableCommit(Signal *signal, const AlterTabReq *req,
                                  regAlterTabOpPtr.p->dynTabDesOffset[DD],
                                  DD);
 
+    /* Apply TTL changes before releasing, for combined AddAttr+TTL ALTER. */
+    if (AlterTableReq::getTTLSecFlag(req->changeMask) ||
+        AlterTableReq::getTTLColFlag(req->changeMask)) {
+      jam();
+      regTabPtr->m_ttl_sec = regAlterTabOpPtr.p->ttlSec;
+      regTabPtr->m_ttl_col_no = regAlterTabOpPtr.p->ttlColumnNo;
+      g_eventLogger->info("[DBTUP], execALTER_TAB_REQ, update TTL on table "
+                           "%u, [%u, %u]",
+                           req->tableId,
+                           regTabPtr->m_ttl_sec,
+                           regTabPtr->m_ttl_col_no);
+    }
+
     releaseAlterTabOpRec(regAlterTabOpPtr);
 
     /* Recompute aggregate table meta data. */
@@ -1592,8 +1605,10 @@ void Dbtup::handleAlterTableCommit(Signal *signal, const AlterTabReq *req,
     }
   }
 
-  if (AlterTableReq::getTTLSecFlag(req->changeMask) ||
-      AlterTableReq::getTTLColFlag(req->changeMask)) {
+  /* TTL-only ALTER (no AddAttr). Combined AddAttr+TTL is handled above. */
+  if (!AlterTableReq::getAddAttrFlag(req->changeMask) &&
+      (AlterTableReq::getTTLSecFlag(req->changeMask) ||
+       AlterTableReq::getTTLColFlag(req->changeMask))) {
     jam();
     AlterTabOperationPtr regAlterTabOpPtr;
     regAlterTabOpPtr.i = req->connectPtr;
@@ -1605,6 +1620,7 @@ void Dbtup::handleAlterTableCommit(Signal *signal, const AlterTabReq *req,
                          req->tableId,
                          regTabPtr->m_ttl_sec,
                          regTabPtr->m_ttl_col_no);
+    releaseAlterTabOpRec(regAlterTabOpPtr);
   }
 
   sendAlterTabConf(signal, RNIL);
@@ -1674,6 +1690,14 @@ void Dbtup::handleAlterTableAbort(Signal *signal, const AlterTabReq *req,
       releaseTabDescr(regAlterTabOpPtr.p->dynTableDescriptor[DD]);
       releaseAlterTabOpRec(regAlterTabOpPtr);
     }
+  } else if ((AlterTableReq::getTTLSecFlag(req->changeMask) ||
+              AlterTableReq::getTTLColFlag(req->changeMask)) &&
+             req->connectPtr != RNIL) {
+    jam();
+    AlterTabOperationPtr regAlterTabOpPtr;
+    regAlterTabOpPtr.i = req->connectPtr;
+    ptrCheckGuard(regAlterTabOpPtr, cnoOfAlterTabOps, alterTabOperRec);
+    releaseAlterTabOpRec(regAlterTabOpPtr);
   }
 
   sendAlterTabConf(signal, RNIL);


### PR DESCRIPTION
TTL-only ALTER TABLE operations (e.g. ALTER TABLE t COMMENT="NDB_TABLE=TTL=5@col_b") seized an AlterTabOperation record in handleAlterTablePrepare() but never released it in handleAlterTableCommit() or handleAlterTableAbort(). Each leaked record permanently consumed one slot from the 16-entry pool per DBTUP instance, eventually crashing all data nodes with "Pointer too large" (error 2306) at DbtupMeta.cpp:1100.

The fix has three parts:

1. handleAlterTableCommit - TTL-only path: add releaseAlterTabOpRec() after applying TTL values. Guarded by !getAddAttrFlag since the combined AddAttr+TTL case shares the AlterTabOp with AddAttr which already releases it.

2. handleAlterTableCommit - combined AddAttr+TTL path: apply TTL values inside the AddAttr block before releaseAlterTabOpRec(), instead of reading from the already-freed record in the separate TTL block (pre-existing use-after-free).

3. handleAlterTableAbort: add else-if branch to release the AlterTabOp for TTL-only aborts. No descriptor release needed since TTL-only AlterTabOps have nullptr descriptors.

MTR regression test (ttl_alter_leak) will be submitted in a separate patch.