### PR TITLE
TTL: allow NdbBlob lock-upgrade scans to route to backup replica

### DIFF
--- a/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
+++ b/storage/ndb/src/kernel/blocks/dbtc/DbtcMain.cpp
@@ -16435,7 +16435,14 @@ void Dbtc::sendDihGetNodesLab(Signal *signal, ScanRecordPtr scanptr,
                     buddyApiPtr.i, op_count);
     if (!ttl_table || (ttl_table && (read_back || fully_replicated) &&
         (rc || rcb) && op_count == 0)) {
-      ndbrequire(!ttl_table || (!lockmode && !holdlock));
+      /*
+       * NdbBlob::atPrepareNdbRecord legitimately reaches here with rcb=1
+       * and holdlock=1: the user asked for LM_CommittedRead/LM_SimpleRead,
+       * NDB upgraded to LM_Read for blob-read atomicity only.  Same policy
+       * as the non-TTL READ_BACKUP branch in sendDihGetNodeReq below.
+       * Genuine user-requested locks (rcb=0) still trip the assertion.
+       */
+      ndbrequire(!ttl_table || rcb || (!lockmode && !holdlock));
       ttl_can_go_to_replica = true;
     }
   }


### PR DESCRIPTION
DbtcMain.cpp:16438 ndbrequire was too strict for TTL+BLOB+READ_BACKUP/ FULLY_REPLICATED scans: NdbBlob::atPrepareNdbRecord upgrades the user's LM_CommittedRead to LM_Read for blob-read atomicity and stamps rcb=1. The outer if accepts the scan (rcb=1, op_count=0), but the inner check "!ttl_table || (!lockmode && !holdlock)" then fired on the now-set holdlock and killed the data node with error 2341.

Allow rcb=1 through the assertion; mirrors the non-TTL policy already documented at sendDihGetNodeReq ("safe to read from backup replicas"). "Read what you locked, even if expired" is preserved because the outer if still requires op_count==0, so no prior in-txn locks exist when the replica branch fires.