### PR TITLE
RONDB-1017: Add SET MaxDiskWriteSpeed command to MGM client

### DIFF
--- a/mysql-test/suite/ndb/r/ndb_config_set.result
+++ b/mysql-test/suite/ndb/r/ndb_config_set.result
@@ -1,0 +1,49 @@
+Configuration updated for all data nodes
+MaxDiskWriteSpeed set to 104857600 on all data nodes
+
+select node_id, config_value
+from ndbinfo.config_values
+where config_param = 639
+order by node_id;
+node_id	config_value
+1	104857600
+2	104857600
+Configuration updated for node 1
+MaxDiskWriteSpeed set to 52428800 on node 1
+
+select node_id, config_value
+from ndbinfo.config_values
+where config_param = 639
+order by node_id;
+node_id	config_value
+1	52428800
+2	104857600
+MaxDiskWriteSpeed must be between 1M and 1024G
+
+MaxDiskWriteSpeed must be between 1M and 1024G
+
+Invalid value: '100X'. Use a number with optional K, M, or G suffix (e.g., 100M)
+
+Usage: <id> SET <parameter> <value>
+Supported parameters: MaxDiskWriteSpeed
+
+Unknown SET parameter: 'FooBar'
+Supported parameters: MaxDiskWriteSpeed
+
+select node_id, config_value
+from ndbinfo.config_values
+where config_param = 639
+order by node_id;
+node_id	config_value
+1	52428800
+2	104857600
+Configuration updated for all data nodes
+MaxDiskWriteSpeed set to 4194304 on all data nodes
+
+select node_id, config_value
+from ndbinfo.config_values
+where config_param = 639
+order by node_id;
+node_id	config_value
+1	4194304
+2	4194304

--- a/mysql-test/suite/ndb/t/ndb_config_set.test
+++ b/mysql-test/suite/ndb/t/ndb_config_set.test
@@ -1,0 +1,82 @@
+-- source include/have_ndb.inc
+
+#
+# Test dynamic configuration changes via the SET command.
+# New dynamically changeable parameters should add their
+# test cases to this file.
+#
+
+# ==========================================
+# Test: SET MaxDiskWriteSpeed
+# ==========================================
+
+#
+# Test 1: ALL SET — update all data nodes
+#
+--exec $NDB_MGM -e "ALL SET MaxDiskWriteSpeed 100M"
+
+# Verify both nodes report the new value via ndbinfo
+--sorted_result
+select node_id, config_value
+  from ndbinfo.config_values
+  where config_param = 639
+  order by node_id;
+
+#
+# Test 2: Single node SET — update only node 1
+#
+--exec $NDB_MGM -e "1 SET MaxDiskWriteSpeed 50M"
+
+--sorted_result
+select node_id, config_value
+  from ndbinfo.config_values
+  where config_param = 639
+  order by node_id;
+
+#
+# Test 3: Error cases
+#
+
+# Value below minimum (1M)
+--error 255
+--exec $NDB_MGM -e "ALL SET MaxDiskWriteSpeed 500K"
+
+# Value above maximum (1024G)
+--error 255
+--exec $NDB_MGM -e "ALL SET MaxDiskWriteSpeed 2048G"
+
+# Invalid suffix
+--error 255
+--exec $NDB_MGM -e "ALL SET MaxDiskWriteSpeed 100X"
+
+# Missing value
+--error 255
+--exec $NDB_MGM -e "ALL SET MaxDiskWriteSpeed"
+
+# Unknown parameter
+--error 255
+--exec $NDB_MGM -e "ALL SET FooBar 100M"
+
+#
+# Test 4: Verify config unchanged after failed error cases
+#
+--sorted_result
+select node_id, config_value
+  from ndbinfo.config_values
+  where config_param = 639
+  order by node_id;
+
+#
+# Test 5: Restore default value (4M)
+#
+--exec $NDB_MGM -e "ALL SET MaxDiskWriteSpeed 4M"
+
+--sorted_result
+select node_id, config_value
+  from ndbinfo.config_values
+  where config_param = 639
+  order by node_id;
+
+# ==========================================
+# Add new dynamic config parameter tests below
+# ==========================================

--- a/storage/ndb/CLAUDE.md
+++ b/storage/ndb/CLAUDE.md
@@ -1,0 +1,154 @@
+# CLAUDE.md — NDB Storage Engine
+
+## Adding a New Runtime-Settable Configuration Parameter
+
+The `SET` command in the MGM client allows changing configuration parameters on running data nodes. It updates the persistent configuration, the runtime value, and ndbinfo reporting — all in one command.
+
+**Reference implementation**: `MaxDiskWriteSpeed` (RONDB-1017).
+
+### Architecture
+
+```
+MGM Client (CommandInterpreter.cpp)
+  1. Parse command, validate value
+  2. Update permanent config via ndb_mgm_set_configuration()
+  3. Send runtime signal via ndb_mgm_set_config_param()
+       |
+MGM API (mgmapi.cpp)
+  -> ndb_mgm_call("set_config_param", ...)
+       |
+MGM Server (Services.cpp -> MgmtSrvr.cpp)
+  -> MgmApiSession::set_config_param()
+  -> MgmtSrvr::set_config_param_request()
+  -> Creates SetConfigParamReq signal, sends to target data node(s)
+  -> Waits for CONF/REF responses
+       |
+Data Node CMVMI (Cmvmi.cpp)
+  1. Updates ConfigValues (for ndbinfo reporting)
+  2. Dispatches to appropriate block via switch(configKey)
+  3. Sends SetConfigParamConf back to MgmtSrvr
+```
+
+The signal infrastructure (`SetConfigParam`) is **already implemented** and generic — it carries a config key (Uint32) and a value (Uint64 split into two Uint32 words). Adding a new parameter only requires changes in two files.
+
+### Steps to Add a New Parameter
+
+Only **2 files** need changes for a new parameter (the signal plumbing is already in place):
+
+#### Step 1: Cmvmi.cpp — Add Runtime Dispatch
+
+File: `storage/ndb/src/kernel/blocks/cmvmi/Cmvmi.cpp`
+
+In `Cmvmi::execSET_CONFIG_PARAM_REQ()`, add a new case to the `switch (configKey)` block. The case must apply the runtime effect by sending a signal to the appropriate block.
+
+```cpp
+switch (configKey)
+{
+case CFG_DB_MAX_DISK_WRITE_SPEED:
+{
+  // ... existing case ...
+  break;
+}
+case CFG_DB_YOUR_NEW_PARAM:
+{
+  jam();
+  // Send signal to the block that owns this parameter at runtime.
+  // Example: DumpStateOrd to the target block, or a dedicated signal.
+  signal->theData[0] = DumpStateOrd::YourDumpCode;
+  signal->theData[1] = Uint32(configValue >> 32);
+  signal->theData[2] = Uint32(configValue & 0xFFFFFFFF);
+  sendSignal(TARGET_BLOCK_REF, GSN_DUMP_STATE_ORD, signal, 3, JBB);
+  break;
+}
+default:
+  // ...
+}
+```
+
+The ConfigValues update (for ndbinfo) happens automatically before the switch — no per-parameter code needed for that.
+
+If no runtime dispatch is needed (config only takes effect after restart), you can add an empty case with a log message.
+
+#### Step 2: CommandInterpreter.cpp — Add Client-Side Command
+
+File: `storage/ndb/src/mgmclient/CommandInterpreter.cpp`
+
+**a)** Add a new `executeSetYourParam()` method declaration near the existing ones:
+
+```cpp
+int executeSetYourParam(int processId, const char *value_str, bool all);
+```
+
+**b)** Add a case in `executeSet()` to dispatch the new parameter name:
+
+```cpp
+if (native_strcasecmp(param_name, "MaxDiskWriteSpeed") == 0)
+{
+  return executeSetMaxDiskWriteSpeed(processId, value_str, all);
+}
+else if (native_strcasecmp(param_name, "YourParamName") == 0)
+{
+  return executeSetYourParam(processId, value_str, all);
+}
+```
+
+**c)** Implement `executeSetYourParam()` following the `executeSetMaxDiskWriteSpeed()` pattern:
+
+1. Parse and validate the value (use `parse_size_value()` for byte values with K/M/G suffixes, or write custom parsing)
+2. Validate range against ConfigInfo.cpp limits
+3. Get config via `ndb_mgm_get_configuration()`, update the key, save via `ndb_mgm_set_configuration()`
+4. Call `ndb_mgm_set_config_param(handle, nodeId, CFG_DB_YOUR_PARAM, value)` for runtime update
+5. Print success/failure message
+
+**d)** Update the `helpTextSet` string to list the new parameter.
+
+**e)** Update the error message in `executeSet()` that lists supported parameters.
+
+### Key Reference Points
+
+| What | File | Look for |
+|------|------|----------|
+| Config key constants | `include/mgmapi/mgmapi_config_parameters.h` | `CFG_DB_*` |
+| Config metadata (type, range, default) | `src/common/mgmcommon/ConfigInfo.cpp` | Parameter name string |
+| DUMP state codes | `include/kernel/signaldata/DumpStateOrd.hpp` | `DumpStateOrd` enum |
+| Signal definition | `include/kernel/signaldata/SetConfigParam.hpp` | SetConfigParamReq/Conf/Ref |
+| Signal numbers (GSN) | `include/kernel/GlobalSignalNumbers.h` | `GSN_SET_CONFIG_PARAM_*` |
+| Cmvmi handler | `src/kernel/blocks/cmvmi/Cmvmi.cpp` | `execSET_CONFIG_PARAM_REQ` |
+| Client SET command | `src/mgmclient/CommandInterpreter.cpp` | `executeSet`, `executeSetMaxDiskWriteSpeed` |
+| Value parser (K/M/G) | `src/mgmclient/CommandInterpreter.cpp` | `parse_size_value` |
+| MgmtSrvr handler | `src/mgmsrv/MgmtSrvr.cpp` | `set_config_param_request` |
+| Services handler | `src/mgmsrv/Services.cpp` | `set_config_param` |
+| mgmapi function | `src/mgmapi/mgmapi.cpp` | `ndb_mgm_set_config_param` |
+| Error code | `src/mgmsrv/ndb_mgmd_error.h` | `FAILED_SET_CONFIG_PARAM_REQUEST` |
+| Error text | `src/ndbapi/ndberror.cpp` | `5070` |
+
+All paths are relative to `storage/ndb/`.
+
+### Files That Do NOT Need Changes for New Parameters
+
+These files contain the generic signal infrastructure and are already complete:
+
+- `SetConfigParam.hpp` — signal definition (generic key + Uint64 value)
+- `GlobalSignalNumbers.h` — GSN numbers already allocated
+- `SignalNames.cpp` — signal names already registered
+- `Cmvmi.hpp` — handler declaration already present
+- `MgmtSrvr.hpp` / `MgmtSrvr.cpp` — generic request sender
+- `Services.hpp` / `Services.cpp` — generic API session handler
+- `mgmapi.h` / `mgmapi.cpp` — generic client API function
+- `ndb_mgmd_error.h` / `ndberror.cpp` — error code already defined
+
+### Design Notes
+
+- **Uint64 encoding**: Values are split into two Uint32 signal words (high/low). This is handled automatically by the signal infrastructure. The Cmvmi handler reconstructs with `(Uint64(high) << 32) | Uint64(low)`.
+- **ALL support**: When nodeId is 0, `MgmtSrvr::set_config_param_request()` sends to all data nodes. The `executeForAll()` function in CommandInterpreter routes "ALL SET ..." as a single call with nodeId=0.
+- **ndbinfo update**: Cmvmi updates ConfigValues before dispatching to the target block. The `config_values` table in ndbinfo reads from these values, so it reflects changes immediately.
+- **Two-phase update**: Step 1 persists to management server config (survives restarts). Step 2 applies to running nodes immediately. If step 2 fails, the config is still saved and takes effect on next restart.
+
+### Verification Checklist
+
+1. Build: `cmake -DWITH_NDB=1 . && make -j$(nproc)`
+2. `ndb_mgm -e "ALL SET YourParam <value>"` — succeeds
+3. `ndb_mgm -e "1 SET YourParam <value>"` — succeeds for node 1
+4. `SELECT config_value FROM ndbinfo.config_values WHERE config_param = <key>` — shows new value
+5. Invalid value rejected with helpful error message
+6. Value persists across management server restart (config saved)

--- a/storage/ndb/include/kernel/GlobalSignalNumbers.h
+++ b/storage/ndb/include/kernel/GlobalSignalNumbers.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -33,7 +33,7 @@
  *
  * When adding a new signal, remember to update MAX_GSN and SignalNames.cpp
  */
-const GlobalSignalNumber MAX_GSN = 947;
+const GlobalSignalNumber MAX_GSN = 950;
 
 struct GsnName {
   GlobalSignalNumber gsn;
@@ -1278,4 +1278,8 @@ extern const GlobalSignalNumber NO_OF_SIGNAL_NAMES;
 #define GSN_SET_DOMAIN_ID_REF           946
 
 #define GSN_COPY_FRAG_DONE_REP          947
+
+#define GSN_SET_CONFIG_PARAM_REQ        948
+#define GSN_SET_CONFIG_PARAM_CONF       949
+#define GSN_SET_CONFIG_PARAM_REF        950
 #endif

--- a/storage/ndb/include/kernel/signaldata/SetConfigParam.hpp
+++ b/storage/ndb/include/kernel/signaldata/SetConfigParam.hpp
@@ -1,0 +1,95 @@
+/*
+   Copyright (c) 2026, 2026, Hopsworks and/or its affiliates.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
+
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#ifndef SET_CONFIG_PARAM_HPP
+#define SET_CONFIG_PARAM_HPP
+
+#include "SignalData.hpp"
+
+#define JAM_FILE_ID 565
+
+class SetConfigParamReq
+{
+  /**
+   * Receiver(s)
+   */
+  friend class Cmvmi;
+
+  /**
+   * Sender
+   */
+  friend class MgmtSrvr;
+
+public:
+  static constexpr Uint32 SignalLength = 4;
+
+private:
+  Uint32 senderRef;
+  Uint32 configParamKey;
+  Uint32 configParamValueHigh;
+  Uint32 configParamValueLow;
+};
+
+class SetConfigParamConf
+{
+  /**
+   * Sender(s)
+   */
+  friend class Cmvmi;
+
+  /**
+   * Receiver
+   */
+  friend class MgmtSrvr;
+
+public:
+  static constexpr Uint32 SignalLength = 2;
+
+private:
+  Uint32 senderRef;
+  Uint32 configParamKey;
+};
+
+class SetConfigParamRef
+{
+  /**
+   * Sender(s)
+   */
+  friend class Cmvmi;
+
+  /**
+   * Receiver
+   */
+  friend class MgmtSrvr;
+
+public:
+  static constexpr Uint32 SignalLength = 3;
+
+private:
+  Uint32 senderRef;
+  Uint32 configParamKey;
+  Uint32 errorCode;
+};
+#undef JAM_FILE_ID
+#endif

--- a/storage/ndb/include/mgmapi/mgmapi.h
+++ b/storage/ndb/include/mgmapi/mgmapi.h
@@ -1169,6 +1169,21 @@ int ndb_mgm_restart5(NdbMgmHandle handle, int no_of_nodes, const int *node_list,
    */
   int ndb_mgm_deactivate(NdbMgmHandle handle, const int nodeId);
 
+  /**
+   * Set a configuration parameter on a running data node.
+   *
+   * @param   handle        Management handle.
+   * @param   nodeId        Node id (0 for all data nodes).
+   * @param   configKey     Configuration parameter key (CFG_DB_*).
+   * @param   configValue   New value for the parameter.
+   *
+   * @return                0 for success, -1 on error.
+   */
+  int ndb_mgm_set_config_param(NdbMgmHandle handle,
+                               const int nodeId,
+                               const unsigned int configKey,
+                               const unsigned long long configValue);
+
   /** @} *********************************************************************/
   /**
    * @name Functions: Controlling Clusterlog output

--- a/storage/ndb/src/common/debugger/signaldata/SignalNames.cpp
+++ b/storage/ndb/src/common/debugger/signaldata/SignalNames.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -974,5 +974,8 @@ const GsnName SignalNames [] = {
   ,{ GSN_SET_DOMAIN_ID_CONF, "SET_DOMAIN_ID_CONF" }
   ,{ GSN_SET_DOMAIN_ID_REF, "SET_DOMAIN_ID_REF" }
   ,{ GSN_COPY_FRAG_DONE_REP, "COPY_FRAG_DONE_REP" }
+  ,{ GSN_SET_CONFIG_PARAM_REQ, "SET_CONFIG_PARAM_REQ" }
+  ,{ GSN_SET_CONFIG_PARAM_CONF, "SET_CONFIG_PARAM_CONF" }
+  ,{ GSN_SET_CONFIG_PARAM_REF, "SET_CONFIG_PARAM_REF" }
 };
 const unsigned short NO_OF_SIGNAL_NAMES = sizeof(SignalNames)/sizeof(GsnName);

--- a/storage/ndb/src/kernel/blocks/cmvmi/Cmvmi.cpp
+++ b/storage/ndb/src/kernel/blocks/cmvmi/Cmvmi.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -60,6 +60,7 @@
 #include <signaldata/TamperOrd.hpp>
 #include <signaldata/TestOrd.hpp>
 #include <signaldata/SetDomainId.hpp>
+#include <signaldata/SetConfigParam.hpp>
 
 #ifdef ERROR_INSERT
 #include <signaldata/FsOpenReq.hpp>
@@ -160,6 +161,7 @@ Cmvmi::Cmvmi(Block_context &ctx)
   addRecSignal(GSN_DEACTIVATE_REQ, &Cmvmi::execDEACTIVATE_REQ);
   addRecSignal(GSN_SET_HOSTNAME_REQ, &Cmvmi::execSET_HOSTNAME_REQ);
   addRecSignal(GSN_SET_DOMAIN_ID_REQ, &Cmvmi::execSET_DOMAIN_ID_REQ);
+  addRecSignal(GSN_SET_CONFIG_PARAM_REQ, &Cmvmi::execSET_CONFIG_PARAM_REQ);
 #ifdef ERROR_INSERT
   addRecSignal(GSN_FSOPENCONF, &Cmvmi::execFSOPENCONF);
   addRecSignal(GSN_FSCLOSECONF, &Cmvmi::execFSCLOSECONF);
@@ -3490,5 +3492,72 @@ void Cmvmi::execDEACTIVATE_REQ(Signal *signal)
              GSN_DEACTIVATE_REQ,
              signal,
              DeactivateReq::SignalLength,
+             JBB);
+}
+
+/**
+ * Set a configuration parameter at runtime.
+ * Updates the local ConfigValues (for ndbinfo reporting) and
+ * dispatches the change to the appropriate block for runtime effect.
+ */
+void Cmvmi::execSET_CONFIG_PARAM_REQ(Signal *signal)
+{
+  jamEntry();
+  const SetConfigParamReq* const req =
+    (const SetConfigParamReq *)signal->getDataPtr();
+  BlockReference senderRef = req->senderRef;
+  Uint32 configKey = req->configParamKey;
+  Uint64 configValue = (Uint64(req->configParamValueHigh) << 32) |
+                        Uint64(req->configParamValueLow);
+
+  /**
+   * Update the node's own ConfigValues so that ndbinfo config_values
+   * reports the new value.
+   */
+  ConfigValues *own_config_values = m_ctx.m_config.get_own_config_values_mutable();
+  ConfigValues::Iterator iter(*own_config_values);
+  if (iter.openSection(CFG_SECTION_NODE, 0))
+  {
+    jam();
+    iter.set(configKey, configValue);
+    iter.closeSection();
+  }
+
+  /**
+   * Dispatch to the appropriate block based on the config parameter.
+   */
+  switch (configKey)
+  {
+  case CFG_DB_MAX_DISK_WRITE_SPEED:
+  {
+    jam();
+    /**
+     * Send DumpStateOrd to Backup block to update runtime value.
+     * Use the 64-bit variant (BackupMaxWriteSpeed64) to support large values.
+     */
+    signal->theData[0] = DumpStateOrd::BackupMaxWriteSpeed64;
+    signal->theData[1] = Uint32(configValue >> 32);  // MSB
+    signal->theData[2] = Uint32(configValue & 0xFFFFFFFF);  // LSB
+    sendSignal(BACKUP_REF, GSN_DUMP_STATE_ORD, signal, 3, JBB);
+    break;
+  }
+  default:
+    jam();
+    g_eventLogger->info("SET_CONFIG_PARAM_REQ: unsupported config key %u",
+                        configKey);
+    break;
+  }
+
+  /**
+   * Send confirmation back to the management server.
+   */
+  SetConfigParamConf* conf =
+    (SetConfigParamConf *)signal->getDataPtrSend();
+  conf->senderRef = reference();
+  conf->configParamKey = configKey;
+  sendSignal(senderRef,
+             GSN_SET_CONFIG_PARAM_CONF,
+             signal,
+             SetConfigParamConf::SignalLength,
              JBB);
 }

--- a/storage/ndb/src/kernel/blocks/cmvmi/Cmvmi.hpp
+++ b/storage/ndb/src/kernel/blocks/cmvmi/Cmvmi.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -79,6 +79,7 @@ class Cmvmi : public SimulatedBlock {
   void execDEACTIVATE_REQ(Signal*);
   void execSET_HOSTNAME_REQ(Signal*);
   void execSET_DOMAIN_ID_REQ(Signal*);
+  void execSET_CONFIG_PARAM_REQ(Signal*);
 
 #ifdef ERROR_INSERT
   Uint32 g_remaining_responses;

--- a/storage/ndb/src/kernel/vm/Configuration.cpp
+++ b/storage/ndb/src/kernel/vm/Configuration.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -2078,6 +2078,10 @@ Configuration::getOwnConfigIterator() const {
 }
 
 const ConfigValues *Configuration::get_own_config_values() {
+  return &m_ownConfig->m_config_values;
+}
+
+ConfigValues *Configuration::get_own_config_values_mutable() {
   return &m_ownConfig->m_config_values;
 }
 

--- a/storage/ndb/src/kernel/vm/Configuration.hpp
+++ b/storage/ndb/src/kernel/vm/Configuration.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -199,6 +199,7 @@ class Configuration {
 
   ndb_mgm_configuration *m_ownConfig;
   const class ConfigValues *get_own_config_values();
+  class ConfigValues *get_own_config_values_mutable();
   ndb_mgm::config_ptr m_clusterConfig;
   UtilBuffer m_clusterConfigPacked_v1;
   UtilBuffer m_clusterConfigPacked_v2;

--- a/storage/ndb/src/mgmapi/mgmapi.cpp
+++ b/storage/ndb/src/mgmapi/mgmapi.cpp
@@ -2712,6 +2712,50 @@ ndb_mgm_set_domain_id(NdbMgmHandle handle,
 
 extern "C"
 int
+ndb_mgm_set_config_param(NdbMgmHandle handle,
+                         const int nodeId,
+                         const unsigned int configKey,
+                         const unsigned long long configValue)
+{
+  DBUG_ENTER("ndb_mgm_set_config_param");
+  CHECK_HANDLE(handle, -1);
+  SET_ERROR(handle, NDB_MGM_NO_ERROR, "Executing: ndb_mgm_set_config_param");
+  const ParserRow<ParserDummy> set_config_param_reply[] = {
+    MGM_CMD("set_config_param reply", NULL, ""),
+    MGM_ARG("result", String, Mandatory, "Error message"),
+    MGM_END()
+  };
+  int ret = -1;
+  CHECK_CONNECTED(handle, -1);
+  Properties args;
+  args.put("node", (Uint32)nodeId);
+  args.put("config_key", (Uint32)configKey);
+  args.put("config_value_high", (Uint32)(configValue >> 32));
+  args.put("config_value_low", (Uint32)(configValue & 0xFFFFFFFF));
+  const Properties *reply;
+  reply = ndb_mgm_call(handle,
+                       set_config_param_reply,
+                       "set_config_param",
+                       &args);
+  if (reply != NULL)
+  {
+    BaseString result;
+    reply->get("result", result);
+    if (strcmp(result.c_str(), "Ok") == 0)
+    {
+      ret = 0;
+    }
+    else
+    {
+      SET_ERROR(handle, EINVAL, result.c_str());
+    }
+  }
+  delete reply;
+  DBUG_RETURN(ret);
+}
+
+extern "C"
+int
 ndb_mgm_set_hostname(NdbMgmHandle handle,
                      const int nodeId,
                      const char *new_hostname)

--- a/storage/ndb/src/mgmclient/CommandInterpreter.cpp
+++ b/storage/ndb/src/mgmclient/CommandInterpreter.cpp
@@ -158,6 +158,10 @@ class CommandInterpreter {
   void waitForEventThread();
 
  public:
+  int executeSet(int processId, const char *parameters, bool all);
+  int executeSetMaxDiskWriteSpeed(int processId, const char *value_str,
+                                  bool all);
+  Uint64 parse_size_value(const char *str, bool &ok);
   int executeSetDomain(int processId, const char *parameters, bool all);
   int executeHostname(int processId, const char *parameters, bool all);
   int executeActivate(int processId, const char *parameters, bool all);
@@ -326,6 +330,7 @@ static const char* helpText =
 "CLUSTERLOG OFF [<severity>] ...        Disable Cluster logging\n"
 "CLUSTERLOG TOGGLE [<severity>] ...     Toggle severity filter on/off\n"
 "CLUSTERLOG INFO                        Print cluster log information\n"
+"<id> SET <param> <value>               Set config parameter on data node(s)\n"
 "<id> LOCATION_DOMAIN_ID [<id>]         Change location domain id of a node\n"
 "<id> HOSTNAME [<hostname/IP>]          Change hostname of a deactivated node\n"
 "<id> ACTIVATE                          Activate a node previously deactivated\n"
@@ -509,6 +514,22 @@ static const char* helpTextClusterlogInfo =
 "CLUSTERLOG INFO  Print cluster log information\n\n"
 "CLUSTERLOG INFO    Display which severity levels have been enabled,\n"
 "                   see HELP CLUSTERLOG for list of the severity levels.\n"
+;
+
+static const char* helpTextSet =
+"---------------------------------------------------------------------------\n"
+" RonDB -- Management Client -- Help for SET command\n"
+"---------------------------------------------------------------------------\n"
+"SET Set a configuration parameter on a running data node\n\n"
+"<id> SET <param> <value>    Set configuration parameter <param> to <value>\n"
+"                            on node <id>. Use ALL to set on all data nodes.\n\n"
+"Supported parameters:\n"
+"  MaxDiskWriteSpeed          Max bytes/sec for LCP and backup disk writes.\n"
+"                             Value supports K, M, G suffixes (e.g., 100M).\n"
+"                             Range: 1M to 1024G.\n\n"
+"Examples:\n"
+"  ALL SET MaxDiskWriteSpeed 100M    Set on all data nodes to 100 MB/s\n"
+"  1 SET MaxDiskWriteSpeed 50M       Set on node 1 to 50 MB/s\n"
 ;
 
 static const char* helpTextHostname =
@@ -848,6 +869,7 @@ struct st_cmd_help {
                   {"CLUSTERLOG OFF", helpTextClusterlogOff, NULL},
                   {"CLUSTERLOG TOGGLE", helpTextClusterlogToggle, NULL},
                   {"CLUSTERLOG INFO", helpTextClusterlogInfo, NULL},
+                  {"SET", helpTextSet, NULL},
                   {"LOCATION_DOMAIN_ID", helpTextSetDomainId, NULL},
                   {"HOSTNAME", helpTextHostname, NULL},
                   {"ACTIVATE", helpTextActivate, NULL},
@@ -1666,6 +1688,7 @@ static const CommandInterpreter::CommandFunctionPair commands[] = {
   ,{ "ACTIVATE", &CommandInterpreter::executeActivate }
   ,{ "DEACTIVATE", &CommandInterpreter::executeDeactivate }
   ,{ "LOCATION_DOMAIN_ID", &CommandInterpreter::executeSetDomain }
+  ,{ "SET", &CommandInterpreter::executeSet }
 };
 
 
@@ -1781,6 +1804,8 @@ int CommandInterpreter::executeForAll(const char *cmd, ExecuteFunction fun,
   } else if (native_strcasecmp(cmd, "REPORT") == 0) {
     Guard g(m_print_mutex);
     retval = executeReport(nodeId, allAfterSecondToken, true);
+  } else if (native_strcasecmp(cmd, "SET") == 0) {
+    retval = (this->*fun)(nodeId, allAfterSecondToken, true);
   } else {
     Guard g(m_print_mutex);
     struct ndb_mgm_cluster_state *cl = ndb_mgm_get_status(m_mgmsrv);
@@ -2629,6 +2654,214 @@ CommandInterpreter::check_before_config_change(int processId,
     return false;
   }
   return true;
+}
+
+/**
+ * Parse a size value with optional K, M, G suffix.
+ * Returns the value in bytes. Sets ok to false on parse error.
+ */
+Uint64
+CommandInterpreter::parse_size_value(const char *str, bool &ok)
+{
+  ok = false;
+  if (str == nullptr || *str == '\0')
+    return 0;
+
+  char *end_ptr = nullptr;
+  errno = 0;
+  unsigned long long val = strtoull(str, &end_ptr, 10);
+  if (errno == ERANGE || errno == EINVAL || end_ptr == str)
+    return 0;
+
+  Uint64 multiplier = 1;
+  if (*end_ptr != '\0')
+  {
+    char suffix = *end_ptr;
+    // Check there's nothing after the suffix
+    if (*(end_ptr + 1) != '\0')
+      return 0;
+    switch (suffix)
+    {
+    case 'k': case 'K':
+      multiplier = 1024ULL;
+      break;
+    case 'm': case 'M':
+      multiplier = 1024ULL * 1024ULL;
+      break;
+    case 'g': case 'G':
+      multiplier = 1024ULL * 1024ULL * 1024ULL;
+      break;
+    default:
+      return 0;
+    }
+  }
+
+  // Check for overflow
+  Uint64 result = Uint64(val) * multiplier;
+  if (val != 0 && result / multiplier != Uint64(val))
+    return 0;
+
+  ok = true;
+  return result;
+}
+
+int
+CommandInterpreter::executeSet(int processId,
+                               const char *parameters,
+                               bool all)
+{
+  if (!parameters || *parameters == '\0')
+  {
+    ndbout_c("Usage: <id> SET <parameter> <value>");
+    ndbout_c("Supported parameters: MaxDiskWriteSpeed");
+    return -1;
+  }
+
+  Vector<BaseString> command_list;
+  BaseString tmp(parameters);
+  tmp.split(command_list, " \t", 2);
+
+  if (command_list.size() < 2)
+  {
+    ndbout_c("Usage: <id> SET <parameter> <value>");
+    ndbout_c("Supported parameters: MaxDiskWriteSpeed");
+    return -1;
+  }
+
+  const char *param_name = command_list[0].c_str();
+  const char *value_str = command_list[1].c_str();
+
+  if (native_strcasecmp(param_name, "MaxDiskWriteSpeed") == 0)
+  {
+    return executeSetMaxDiskWriteSpeed(processId, value_str, all);
+  }
+
+  ndbout_c("Unknown SET parameter: '%s'", param_name);
+  ndbout_c("Supported parameters: MaxDiskWriteSpeed");
+  return -1;
+}
+
+int
+CommandInterpreter::executeSetMaxDiskWriteSpeed(int processId,
+                                                const char *value_str,
+                                                bool all)
+{
+  bool parse_ok = false;
+  Uint64 new_value = parse_size_value(value_str, parse_ok);
+  if (!parse_ok)
+  {
+    ndbout_c("Invalid value: '%s'. Use a number with optional K, M, or G "
+             "suffix (e.g., 100M)", value_str);
+    return -1;
+  }
+
+  const Uint64 min_value = 1024ULL * 1024ULL;          // 1M
+  const Uint64 max_value = 1024ULL * 1024ULL * 1024ULL * 1024ULL;  // 1024G
+  if (new_value < min_value || new_value > max_value)
+  {
+    ndbout_c("MaxDiskWriteSpeed must be between 1M and 1024G");
+    return -1;
+  }
+
+  /*
+   * Step 1: Update the permanent configuration on the management server.
+   */
+  ndb_mgm_configuration *conf = ndb_mgm_get_configuration(m_mgmsrv,
+                                                           NDB_VERSION);
+  if (conf == 0)
+  {
+    ndbout_c("Could not get configuration");
+    printError();
+    return -1;
+  }
+
+  ConfigValues::Iterator iter(conf->m_config_values);
+  bool found_any = false;
+
+  if (all)
+  {
+    /*
+     * Update MaxDiskWriteSpeed for all data nodes in the configuration.
+     */
+    for (int i = 0; i < ABS_MAX_NODES; i++)
+    {
+      if (!iter.openSection(CFG_SECTION_NODE, i))
+        continue;
+      Uint32 node_type = 0;
+      iter.get(CFG_TYPE_OF_SECTION, &node_type);
+      if (node_type != (Uint32)NODE_TYPE_DB)
+      {
+        iter.closeSection();
+        continue;
+      }
+      iter.set(CFG_DB_MAX_DISK_WRITE_SPEED, new_value);
+      iter.closeSection();
+      found_any = true;
+    }
+  }
+  else
+  {
+    /*
+     * Update MaxDiskWriteSpeed for a specific data node.
+     */
+    bool ret = get_node_section(iter, processId, 0);
+    if (!ret)
+    {
+      printError();
+      ndbout_c("Failed to get configuration of node %d", processId);
+      ndb_mgm_destroy_configuration(conf);
+      return -1;
+    }
+    iter.set(CFG_DB_MAX_DISK_WRITE_SPEED, new_value);
+    iter.closeSection();
+    found_any = true;
+  }
+
+  if (!found_any)
+  {
+    ndbout_c("No data nodes found in configuration");
+    ndb_mgm_destroy_configuration(conf);
+    return -1;
+  }
+
+  int ret_code = ndb_mgm_set_configuration(m_mgmsrv, conf);
+  ndb_mgm_destroy_configuration(conf);
+  if (ret_code != 0)
+  {
+    ndbout_c("Failed to update configuration");
+    printError();
+    return -1;
+  }
+
+  if (all)
+    ndbout_c("Configuration updated for all data nodes");
+  else
+    ndbout_c("Configuration updated for node %d", processId);
+
+  /*
+   * Step 2: Send runtime update signal to data nodes so the change
+   * takes effect immediately and ndbinfo reports the new value.
+   */
+  ret_code = ndb_mgm_set_config_param(m_mgmsrv,
+                                      all ? 0 : processId,
+                                      CFG_DB_MAX_DISK_WRITE_SPEED,
+                                      new_value);
+  if (ret_code < 0)
+  {
+    ndbout_c("Warning: Configuration saved but failed to update running "
+             "nodes. Restart nodes for the change to take effect.");
+    printError();
+    return -1;
+  }
+
+  if (all)
+    ndbout_c("MaxDiskWriteSpeed set to %llu on all data nodes",
+             (unsigned long long)new_value);
+  else
+    ndbout_c("MaxDiskWriteSpeed set to %llu on node %d",
+             (unsigned long long)new_value, processId);
+
+  return 0;
 }
 
 int

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -80,6 +80,7 @@
 #include "portlib/ndb_openssl_version.h"
 #include "portlib/ndb_sockaddr.h"
 #include <signaldata/SetDomainId.hpp>
+#include <signaldata/SetConfigParam.hpp>
 
 #include <NdbConfig.h>
 #include <SocketServer.hpp>
@@ -1324,6 +1325,119 @@ MgmtSrvr::set_location_domain_id_request(
       assert(setDomainIdConf->changeNodeId == Uint32(changeNodeId));
       assert(setDomainIdConf->senderId <= nodes.max_size());
       NodeId senderNodeId = refToNode(setDomainIdConf->senderRef);
+      nodes.clear(senderNodeId);
+      break;
+    }
+    case GSN_NF_COMPLETEREP:
+    {
+      const NFCompleteRep * rep = CAST_CONSTPTR(NFCompleteRep,
+                                                signal->getDataPtr());
+      if (rep->failedNodeId <= nodes.max_size())
+        nodes.clear(rep->failedNodeId); // clear the failed node
+      break;
+    }
+    case GSN_NODE_FAILREP:
+    {
+      const NodeFailRep * rep = CAST_CONSTPTR(NodeFailRep,
+                                              signal->getDataPtr());
+      Uint32 len = NodeFailRep::getNodeMaskLength(signal->getLength());
+      assert(len == NodeBitmask::Size || // only full length in ndbapi
+             len == 0);
+      NodeBitmask mask;
+      if (signal->header.m_noOfSections >= 1)
+      {
+        mask.assign(signal->ptr[0].sz, signal->ptr[0].p);
+      }
+      else
+      {
+        mask.assign(len, rep->theAllNodes);
+      }
+      nodes.bitANDC(mask);
+      break;
+    }
+    case GSN_API_REGCONF:
+    case GSN_TAKE_OVERTCCONF:
+    case GSN_CONNECT_REP:
+      continue;
+    default:
+      report_unknown_signal(signal);
+      DBUG_RETURN(SEND_OR_RECEIVE_FAILED);
+    }
+  }
+  DBUG_RETURN(error_code);
+}
+
+int
+MgmtSrvr::set_config_param_request(
+  int nodeId,
+  Uint32 configKey,
+  Uint64 configValue)
+{
+  DBUG_ENTER("MgmtSrvr::set_config_param_request");
+  DBUG_PRINT("enter", ("Set config param: key=%u value=%llu for node %d",
+             configKey, configValue, nodeId));
+
+  SignalSender ss(theFacade);
+  SimpleSignal ssig;
+  ss.lock(); // lock will be released on exit
+  SetConfigParamReq* const req = CAST_PTR(SetConfigParamReq,
+                                          ssig.getDataPtrSend());
+  ssig.set(ss,
+           TestOrd::TraceAPI,
+           CMVMI,
+           GSN_SET_CONFIG_PARAM_REQ,
+           SetConfigParamReq::SignalLength);
+  req->senderRef = ss.getOwnRef();
+  req->configParamKey = configKey;
+  req->configParamValueHigh = Uint32(configValue >> 32);
+  req->configParamValueLow = Uint32(configValue & 0xFFFFFFFF);
+
+  // send the signals
+  int failed = 0;
+  NodeBitmask nodes;
+  {
+    NodeId targetNodeId = 0;
+    while(getNextNodeId(&targetNodeId, NDB_MGM_NODE_TYPE_NDB))
+    {
+      if (nodeId != 0 && (int)targetNodeId != nodeId)
+      {
+        // Skip nodes that don't match the target
+        continue;
+      }
+      if (okToSendTo(targetNodeId, true) == 0)
+      {
+        SendStatus result = ss.sendSignal(targetNodeId, &ssig);
+        if (result == SEND_OK)
+          nodes.set(targetNodeId);
+        else
+          failed++;
+      }
+    }
+  }
+  if (nodes.isclear() && failed > 0)
+  {
+    DBUG_RETURN(SEND_OR_RECEIVE_FAILED);
+  }
+  int error_code = 0;
+  while (!nodes.isclear())
+  {
+    SimpleSignal *signal = ss.waitFor();
+    int gsn = signal->readSignalNumber();
+    switch (gsn) {
+    case GSN_SET_CONFIG_PARAM_REF:
+    {
+      const SetConfigParamRef* ref =
+        CAST_CONSTPTR(SetConfigParamRef, signal->getDataPtr());
+      NodeId senderNodeId = refToNode(ref->senderRef);
+      nodes.clear(senderNodeId);
+      error_code = FAILED_SET_CONFIG_PARAM_REQUEST;
+      break;
+    }
+    case GSN_SET_CONFIG_PARAM_CONF:
+    {
+      const SetConfigParamConf* conf =
+        CAST_CONSTPTR(SetConfigParamConf, signal->getDataPtr());
+      NodeId senderNodeId = refToNode(conf->senderRef);
       nodes.clear(senderNodeId);
       break;
     }

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.hpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -233,6 +233,16 @@ class MgmtSrvr : private ConfigSubscriber, public trp_client {
    *   @return 0 if succeeded, otherwise: error code
    */
   int deactivate_request(int processId);
+
+  /**
+   * Set a configuration parameter on a running data node.
+   *   @param  nodeId      Id of the DB node (0 = all data nodes)
+   *   @param  configKey   Configuration parameter key (CFG_DB_*)
+   *   @param  configValue New value for the parameter
+   *   @return 0 if succeeded, otherwise: error code
+   */
+  int set_config_param_request(int nodeId, Uint32 configKey,
+                               Uint64 configValue);
 
   /**
    *   Restart a list of nodes

--- a/storage/ndb/src/mgmsrv/Services.cpp
+++ b/storage/ndb/src/mgmsrv/Services.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -288,6 +288,12 @@ const ParserRow<MgmApiSession> commands[] = {
 
     MGM_CMD("deactivate", &MgmApiSession::deactivate, "", &Basic),
     MGM_ARG("node", Int, Mandatory, "node"),
+
+    MGM_CMD("set_config_param", &MgmApiSession::set_config_param, "", &Basic),
+    MGM_ARG("node", Int, Mandatory, "node"),
+    MGM_ARG("config_key", Int, Mandatory, "config parameter key"),
+    MGM_ARG("config_value_high", Int, Mandatory, "config value high 32 bits"),
+    MGM_ARG("config_value_low", Int, Mandatory, "config value low 32 bits"),
 
     MGM_CMD("start", &MgmApiSession::start, "", &Basic),
     MGM_ARG("node", Int, Mandatory, "Node"),
@@ -1683,6 +1689,40 @@ MgmApiSession::deactivate(Parser<MgmApiSession>::Context &,
     result = INCORRECT_MGM_COMMAND;
   }
   m_output->println("deactivate reply");
+  if(result != 0)
+    m_output->println("result: %s", get_error_text(result));
+  else
+    m_output->println("result: Ok");
+  m_output->println("%s", "");
+}
+
+void
+MgmApiSession::set_config_param(Parser<MgmApiSession>::Context &,
+                                Properties const &args)
+{
+  Uint32 node;
+  Uint32 config_key;
+  Uint32 config_value_high;
+  Uint32 config_value_low;
+
+  bool ok = args.get("node", &node);
+  ok = ok && args.get("config_key", &config_key);
+  ok = ok && args.get("config_value_high", &config_value_high);
+  ok = ok && args.get("config_value_low", &config_value_low);
+
+  int result;
+  if (ok)
+  {
+    Uint64 config_value = (Uint64(config_value_high) << 32) |
+                           Uint64(config_value_low);
+    result = m_mgmsrv.set_config_param_request(node, config_key, config_value);
+  }
+  else
+  {
+    result = INCORRECT_MGM_COMMAND;
+  }
+
+  m_output->println("set_config_param reply");
   if(result != 0)
     m_output->println("result: %s", get_error_text(result));
   else

--- a/storage/ndb/src/mgmsrv/Services.hpp
+++ b/storage/ndb/src/mgmsrv/Services.hpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2003, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -130,6 +130,7 @@ class MgmApiSession : public SocketServer::Session {
   void set_hostname(Parser_t::Context &ctx, const class Properties &args);
   void activate(Parser_t::Context &ctx, const class Properties &args);
   void deactivate(Parser_t::Context &ctx, const class Properties &args);
+  void set_config_param(Parser_t::Context &ctx, const class Properties &args);
   void start(Parser_t::Context &ctx, const class Properties &args);
   void startAll(Parser_t::Context &ctx, const class Properties &args);
   void startTls(Parser_t::Context &ctx, const class Properties &args);

--- a/storage/ndb/src/mgmsrv/ndb_mgmd_error.h
+++ b/storage/ndb/src/mgmsrv/ndb_mgmd_error.h
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2007, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -48,5 +48,6 @@
 #define INCORRECT_MGM_COMMAND 5066
 #define FAILED_SET_HOSTNAME_REQUEST 5067
 #define FAILED_SET_DOMAIN_ID_REQUEST 5069
+#define FAILED_SET_CONFIG_PARAM_REQUEST 5070
 
 #endif

--- a/storage/ndb/src/ndbapi/ndberror.cpp
+++ b/storage/ndb/src/ndbapi/ndberror.cpp
@@ -1,6 +1,6 @@
 /*
    Copyright (c) 2004, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2021, 2025, Hopsworks and/or its affiliates.
+   Copyright (c) 2021, 2026, Hopsworks and/or its affiliates.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -1122,6 +1122,8 @@ ErrorBundle ErrorCodes[] = {
     "Data nodes failed Deactivate Request"},
   { 5069 /* FAILED_SET_DOMAIN_ID_REQUEST */, DMEC, AE,
     "Data nodes failed Set Location_Domain_Id Request"},
+  { 5070 /* FAILED_SET_CONFIG_PARAM_REQUEST */, DMEC, AE,
+    "Data nodes failed Set Config Param Request"},
   { 1120, DMEC, AE,
     "Set Location_Domain_Id Request failed, busy state"}
 };


### PR DESCRIPTION
Add a proper MGM client command to set MaxDiskWriteSpeed at runtime, replacing the need to use the raw DUMP 100002 command. The new command updates the persistent configuration, the runtime value on data nodes, and the node's local ConfigValues so ndbinfo reports the new value.

Syntax: <id> SET MaxDiskWriteSpeed <value>
        ALL SET MaxDiskWriteSpeed 100M

The implementation uses a semi-generic SetConfigParam signal that carries a config key and Uint64 value, making it easy to extend for additional parameters in the future. Adding a new parameter only requires changes in Cmvmi.cpp (runtime dispatch) and CommandInterpreter.cpp (client-side command).

Includes MTR test (ndb_config_set) and CLAUDE.md developer guide.