### PR TITLE
Fix rdrs2 scan heap corruption on composite secondary index over mult…

### DIFF
--- a/mysql-test/suite/rdrs2/r/rdrs2_scan_composite_index.result
+++ b/mysql-test/suite/rdrs2/r/rdrs2_scan_composite_index.result
@@ -1,0 +1,30 @@
+===== Prepare table to exercise a composite secondary-index scan =====
+
+The index columns (customer_number, occurred_at) have non-contiguous
+base-table attrIds because occurred_at (col 1) sits inside the primary
+key while customer_number (col 3) is after it. Before the fix in
+CompileIndexRanges in rdrs_dal.cpp, this shape corrupted the scan
+buffer because the code iterated the record's attrIds in ascending
+order and wrote each user-supplied bound value at the wrong column's
+offset. Three rows sharing one customer_number are enough to trip it.
+CREATE DATABASE db1;
+USE db1;
+CREATE TABLE t1 (
+client_id       VARCHAR(40) NOT NULL,
+occurred_at     BIGINT      NOT NULL,
+event_id        VARCHAR(36) NOT NULL,
+customer_number VARCHAR(16),
+v               VARCHAR(20),
+PRIMARY KEY (client_id, occurred_at, event_id),
+KEY idx_cn_ts (customer_number, occurred_at)
+) ENGINE=ndbcluster;
+INSERT INTO t1 VALUES
+('ca', 1000, 'ea', '91861192135020', 'x'),
+('cb', 2000, 'eb', '91861192135020', 'y'),
+('cc', 3000, 'ec', '91861192135020', 'z');
+===== DESC ordered scan on the composite secondary index =====
+{"data":[{"customer_number":"91861192135020","occurred_at":3000,"event_id":"ec"},{"customer_number":"91861192135020","occurred_at":2000,"event_id":"eb"},{"customer_number":"91861192135020","occurred_at":1000,"event_id":"ea"}],"rows":3}
+===== ASC ordered scan on the composite secondary index =====
+{"data":[{"customer_number":"91861192135020","occurred_at":1000,"event_id":"ea"},{"customer_number":"91861192135020","occurred_at":2000,"event_id":"eb"},{"customer_number":"91861192135020","occurred_at":3000,"event_id":"ec"}],"rows":3}
+USE test;
+DROP DATABASE db1;

--- a/mysql-test/suite/rdrs2/t/rdrs2_scan_composite_index.test
+++ b/mysql-test/suite/rdrs2/t/rdrs2_scan_composite_index.test
@@ -1,0 +1,41 @@
+--source include/have_util_curl.inc
+
+--echo ===== Prepare table to exercise a composite secondary-index scan =====
+--echo
+--echo The index columns (customer_number, occurred_at) have non-contiguous
+--echo base-table attrIds because occurred_at (col 1) sits inside the primary
+--echo key while customer_number (col 3) is after it. Before the fix in
+--echo CompileIndexRanges in rdrs_dal.cpp, this shape corrupted the scan
+--echo buffer because the code iterated the record's attrIds in ascending
+--echo order and wrote each user-supplied bound value at the wrong column's
+--echo offset. Three rows sharing one customer_number are enough to trip it.
+CREATE DATABASE db1;
+USE db1;
+CREATE TABLE t1 (
+  client_id       VARCHAR(40) NOT NULL,
+  occurred_at     BIGINT      NOT NULL,
+  event_id        VARCHAR(36) NOT NULL,
+  customer_number VARCHAR(16),
+  v               VARCHAR(20),
+  PRIMARY KEY (client_id, occurred_at, event_id),
+  KEY idx_cn_ts (customer_number, occurred_at)
+) ENGINE=ndbcluster;
+INSERT INTO t1 VALUES
+  ('ca', 1000, 'ea', '91861192135020', 'x'),
+  ('cb', 2000, 'eb', '91861192135020', 'y'),
+  ('cc', 3000, 'ec', '91861192135020', 'z');
+
+let $scan = curl --fail-with-body -X POST
+  -H "Content-Type: application/json"
+  http://$RDRS_NOKEY_HOST:$RDRS_NOKEY_PORT/0.1.0/db1/t1/scan -d;
+
+--echo ===== DESC ordered scan on the composite secondary index =====
+--exec $scan '{"limit":5,"readColumns":[{"column":"customer_number"},{"column":"occurred_at"},{"column":"event_id"}],"index":{"name":"idx_cn_ts","key_columns":["customer_number","occurred_at"],"ranges":[{"lower":{"values":["91861192135020"],"inclusive":true},"upper":{"values":["91861192135020"],"inclusive":true}}],"order":"desc"}}'
+--echo
+
+--echo ===== ASC ordered scan on the composite secondary index =====
+--exec $scan '{"limit":5,"readColumns":[{"column":"customer_number"},{"column":"occurred_at"},{"column":"event_id"}],"index":{"name":"idx_cn_ts","key_columns":["customer_number","occurred_at"],"ranges":[{"lower":{"values":["91861192135020"],"inclusive":true},"upper":{"values":["91861192135020"],"inclusive":true}}],"order":"asc"}}'
+--echo
+
+USE test;
+DROP DATABASE db1;

--- a/storage/ndb/rest-server2/server/src/rdrs_dal.cpp
+++ b/storage/ndb/rest-server2/server/src/rdrs_dal.cpp
@@ -1593,18 +1593,14 @@ RS_Status CompileIndexRanges(const NdbTransaction* transaction,
       IndexBound& lower = range.lower.value();
       bound.low_inclusive = lower.inclusive;
       bound.low_key_count = lower.values.size();
-      Uint32 curr_attrId = 0;
       Uint32 curr_pos = 0;
-      bool ret = NdbDictionary::getFirstAttrId(index_rec, curr_attrId);
-      if (!ret) {
-        return RS_SERVER_ERROR("Failed to get first attribute ID for index record");
-      }
       for (auto& node : lower.values) {
         node.col = index_params.cols[curr_pos];
         RS_Status status = GenerateBinary(node, node.binary);
         if (status.http_code != HTTP_CODE::SUCCESS) {
           return status;
         }
+        Uint32 curr_attrId = node.col->getAttrId();
         char* field = NdbDictionary::getValuePtr(index_rec, row_ptr, curr_attrId);
         DEB_SCAN("curr_pos: " << curr_pos << ", curr_attrId: " << curr_attrId
           << ", col: " << node.col->getName()
@@ -1615,7 +1611,7 @@ RS_Status CompileIndexRanges(const NdbTransaction* transaction,
         if (node.value.kind == Node::ParsedValue::Kind::NULLVAL) {
           Uint32 nullbit_byte_offset = 0;
           Uint32 nullbit_bit_in_byte = 0;
-          ret = NdbDictionary::getNullBitOffset(index_rec, curr_attrId,
+          bool ret = NdbDictionary::getNullBitOffset(index_rec, curr_attrId,
               nullbit_byte_offset,
               nullbit_bit_in_byte);
           if (!ret) {
@@ -1625,7 +1621,6 @@ RS_Status CompileIndexRanges(const NdbTransaction* transaction,
         } else {
           memcpy(field, node.binary.data(), node.binary.size());
         }
-        NdbDictionary::getNextAttrId(index_rec, curr_attrId);
         curr_pos++;
       }
       bound.low_key = row_ptr;
@@ -1655,18 +1650,14 @@ RS_Status CompileIndexRanges(const NdbTransaction* transaction,
       IndexBound& upper = range.upper.value();
       bound.high_inclusive = upper.inclusive;
       bound.high_key_count = upper.values.size();
-      Uint32 curr_attrId = 0;
       Uint32 curr_pos = 0;
-      bool ret = NdbDictionary::getFirstAttrId(index_rec, curr_attrId);
-      if (!ret) {
-        return RS_SERVER_ERROR("Failed to get first attribute ID for index record");
-      }
       for (auto& node : upper.values) {
         node.col = index_params.cols[curr_pos];
         RS_Status status = GenerateBinary(node, node.binary);
         if (status.http_code != HTTP_CODE::SUCCESS) {
           return status;
         }
+        Uint32 curr_attrId = node.col->getAttrId();
         char* field = NdbDictionary::getValuePtr(index_rec, row_ptr, curr_attrId);
         DEB_SCAN("curr_pos: " << curr_pos << ", curr_attrId: " << curr_attrId
           << ", col: " << node.col->getName()
@@ -1677,7 +1668,7 @@ RS_Status CompileIndexRanges(const NdbTransaction* transaction,
         if (node.value.kind == Node::ParsedValue::Kind::NULLVAL) {
           Uint32 nullbit_byte_offset = 0;
           Uint32 nullbit_bit_in_byte = 0;
-          ret = NdbDictionary::getNullBitOffset(index_rec, curr_attrId,
+          bool ret = NdbDictionary::getNullBitOffset(index_rec, curr_attrId,
               nullbit_byte_offset,
               nullbit_bit_in_byte);
           if (!ret) {
@@ -1687,7 +1678,6 @@ RS_Status CompileIndexRanges(const NdbTransaction* transaction,
         } else {
           memcpy(field, node.binary.data(), node.binary.size());
         }
-        NdbDictionary::getNextAttrId(index_rec, curr_attrId);
         curr_pos++;
       }
       bound.high_key = row_ptr;

--- a/storage/ndb/rest-server2/server/src/ttl_purge.cpp
+++ b/storage/ndb/rest-server2/server/src/ttl_purge.cpp
@@ -122,7 +122,10 @@ void TTLPurger::SchemaWatcherJob() {
   NdbEventOperation* ev_op = nullptr;
   NdbEventOperation* op = nullptr;
   NdbDictionary::Dictionary::List list;
-  const char* message_buf = "API_OK";
+  // NDB VARBINARY on-wire format: 1-byte length prefix + data.
+  // setValue("message", ...) reads the length byte and then that many data
+  // bytes from the buffer; a bare C string literal is mis-sized.
+  const char message_buf[] = {6, 'A', 'P', 'I', '_', 'O', 'K'};
 #ifdef DEBUG_EVENT
   Uint32 event_nums = 0;
 #endif


### PR DESCRIPTION
…i-col PK

CompileIndexRanges in rdrs_dal.cpp iterated the index record's attrIds in ascending base-table attrId order via getFirstAttrId/getNextAttrId, but the user-supplied range values in lower/upper.values are in user-specified index-column order. For a composite secondary index on a table whose PK columns are interleaved with the index columns in attrId space (e.g. PK=(client_id, occurred_at, event_id), secondary =(customer_number, occurred_at); cn attrId=3, ts attrId=1), the two orders disagree and each value is memcpy'd at the wrong column's offset. A VARCHAR binary landing in a BIGINT slot spills past m_row_size and corrupts adjacent heap metadata in m_scan_buffer; glibc notices later at NdbScanOperation::close() and aborts rdrs2 with "corrupted size vs. prev_size".

Derive curr_attrId from the user-supplied column
(node.col->getAttrId()) at each iteration instead of walking the record's attrIds. Symmetric change in both lower and upper loops.

Add MTR regression test
mysql-test/suite/rdrs2/t/rdrs2_scan_composite_index.test using the minimal 3-row schema that triggers the attrId-order mismatch, with both DESC and ASC ordered scans. Pre-fix it crashes rdrs2; post-fix both return the expected rows. Full Go scan suite
(mysql-test/suite/rdrs2-golang/rdrs2-golang_index_scan) also green.

Also fix TTLPurger VARBINARY encoding of "API_OK" (ttl_purge.cpp): setValue("message", ...) on the VARBINARY(255) column in mysql.ndb_schema_result reads the first byte as a length prefix, treating 'A' (0x41=65) as length and memcpy'ing 1+65 bytes from a 7-byte literal. Junk on the wire in a normal build; under ASan a fatal global-buffer-overflow that blocked every ASan MTR run and was caught while regression-testing the scan fix. Framed as a proper VARBINARY buffer: 1-byte length (6) + "API_OK".